### PR TITLE
feat: add txc data model convert command

### DIFF
--- a/src/TALXIS.CLI.Data/DataModelCliCommand.cs
+++ b/src/TALXIS.CLI.Data/DataModelCliCommand.cs
@@ -4,7 +4,8 @@ namespace TALXIS.CLI.Data;
 
 [CliCommand(
     Name = "model",
-    Description = "Data modeling utilities"
+    Description = "Data modeling utilities",
+    Children = new[] { typeof(DataModelConvertCliCommand) }
 )]
 public class DataModelCliCommand
 {

--- a/src/TALXIS.CLI.Data/DataModelConvertCliCommand.cs
+++ b/src/TALXIS.CLI.Data/DataModelConvertCliCommand.cs
@@ -1,0 +1,88 @@
+using DotMake.CommandLine;
+using TALXIS.CLI.Data.DataModelConverter;
+
+namespace TALXIS.CLI.Data;
+
+[CliCommand(
+    Name = "convert",
+    Description = "Convert a Power Platform solution data model to various formats such as DBML, SQL, EDMX or Ribbon"
+)]
+public class DataModelConvertCliCommand
+{
+    private const string ExportsFolderName = "exports";
+
+    [CliOption(
+        Name = "--input",
+        Description = "Path to the input: a solution project folder (.cdsproj/.csproj with SolutionRootPath), a declarations folder, or a .zip solution file. Defaults to the current directory.",
+        Required = false
+    )]
+    public string? InputPath { get; set; }
+
+    [CliOption(
+        Name = "--target",
+        Description = "Target format for the conversion.",
+        AllowedValues = new[] { "dbml", "sql", "plainsql", "edmx", "ribbon" },
+        Required = true
+    )]
+    public string? TargetFormat { get; set; }
+
+    [CliOption(
+        Name = "--output",
+        Description = $"Directory to write the output file into. Defaults to the '{ExportsFolderName}/' folder in the current directory (auto-created and gitignored).",
+        Required = false
+    )]
+    public string? OutputDirectory { get; set; }
+
+    public int Run()
+    {
+        var inputPath = InputPath ?? Directory.GetCurrentDirectory();
+        var outputDir = OutputDirectory ?? Path.Combine(Directory.GetCurrentDirectory(), ExportsFolderName);
+
+        Directory.CreateDirectory(outputDir);
+        EnsureGitIgnored(outputDir);
+
+        var extension = TargetFormat!.ToLower() == "plainsql" ? "sql" : TargetFormat.ToLower();
+        var outputFilePath = Path.Combine(outputDir, $"solution.{extension}");
+
+        DataModelConverterService.ConvertModel(inputPath, TargetFormat!, outputFilePath);
+
+        Console.WriteLine($"Output written to: {outputFilePath}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Ensures the exports folder is listed in the nearest .gitignore,
+    /// adding an entry if it is not already present.
+    /// </summary>
+    private static void EnsureGitIgnored(string exportsDirPath)
+    {
+        var gitIgnorePath = FindGitIgnore(exportsDirPath);
+        if (gitIgnorePath == null)
+            return;
+
+        var entry = $"{ExportsFolderName}/";
+        var lines = File.ReadAllLines(gitIgnorePath);
+        if (lines.Any(l => l.Trim() == entry))
+            return;
+
+        File.AppendAllText(gitIgnorePath, $"{Environment.NewLine}{entry}{Environment.NewLine}");
+    }
+
+    private static string? FindGitIgnore(string startPath)
+    {
+        var dir = new DirectoryInfo(startPath);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, ".gitignore");
+            if (File.Exists(candidate))
+                return candidate;
+
+            // Stop at the git root
+            if (Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                break;
+
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/DataModelConverterService.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/DataModelConverterService.cs
@@ -1,0 +1,617 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using TALXIS.CLI.Data.DataModelConverter.Extensions;
+using TALXIS.CLI.Data.DataModelConverter.Model;
+using TALXIS.CLI.Data.DataModelConverter.Translators;
+
+namespace TALXIS.CLI.Data.DataModelConverter;
+
+public class DataModelConverterService
+{
+    private static readonly string[] SupportedFormats = ["dbml", "sql", "edmx", "ribbon"];
+
+    /// <summary>
+    /// Parses a Power Platform solution from a solution project folder, a declarations
+    /// folder, or a .zip file, converts it to the specified format, and writes the result
+    /// to the output path.
+    /// </summary>
+    /// <remarks>
+    /// Input resolution order:
+    /// <list type="number">
+    ///   <item>Folder containing a <c>.cdsproj</c> or <c>.csproj</c> — reads
+    ///         <c>SolutionRootPath</c> MSBuild property to locate the declarations folder.</item>
+    ///   <item>Folder without a project file — used directly as the declarations folder.</item>
+    ///   <item>A <c>.zip</c> file — decoded and parsed as an exported solution package.</item>
+    /// </list>
+    /// </remarks>
+    public static void ConvertModel(string inputPath, string targetFormat, string outputFilePath)
+    {
+        if (!SupportedFormats.Contains(targetFormat.ToLower()))
+            throw new ArgumentException($"Unsupported target format '{targetFormat}'. Supported formats are: {string.Join(", ", SupportedFormats)}.");
+
+        ParsedModel parsedModel;
+
+        if (Directory.Exists(inputPath))
+        {
+            var declarationsPath = ResolveDeclarationsFolder(inputPath);
+            parsedModel = ParseModelFolder(declarationsPath);
+        }
+        else if (File.Exists(inputPath))
+        {
+            using var fileStream = new FileStream(inputPath, FileMode.Open, FileAccess.Read);
+            using var memoryStream = new MemoryStream();
+            fileStream.CopyTo(memoryStream);
+            parsedModel = ParseModel(Convert.ToBase64String(memoryStream.ToArray()));
+        }
+        else
+        {
+            throw new FileNotFoundException($"Input path '{inputPath}' does not exist.");
+        }
+
+        var resultString = targetFormat.ToLower() switch
+        {
+            "edmx"     => ConvertToEDMX(parsedModel),
+            "sql"      => ConvertToEDSSQL(parsedModel),
+            "plainsql" => ConvertToSQL(parsedModel),
+            "ribbon"   => ConvertToRibbonDiff(parsedModel),
+            _          => ConvertToDBML(parsedModel)
+        };
+
+        using var writer = new StreamWriter(outputFilePath);
+        writer.Write(resultString);
+    }
+
+    /// <summary>
+    /// Resolves the declarations folder from the given input path.
+    /// If the folder contains a <c>.cdsproj</c> or <c>.csproj</c> file with a
+    /// <c>SolutionRootPath</c> property, that relative path is returned.
+    /// Otherwise the folder itself is returned unchanged.
+    /// </summary>
+    private static string ResolveDeclarationsFolder(string folderPath)
+    {
+        var projectFile = Directory.EnumerateFiles(folderPath, "*.cdsproj")
+            .FirstOrDefault()
+            ?? Directory.EnumerateFiles(folderPath, "*.csproj").FirstOrDefault();
+
+        if (projectFile == null)
+            return folderPath;
+
+        var doc = XDocument.Load(projectFile);
+        XNamespace ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+        var solutionRootPath = doc.Descendants(ns + "SolutionRootPath")
+            .FirstOrDefault()?.Value;
+
+        if (string.IsNullOrWhiteSpace(solutionRootPath))
+            return folderPath;
+
+        var resolved = Path.Combine(folderPath, solutionRootPath);
+        if (!Directory.Exists(resolved))
+            throw new DirectoryNotFoundException(
+                $"SolutionRootPath '{solutionRootPath}' from project file does not exist at '{resolved}'.");
+
+        return resolved;
+    }
+
+    public static string ConvertToDBML(ParsedModel model)
+    {
+        string result = string.Empty;
+
+        foreach (Table entityText in model.tables)
+        {
+            result += entityText.ToDbDiagramNotation();
+        }
+        foreach (Relationship relText in model.relationships)
+        {
+            result += relText.ToDbDiagramNotation();
+            result += "\n";
+        }
+        foreach (OptionsetEnum optionsetText in model.optionSets)
+        {
+            result += optionsetText.ToDbDiagramNotation();
+            result += "\n";
+        }
+
+        return result;
+    }
+
+    public static string ConvertToSQL(ParsedModel model)
+    {
+        string result = string.Empty;
+
+        foreach (Table entityText in model.tables)
+        {
+            result += entityText.ToSQLNotation(model.optionSets);
+        }
+        foreach (Relationship relText in model.relationships)
+        {
+            result += relText.ToSQLNotation();
+            result += "\n";
+        }
+
+        return result;
+    }
+
+    public static string ConvertToEDSSQL(ParsedModel model)
+    {
+        string result = string.Empty;
+
+        foreach (Table entityText in model.tables)
+        {
+            result += entityText.ToEDSSQLNotation(model.optionSets, model.relationships.Where(x => x.LeftSideTable.LogicalName == entityText.LogicalName || x.RighSideTable.LogicalName == entityText.LogicalName).ToList());
+        }
+        foreach (Relationship relText in model.relationships)
+        {
+            result += relText.ToSQLNotation();
+            result += "\n";
+        }
+
+        return result;
+    }
+
+    public static string ConvertToRibbonDiff(ParsedModel model)
+    {
+        RibbonDiffXml result = new RibbonDiffXml();
+
+        var ribbondiffs = model.tables.Where(x => x.ribbonDiff != null);
+
+        XmlSerializer xmlSerializer = new XmlSerializer(typeof(RibbonDiffXml));
+
+        using StringWriter textWriter = new StringWriter();
+
+        foreach (var table in ribbondiffs)
+        {
+            result.Merge(table.ribbonDiff);
+        }
+
+        xmlSerializer.Serialize(textWriter, result);
+
+        return textWriter.ToString();
+    }
+
+    public static string ConvertToEDMX(ParsedModel model)
+    {
+        string result = string.Empty;
+        result += "<edmx:Edmx xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\" Version=\"4.0\"><edmx:Reference Uri=\"http://vocabularies.odata.org/OData.Community.Keys.V1.xml\">";
+        result += "<edmx:Include Namespace=\"OData.Community.Keys.V1\" Alias=\"Keys\"/>";
+        result += "<edmx:IncludeAnnotations TermNamespace=\"OData.Community.Keys.V1\"/></edmx:Reference>";
+        result += "<edmx:Reference Uri=\"http://vocabularies.odata.org/OData.Community.Display.V1.xml\">";
+        result += "<edmx:Include Namespace=\"OData.Community.Display.V1\" Alias=\"Display\"/>";
+        result += "<edmx:IncludeAnnotations TermNamespace=\"OData.Community.Display.V1\"/></edmx:Reference><edmx:DataServices>";
+        result += "<Schema xmlns=\"http://docs.oasis-open.org/odata/ns/edm\" Namespace=\"Microsoft.Dynamics.CRM\" Alias=\"mscrm\">";
+        result += "<EntityType Name=\"crmbaseentity\" Abstract=\"true\"/><EntityType Name=\"expando\" BaseType=\"mscrm.crmbaseentity\" OpenType=\"true\"/>";
+        foreach (Table entityText in model.tables)
+        {
+            result += entityText.ToEDMXNotation();
+
+            var relevantRelationships = model.relationships.Where(x => x.LeftSideTable == entityText || x.RighSideTable == entityText);
+
+            foreach (Relationship relationship in relevantRelationships)
+            {
+                result += relationship.ToEDMXNotation(entityText);
+            }
+
+            result += "</EntityType>";
+
+        }
+
+        result += "<EntityContainer Name=\"System\">";
+
+        foreach (Table entityText in model.tables)
+        {
+            var relevantRelationships = model.relationships.Where(x => x.LeftSideTable == entityText || x.RighSideTable == entityText);
+
+            result += $"<EntitySet Name=\"{entityText.SetName.ToLower()}\" EntityType=\"Microsoft.Dynamics.CRM.{entityText.LogicalName.ToLower()}\"";
+
+            if (relevantRelationships.Count() == 0) // there are no relationships
+            {
+                result += "/>";
+            }
+            else // populate relationships in EntitySet
+            {
+                result += ">";
+
+                foreach (Relationship relationship in relevantRelationships)
+                {
+                    result += relationship.ToEDMXNotationBinding(entityText);
+                }
+
+                result += "</EntitySet>";
+            }
+        }
+
+        result += "<Annotation Term=\"Org.OData.Capabilities.V1.FilterFunctions\"><Collection><String>contains</String><String>endswith</String><String>startswith</String></Collection></Annotation>";
+
+        result += "</EntityContainer>";
+
+
+        result += "<EnumType Name=\"ConditionOperator\"><Member Name=\"Equal\" Value=\"0\"/><Member Name=\"NotEqual\" Value=\"1\"/><Member Name=\"GreaterThan\" Value=\"2\"/><Member Name=\"LessThan\" Value=\"3\"/><Member Name=\"GreaterEqual\" Value=\"4\"/><Member Name=\"LessEqual\" Value=\"5\"/><Member Name=\"Like\" Value=\"6\"/><Member Name=\"NotLike\" Value=\"7\"/><Member Name=\"In\" Value=\"8\"/><Member Name=\"NotIn\" Value=\"9\"/><Member Name=\"Between\" Value=\"10\"/><Member Name=\"NotBetween\" Value=\"11\"/><Member Name=\"Null\" Value=\"12\"/><Member Name=\"NotNull\" Value=\"13\"/><Member Name=\"Yesterday\" Value=\"14\"/><Member Name=\"Today\" Value=\"15\"/><Member Name=\"Tomorrow\" Value=\"16\"/><Member Name=\"Last7Days\" Value=\"17\"/><Member Name=\"Next7Days\" Value=\"18\"/><Member Name=\"LastWeek\" Value=\"19\"/><Member Name=\"ThisWeek\" Value=\"20\"/><Member Name=\"NextWeek\" Value=\"21\"/><Member Name=\"LastMonth\" Value=\"22\"/><Member Name=\"ThisMonth\" Value=\"23\"/><Member Name=\"NextMonth\" Value=\"24\"/><Member Name=\"On\" Value=\"25\"/><Member Name=\"OnOrBefore\" Value=\"26\"/><Member Name=\"OnOrAfter\" Value=\"27\"/><Member Name=\"LastYear\" Value=\"28\"/><Member Name=\"ThisYear\" Value=\"29\"/><Member Name=\"NextYear\" Value=\"30\"/><Member Name=\"LastXHours\" Value=\"31\"/><Member Name=\"NextXHours\" Value=\"32\"/><Member Name=\"LastXDays\" Value=\"33\"/><Member Name=\"NextXDays\" Value=\"34\"/><Member Name=\"LastXWeeks\" Value=\"35\"/><Member Name=\"NextXWeeks\" Value=\"36\"/><Member Name=\"LastXMonths\" Value=\"37\"/><Member Name=\"NextXMonths\" Value=\"38\"/><Member Name=\"LastXYears\" Value=\"39\"/><Member Name=\"NextXYears\" Value=\"40\"/><Member Name=\"EqualUserId\" Value=\"41\"/><Member Name=\"NotEqualUserId\" Value=\"42\"/><Member Name=\"EqualBusinessId\" Value=\"43\"/><Member Name=\"NotEqualBusinessId\" Value=\"44\"/><Member Name=\"ChildOf\" Value=\"45\"/><Member Name=\"Mask\" Value=\"46\"/><Member Name=\"NotMask\" Value=\"47\"/><Member Name=\"MasksSelect\" Value=\"48\"/><Member Name=\"Contains\" Value=\"49\"/><Member Name=\"DoesNotContain\" Value=\"50\"/><Member Name=\"EqualUserLanguage\" Value=\"51\"/><Member Name=\"NotOn\" Value=\"52\"/><Member Name=\"OlderThanXMonths\" Value=\"53\"/><Member Name=\"BeginsWith\" Value=\"54\"/><Member Name=\"DoesNotBeginWith\" Value=\"55\"/><Member Name=\"EndsWith\" Value=\"56\"/><Member Name=\"DoesNotEndWith\" Value=\"57\"/><Member Name=\"ThisFiscalYear\" Value=\"58\"/><Member Name=\"ThisFiscalPeriod\" Value=\"59\"/><Member Name=\"NextFiscalYear\" Value=\"60\"/><Member Name=\"NextFiscalPeriod\" Value=\"61\"/><Member Name=\"LastFiscalYear\" Value=\"62\"/><Member Name=\"LastFiscalPeriod\" Value=\"63\"/><Member Name=\"LastXFiscalYears\" Value=\"64\"/><Member Name=\"LastXFiscalPeriods\" Value=\"65\"/><Member Name=\"NextXFiscalYears\" Value=\"66\"/><Member Name=\"NextXFiscalPeriods\" Value=\"67\"/><Member Name=\"InFiscalYear\" Value=\"68\"/><Member Name=\"InFiscalPeriod\" Value=\"69\"/><Member Name=\"InFiscalPeriodAndYear\" Value=\"70\"/><Member Name=\"InOrBeforeFiscalPeriodAndYear\" Value=\"71\"/><Member Name=\"InOrAfterFiscalPeriodAndYear\" Value=\"72\"/><Member Name=\"EqualUserTeams\" Value=\"73\"/><Member Name=\"EqualUserOrUserTeams\" Value=\"74\"/><Member Name=\"Under\" Value=\"75\"/><Member Name=\"NotUnder\" Value=\"76\"/><Member Name=\"UnderOrEqual\" Value=\"77\"/><Member Name=\"Above\" Value=\"78\"/><Member Name=\"AboveOrEqual\" Value=\"79\"/><Member Name=\"EqualUserOrUserHierarchy\" Value=\"80\"/><Member Name=\"EqualUserOrUserHierarchyAndTeams\" Value=\"81\"/><Member Name=\"OlderThanXYears\" Value=\"82\"/><Member Name=\"OlderThanXWeeks\" Value=\"83\"/><Member Name=\"OlderThanXDays\" Value=\"84\"/><Member Name=\"OlderThanXHours\" Value=\"85\"/><Member Name=\"OlderThanXMinutes\" Value=\"86\"/><Member Name=\"ContainValues\" Value=\"87\"/><Member Name=\"DoesNotContainValues\" Value=\"88\"/></EnumType>";
+
+        result += "<Function Name=\"Contains\"><Parameter Name=\"PropertyName\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\"/><Parameter Name=\"PropertyValue\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\"/><ReturnType Type=\"Edm.Boolean\" Nullable=\"false\"/></Function>";
+
+        result += "<Function Name=\"EqualUserId\"><Parameter Name=\"PropertyName\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\"/><ReturnType Type=\"Edm.Boolean\" Nullable=\"false\"/></Function>";
+
+        result += "<Function Name=\"In\"><Parameter Name=\"PropertyName\" Type=\"Edm.String\" Nullable=\"false\" Unicode=\"false\"/><Parameter Name=\"PropertyValues\" Type=\"Collection(Edm.String)\" Nullable=\"false\" Unicode=\"false\"/><ReturnType Type=\"Edm.Boolean\" Nullable=\"false\"/></Function>";
+        result += "</Schema></edmx:DataServices></edmx:Edmx>";
+
+
+        using (var reader = new StringReader(result))
+        {
+            var edmmodel = Microsoft.OData.Edm.Csdl.CsdlReader.Parse(XmlReader.Create(reader));
+        }
+
+
+        return result;
+
+    }
+
+    public static ParsedModel ParseModelFolder(string folderPath)
+    {
+        Module module = new();
+
+        // Get files named Entity.xml in subfolders
+        var entityFiles = Directory.GetFiles(folderPath, "Entity.xml", SearchOption.AllDirectories);
+
+        foreach (var file in entityFiles)
+        {
+            try
+            {
+                var doc = XDocument.Load(file);
+                module.entities.Add(doc.Root);
+
+                // We need to save inline optionsets and state/status optionsets
+                foreach (var item in doc.Root.Descendants().Where(x => x.Name == "optionset").ToList())
+                {
+                    module.optionsets.Add(item);
+                }
+
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading {file}: {ex.Message}");
+            }
+        }
+
+        // Get files in folder Other/Relationships (directory may not exist in scaffolded solutions)
+        var relationshipsDir = Path.Combine(folderPath, "Other", "Relationships");
+        var relationshipFiles = Directory.Exists(relationshipsDir)
+            ? Directory.GetFiles(relationshipsDir, "*.xml", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+        foreach (var file in relationshipFiles)
+        {
+            try
+            {
+                var doc = XDocument.Load(file);
+                module.relationships.AddRange(doc.Root.Descendants().Where(x => x.Name == "EntityRelationship").ToList());
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading {file}: {ex.Message}");
+            }
+        }
+
+        // Get files in folder called OptionSets (directory may not exist in scaffolded solutions)
+        var optionsetsDir = Path.Combine(folderPath, "OptionSets");
+        var optionsetFiles = Directory.Exists(optionsetsDir)
+            ? Directory.GetFiles(optionsetsDir, "*.xml", SearchOption.AllDirectories)
+            : Array.Empty<string>();
+        foreach (var file in optionsetFiles)
+        {
+            try
+            {
+                var doc = XDocument.Load(file);
+                module.optionsets.Add(doc.Root);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading {file}: {ex.Message}");
+            }
+        }
+
+        return ParseModules([module]);
+
+    }
+
+    public static ParsedModel ParseModel(string? base64solution)
+    {
+
+        if (string.IsNullOrWhiteSpace(base64solution))
+        {
+            throw new ArgumentException("Base64 solution content cannot be null or empty.");
+        }
+
+        return ParseModel([base64solution]);
+    }
+
+    public static ParsedModel ParseModel(List<string> base64solution)
+    {
+        List<Module> modules = [];
+
+        foreach (var solution in base64solution)
+        {
+            using ZipArchive archive = new(new MemoryStream(Convert.FromBase64String(solution)));
+
+            var customizationsxml = archive.Entries.FirstOrDefault(x => x.FullName.Equals("customizations.xml", StringComparison.OrdinalIgnoreCase));
+            var solutionxml = archive.Entries.FirstOrDefault(x => x.FullName.Equals("solution.xml", StringComparison.OrdinalIgnoreCase));
+
+            if (customizationsxml == null || solutionxml == null)
+            {
+                throw new FileNotFoundException("The solution archive does not contain the required customizations.xml or solution.xml files.");
+            }
+
+            Module foundModule = new(XDocument.Load(solutionxml.Open()).Descendants().First(x => x.Name == "UniqueName").Value, XDocument.Load(customizationsxml.Open()));
+
+            modules.Add(foundModule);
+        }
+
+        return ParseModules(modules);
+    }
+
+    public static ParsedModel ParseModules(List<Module> modules)
+    {
+
+        List<Table> EntityTables = ParseEntities(modules);
+        List<OptionsetEnum> EntityOptionSets = ParseOptionSets(modules);
+
+        // Remove optionset rows without optionsets defined
+        var validOptionSetNames = EntityOptionSets.Select(x => x.LocalizedName).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var entity in EntityTables)
+        {
+            entity.Rows = [.. entity.Rows
+                .Where(row =>
+                    row.RowType is not (RowType.Picklist or RowType.Multiselectoptionset or RowType.State or RowType.Status or RowType.Bit)
+                    || validOptionSetNames.Contains(row.OptionSetName)
+                )];
+        }
+
+        // Fill in setnames where missing with placeholder logical names
+        foreach (var entity in EntityTables.Where(entity => string.IsNullOrEmpty(entity.SetName)))
+        {
+            entity.SetName = entity.LogicalName;
+        }
+
+        List<Relationship> EntityRelationships = ParseRelationships(modules, EntityTables);
+
+        return new ParsedModel()
+        {
+            tables = EntityTables,
+            relationships = EntityRelationships,
+            optionSets = EntityOptionSets
+        };
+
+    }
+
+    public static List<Relationship> ParseRelationships(List<Module> modules, List<Table> EntityTables)
+    {
+
+        List<Relationship> EntityRelationships = new();
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Parsing {module.ModuleName} with {module.relationships.Count} relationships");
+
+            foreach (var relationship in module.relationships)
+            {
+
+                //Console.WriteLine($"--Relationship {relationship.Attribute("Name").Value} parsing");
+                if (relationship.Element("EntityRelationshipType").Value == "ManyToMany")
+                {
+                    //Console.WriteLine($"---ManyToMany");
+                    var firstEntityTable = EntityTables.Find(relationship.Element("FirstEntityName").Value);
+                    if (firstEntityTable == null)
+                    {
+                        firstEntityTable = TableExtension.CreateTable(relationship.Element("FirstEntityName").Value, TableType.NotInSolution);
+                        EntityTables.Add(firstEntityTable);
+                    }
+
+                    var secondEntityTable = EntityTables.Find(relationship.Element("SecondEntityName").Value);
+                    if (secondEntityTable == null)
+                    {
+                        secondEntityTable = TableExtension.CreateTable(relationship.Element("SecondEntityName").Value, TableType.NotInSolution);
+                        EntityTables.Add(secondEntityTable);
+                    }
+
+                    var intersectEntityName = relationship.Element("IntersectEntityName").Value;
+
+                    var connectionTable = new Table
+                    {
+                        Type = TableType.ConnectionTable,
+                        LocalizedName = relationship.Attribute("Name").Value,
+                        LogicalName = intersectEntityName,
+                        SetName = intersectEntityName + "s",
+                        Rows = {
+                                new TableRow(intersectEntityName + "id", RowType.Primarykey),
+                                new TableRow(firstEntityTable.LogicalName + "id", RowType.Lookup),
+                                new TableRow(secondEntityTable.LogicalName + "id", RowType.Lookup),
+                            }
+                    };
+
+
+                    EntityTables.Add(connectionTable);
+
+                    var firstToMid = new Relationship(relationship.Attribute("Name").Value,
+                                                      "ManyToOne",
+                                                      firstEntityTable,
+                                                      firstEntityTable.Rows.FirstOrDefault(x => x.RowType == RowType.Primarykey),
+                                                      connectionTable,
+                                                      connectionTable.Rows.FirstOrDefault(x => x.Name == firstEntityTable.LogicalName + "id"));
+
+
+                    var secondToMid = new Relationship(relationship.Attribute("Name").Value,
+                                                       "ManyToOne",
+                                                       secondEntityTable,
+                                                       secondEntityTable.Rows.FirstOrDefault(x => x.RowType == RowType.Primarykey),
+                                                       connectionTable,
+                                                       connectionTable.Rows.FirstOrDefault(x => x.Name == secondEntityTable.LogicalName + "id"));
+
+                    EntityRelationships.Add(firstToMid);
+                    EntityRelationships.Add(secondToMid);
+                }
+                else
+                {
+                    //Console.WriteLine($"---OneToMany");
+                    var leftSideTable = EntityTables.Find(relationship.Element("ReferencingEntityName").Value);
+                    if (leftSideTable == null)
+                    {
+                        var missingEntityLogicalName = relationship.Element("ReferencingEntityName").Value;
+
+                        if (missingEntityLogicalName != "FileAttachment")
+                        {
+                            leftSideTable = TableExtension.CreateTable(missingEntityLogicalName, TableType.NotInSolution);
+                            EntityTables.Add(leftSideTable);
+                        }
+                    }
+
+                    var rightSideTable = EntityTables.Find(relationship.Element("ReferencedEntityName").Value);
+                    if (rightSideTable == null)
+                    {
+                        var missingEntityLogicalName = relationship.Element("ReferencedEntityName").Value;
+
+                        if (missingEntityLogicalName != "FileAttachment")
+                        {
+                            rightSideTable = TableExtension.CreateTable(missingEntityLogicalName, TableType.NotInSolution);
+                            EntityTables.Add(rightSideTable);
+                        }
+                    }
+
+                    if (rightSideTable != null && leftSideTable != null)
+                    {
+                        var entityRelationship = new Relationship(relationship.Attribute("Name").Value,
+                                                          relationship.Element("EntityRelationshipType").Value,
+                                                          leftSideTable,
+                                                          leftSideTable.GetOrCreateRow(relationship.Element("ReferencingAttributeName").Value, RowType.Lookup),
+                                                          rightSideTable,
+                                                          rightSideTable.Rows.FirstOrDefault(x => x.RowType == RowType.Primarykey));
+
+                        if (EntityRelationships.FirstOrDefault(x => x.LeftSideTable == entityRelationship.LeftSideTable && x.RighSideTable == entityRelationship.RighSideTable) == default)
+                        {
+                            EntityRelationships.Add(entityRelationship);
+                        }
+                    }
+
+                }
+
+            }
+
+        }
+
+        foreach (var relText in EntityRelationships.Where(relText => relText.GetType().GetProperties().Any(p => p.GetValue(relText) == null)))
+        {
+            throw new Exception($"Something is missing in the {EntityRelationships.IndexOf(relText)} relationship");
+        }
+
+        return EntityRelationships;
+    }
+
+    public static List<OptionsetEnum> ParseOptionSets(List<Module> modules)
+    {
+        List<OptionsetEnum> EntityOptionSets = new();
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Parsing {module.ModuleName} with {module.optionsets.Count} option sets");
+            foreach (var optionsetXElement in module.optionsets)
+            {
+
+                var optionsetRows = new List<OptionsetRow>();
+                List<XElement> options = [];
+                switch (optionsetXElement.Element("OptionSetType")?.Value)
+                {
+                    case "status":
+                    case "state":
+                        options = optionsetXElement.Descendants(optionsetXElement.Element("OptionSetType")?.Value).ToList();
+                        break;
+                    default:
+                        options = optionsetXElement.Descendants("option").ToList();
+                        break;
+                }
+
+                foreach (var item in options)
+                {
+                    var value = item.Attribute("value")?.Value;
+                    var labelElement = item.Descendants("label").FirstOrDefault(x => x.Attribute("languagecode")?.Value == "1033" || x.Attribute("languagecode")?.Value == "1029");
+                    var label = labelElement != null ? labelElement.Attribute("description")?.Value.NormalizeString() : value;
+
+                    if (optionsetRows.Where(x => x.Value == int.Parse(value)).Count() == 0) optionsetRows.Add(new OptionsetRow(label, int.Parse(value)));
+                }
+
+                if (EntityOptionSets.FirstOrDefault(x => x.LocalizedName == optionsetXElement.Attribute("Name")?.Value) != default)
+                {
+                    EntityOptionSets.FirstOrDefault(x => x.LocalizedName == optionsetXElement.Attribute("Name")?.Value)?.MergeOptions(optionsetRows);
+                }
+                else
+                {
+                    var optionsetEnum = new OptionsetEnum(optionsetXElement.Attribute("Name")!.Value, optionsetRows);
+                    if (optionsetEnum.Values.Count > 0 && !EntityOptionSets.Where(x => x.LocalizedName == optionsetEnum.LocalizedName).Any()) EntityOptionSets.Add(optionsetEnum);
+                }
+
+                //Console.WriteLine($"-- {optionset.Attribute("Name").Value} parsed");
+            }
+
+        }
+
+        return EntityOptionSets;
+    }
+
+    public static List<Table> ParseEntities(List<Module> modules)
+    {
+
+        var EntityTables = new List<Table>();
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Parsing {module.ModuleName} with {module.entities.Count} entities");
+
+            foreach (var entityXmlElement in module.entities)
+            {
+                var entityTable = new Table();
+
+                if (EntityTables.FirstOrDefault(x => x.LogicalName == entityXmlElement.Element("Name")?.Value) != default)
+                {
+                    entityTable = EntityTables.FirstOrDefault(x => x.LogicalName == entityXmlElement.Element("Name")?.Value);
+
+                    if (string.IsNullOrEmpty(entityTable.SetName))
+                    {
+                        entityTable.SetName = entityXmlElement.Elements("EntityInfo").Elements("entity").Elements("EntitySetName").ToList().Count != 0 ? entityXmlElement.Elements("EntityInfo").Elements("entity").Elements("EntitySetName").FirstOrDefault()?.Value : string.Empty;
+                    }
+
+                }
+                else
+                {
+                    entityTable = new Table(entityXmlElement)
+                    {
+                        ParentModule = module,
+                        Type = TableType.InSolution
+                    };
+                    EntityTables.Add(entityTable);
+                }
+
+                if (entityXmlElement.Element("RibbonDiffXml") != null)
+                {
+                    entityTable.ParseRibbonDiffXml(entityXmlElement.Element("RibbonDiffXml")!);
+                }
+
+                var attributeXElements = entityXmlElement.Elements("EntityInfo").Elements("entity").Elements("attributes").Elements("attribute").ToList();
+
+                entityTable.ParseMultipleRowsFromXml(attributeXElements);
+
+                if (!entityTable.Rows.Any(x => x.RowType == RowType.Primarykey))
+                {
+                    entityTable.Rows.Add(new TableRow(entityTable.LogicalName + "id", RowType.Primarykey));
+                }
+
+                //Console.WriteLine($"-- {entityTable.LocalizedName} parsed");
+
+            }
+
+        }
+
+        return EntityTables;
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Extensions/StringExtension.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Extensions/StringExtension.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Extensions;
+
+public static class StringExtension
+{
+    public static string FirstCharToUpper(this string input) => input switch
+    {
+        null => throw new ArgumentNullException(nameof(input)),
+        "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
+        _ => string.Concat(input.First().ToString().ToUpper(), input.AsSpan(1))
+    };
+
+    /// <summary>
+    /// Remove diacritics, pascal case, remove spaces and replace "-" with "_"
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    public static string NormalizeString(this string text)
+    {
+        var normalizedString = text.Normalize(NormalizationForm.FormD);
+        var stringBuilder = new StringBuilder();
+
+        foreach (var c in normalizedString)
+        {
+            var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
+            if (unicodeCategory != UnicodeCategory.NonSpacingMark)
+            {
+                stringBuilder.Append(c);
+            }
+        }
+
+        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(stringBuilder.ToString().Normalize(NormalizationForm.FormC)).Replace(" ", "").Replace("-", "_");
+
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Extensions/TableExtension.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Extensions/TableExtension.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using TALXIS.CLI.Data.DataModelConverter.Model;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Extensions;
+
+public static class TableExtension
+{
+    public static Table Find(this List<Table> list, string logicalName)
+    {
+        return list.FirstOrDefault(x => x.LogicalName.Equals(logicalName, StringComparison.InvariantCultureIgnoreCase));
+    }
+
+    public static Table CreateTable(string tableName, TableType type)
+    {
+        return new Table
+        {
+            Type = type,
+            LocalizedName = tableName,
+            LogicalName = tableName,
+            SetName = tableName + "s",
+            Rows = { new TableRow(tableName + "id", RowType.Primarykey) }
+        };
+    }
+}
+

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/DataverseToSqlTypeMapper.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/DataverseToSqlTypeMapper.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class DataverseToSqlTypeMapper
+{
+    private readonly Dictionary<string, string> translationTable = new Dictionary<string, string>()
+    {
+        { "nvarchar", "varchar" },
+        { "lookup", "uniqueidentifier" },
+        { "primarykey", "uniqueidentifier [primary key]"},
+        { "partylist", "varchar"},
+        { "file", "varchar" },
+        { "customer", "uniqueidentifier" },
+        { "ntext", "varchar" }
+    };
+
+    public string this[string key]
+    {
+        get
+        {
+            if (translationTable.ContainsKey(key)) return translationTable[key];
+            return key;
+        }
+    }
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/Module.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/Module.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class Module
+{
+    public Module()
+    {
+        var random = new Random();
+        Colorhex = string.Format("#{0:X6}", random.Next(0x1000000));
+    }
+
+    public Module(string module, XDocument xml)
+    {
+        ModuleName = module;
+        XmlDoc = xml;
+
+        var random = new Random();
+        Colorhex = string.Format("#{0:X6}", random.Next(0x1000000));
+
+        entities = XmlDoc.Descendants().Where(x => x.Name == "Entity").ToList();
+        relationships = XmlDoc.Descendants().Where(x => x.Name == "EntityRelationship").ToList();
+        optionsets = XmlDoc.Descendants().Where(x => x.Name == "optionset").ToList();
+    }
+
+    public string ModuleName { get; set; } = "";
+    public XDocument XmlDoc { get; set; } = new XDocument();
+
+    public List<XElement> entities = [];
+    public List<XElement> relationships = [];
+    public List<XElement> optionsets = [];
+
+    public string Colorhex { get; }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/OptionsetEnum.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/OptionsetEnum.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class OptionsetEnum
+{
+    public string LocalizedName { get; set; }
+
+    public List<OptionsetRow> Values = [];
+
+    public OptionsetEnum(string localizedName, List<OptionsetRow> values)
+    {
+        LocalizedName = localizedName;
+        Values = values;
+    }
+
+    public void Add(string label, int value)
+    {
+        Values.Add(new OptionsetRow(label, value));
+    }
+
+    public void MergeOptions(List<OptionsetRow> options)
+    {
+        foreach (var newoption in options)
+        {
+            OptionsetRow optionsetRow = Values.FirstOrDefault(x => x.Value == newoption.Value);
+            if (optionsetRow == default)
+            {
+                Values.Add(newoption);
+            }
+            else
+            {
+                if (optionsetRow.Label != newoption.Label) optionsetRow.Label = $"{newoption.Label}";
+            }
+        }
+    }
+
+    public override string ToString()
+    {
+        return LocalizedName;
+    }
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/OptionsetRow.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/OptionsetRow.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class OptionsetRow
+{
+    public OptionsetRow(string label, int value)
+    {
+        Label = label;
+        Value = value;
+    }
+
+    public string Label { get; set; }
+    public int Value { get; set; }
+
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/ParsedModel.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/ParsedModel.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class ParsedModel
+{
+    public List<Table> tables = [];
+    public List<Relationship> relationships = [];
+    public List<OptionsetEnum> optionSets = [];
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/Relationship.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/Relationship.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public class Relationship
+{
+    private static Dictionary<string, string> CardinalityLookup = new Dictionary<string, string>()
+    {
+        {"OneToOne", "-"},
+        {"OneToMany", ">" },
+        {"ManyToOne", "<" }
+    };
+
+    public Relationship(string name, string cardinality, Table leftSideTable, TableRow leftSideRow, Table righSideTable, TableRow righSideRow)
+    {
+        Name = name;
+        Cardinality = cardinality;
+        LeftSideTable = leftSideTable;
+        LeftSideRow = leftSideRow;
+        RighSideTable = righSideTable;
+        RighSideRow = righSideRow;
+    }
+
+    public string Name { get; set; }
+    public string Cardinality { get; set; }
+    public Table LeftSideTable { get; set; }
+    public TableRow LeftSideRow { get; set; }
+    public Table RighSideTable { get; set; }
+    public TableRow RighSideRow { get; set; }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/RibbonDiff.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/RibbonDiff.cs
@@ -1,0 +1,263 @@
+﻿using System.Xml.Serialization;
+using System.Collections.Generic;
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+[XmlRoot(ElementName = "Button")]
+public class Button
+{
+    [XmlAttribute(AttributeName = "Command")]
+    public string Command { get; set; }
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+    [XmlAttribute(AttributeName = "LabelText")]
+    public string LabelText { get; set; }
+    [XmlAttribute(AttributeName = "Sequence")]
+    public string Sequence { get; set; }
+    [XmlAttribute(AttributeName = "TemplateAlias")]
+    public string TemplateAlias { get; set; }
+    [XmlAttribute(AttributeName = "ModernImage")]
+    public string ModernImage { get; set; }
+}
+
+[XmlRoot(ElementName = "CommandUIDefinition")]
+public class CommandUIDefinition
+{
+    [XmlElement(ElementName = "Button")]
+    public Button Button { get; set; }
+}
+
+[XmlRoot(ElementName = "CustomAction")]
+public class CustomAction
+{
+    [XmlElement(ElementName = "CommandUIDefinition")]
+    public CommandUIDefinition CommandUIDefinition { get; set; }
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+    [XmlAttribute(AttributeName = "Location")]
+    public string Location { get; set; }
+    [XmlAttribute(AttributeName = "Sequence")]
+    public string Sequence { get; set; }
+}
+
+[XmlRoot(ElementName = "CustomActions")]
+public class CustomActions
+{
+    [XmlElement(ElementName = "CustomAction")]
+    public List<CustomAction> CustomAction { get; set; }
+}
+
+[XmlRoot(ElementName = "RibbonTemplates")]
+public class RibbonTemplates
+{
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+}
+
+[XmlRoot(ElementName = "Templates")]
+public class Templates
+{
+    [XmlElement(ElementName = "RibbonTemplates")]
+    public RibbonTemplates RibbonTemplates { get; set; }
+}
+
+[XmlRoot(ElementName = "EnableRule")]
+public class EnableRule
+{
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+    [XmlElement(ElementName = "CustomRule")]
+    public CustomRule CustomRule { get; set; }
+    [XmlElement(ElementName = "SelectionCountRule")]
+    public SelectionCountRule SelectionCountRule { get; set; }
+}
+
+[XmlRoot(ElementName = "EnableRules")]
+public class EnableRules
+{
+    [XmlElement(ElementName = "EnableRule")]
+    public List<EnableRule> EnableRule { get; set; }
+}
+
+[XmlRoot(ElementName = "CrmParameter")]
+public class CrmParameter
+{
+    [XmlAttribute(AttributeName = "Value")]
+    public string Value { get; set; }
+}
+
+[XmlRoot(ElementName = "JavaScriptFunction")]
+public class JavaScriptFunction
+{
+    [XmlElement(ElementName = "CrmParameter")]
+    public List<CrmParameter> CrmParameter { get; set; }
+    [XmlAttribute(AttributeName = "FunctionName")]
+    public string FunctionName { get; set; }
+    [XmlAttribute(AttributeName = "Library")]
+    public string Library { get; set; }
+}
+
+[XmlRoot(ElementName = "Actions")]
+public class Actions
+{
+    [XmlElement(ElementName = "JavaScriptFunction")]
+    public JavaScriptFunction JavaScriptFunction { get; set; }
+}
+
+[XmlRoot(ElementName = "CommandDefinition")]
+public class CommandDefinition
+{
+    [XmlElement(ElementName = "EnableRules")]
+    public EnableRules EnableRules { get; set; }
+    [XmlElement(ElementName = "DisplayRules")]
+    public string DisplayRules { get; set; }
+    [XmlElement(ElementName = "Actions")]
+    public Actions Actions { get; set; }
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+}
+
+[XmlRoot(ElementName = "CommandDefinitions")]
+public class CommandDefinitions
+{
+    [XmlElement(ElementName = "CommandDefinition")]
+    public List<CommandDefinition> CommandDefinition { get; set; }
+}
+
+[XmlRoot(ElementName = "CustomRule")]
+public class CustomRule
+{
+    [XmlElement(ElementName = "CrmParameter")]
+    public List<CrmParameter> CrmParameter { get; set; }
+    [XmlAttribute(AttributeName = "FunctionName")]
+    public string FunctionName { get; set; }
+    [XmlAttribute(AttributeName = "Library")]
+    public string Library { get; set; }
+    [XmlAttribute(AttributeName = "Default")]
+    public string Default { get; set; }
+    [XmlAttribute(AttributeName = "InvertResult")]
+    public string InvertResult { get; set; }
+}
+
+[XmlRoot(ElementName = "SelectionCountRule")]
+public class SelectionCountRule
+{
+    [XmlAttribute(AttributeName = "AppliesTo")]
+    public string AppliesTo { get; set; }
+    [XmlAttribute(AttributeName = "Minimum")]
+    public string Minimum { get; set; }
+    [XmlAttribute(AttributeName = "Maximum")]
+    public string Maximum { get; set; }
+    [XmlAttribute(AttributeName = "Default")]
+    public string Default { get; set; }
+    [XmlAttribute(AttributeName = "InvertResult")]
+    public string InvertResult { get; set; }
+}
+
+[XmlRoot(ElementName = "RuleDefinitions")]
+public class RuleDefinitions
+{
+    [XmlElement(ElementName = "TabDisplayRules")]
+    public string TabDisplayRules { get; set; }
+    [XmlElement(ElementName = "DisplayRules")]
+    public string DisplayRules { get; set; }
+    [XmlElement(ElementName = "EnableRules")]
+    public EnableRules EnableRules { get; set; }
+}
+
+[XmlRoot(ElementName = "Title")]
+public class Title
+{
+    [XmlAttribute(AttributeName = "description")]
+    public string Description { get; set; }
+    [XmlAttribute(AttributeName = "languagecode")]
+    public string Languagecode { get; set; }
+}
+
+[XmlRoot(ElementName = "Titles")]
+public class Titles
+{
+    [XmlElement(ElementName = "Title")]
+    public Title Title { get; set; }
+}
+
+[XmlRoot(ElementName = "LocLabel")]
+public class LocLabel
+{
+    [XmlElement(ElementName = "Titles")]
+    public Titles Titles { get; set; }
+    [XmlAttribute(AttributeName = "Id")]
+    public string Id { get; set; }
+}
+
+[XmlRoot(ElementName = "LocLabels")]
+public class LocLabels
+{
+    [XmlElement(ElementName = "LocLabel")]
+    public List<LocLabel> LocLabel { get; set; }
+}
+
+[XmlRoot(ElementName = "RibbonDiffXml")]
+public class RibbonDiffXml
+{
+    [XmlElement(ElementName = "CustomActions")]
+    public CustomActions CustomActions { get; set; }
+    [XmlElement(ElementName = "Templates")]
+    public Templates Templates { get; set; }
+    [XmlElement(ElementName = "CommandDefinitions")]
+    public CommandDefinitions CommandDefinitions { get; set; }
+    [XmlElement(ElementName = "RuleDefinitions")]
+    public RuleDefinitions RuleDefinitions { get; set; }
+    [XmlElement(ElementName = "LocLabels")]
+    public LocLabels LocLabels { get; set; }
+
+    public void Merge(RibbonDiffXml diff)
+    {
+        if (diff.CustomActions != null)
+        {
+            if (CustomActions != null)
+            {
+                CustomActions.CustomAction.AddRange(diff.CustomActions.CustomAction);
+            }
+            else
+            {
+                CustomActions = new CustomActions() { CustomAction = diff.CustomActions.CustomAction };
+            }
+        }
+
+        if (diff.CommandDefinitions != null)
+        {
+            if (CommandDefinitions != null)
+            {
+                CommandDefinitions.CommandDefinition.AddRange(diff.CommandDefinitions.CommandDefinition);
+            }
+            else
+            {
+                CommandDefinitions = new CommandDefinitions() { CommandDefinition = diff.CommandDefinitions.CommandDefinition };
+            }
+        }
+
+        if (diff.RuleDefinitions != null)
+        {
+            if (RuleDefinitions != null)
+            {
+                RuleDefinitions.EnableRules.EnableRule.AddRange(diff.RuleDefinitions.EnableRules.EnableRule);
+            }
+            else
+            {
+                RuleDefinitions = new RuleDefinitions() { EnableRules = new EnableRules() { EnableRule = diff.RuleDefinitions.EnableRules.EnableRule } };
+            }
+        }
+
+        if (diff.LocLabels != null)
+        {
+            if (LocLabels != null)
+            {
+                LocLabels.LocLabel.AddRange(diff.LocLabels.LocLabel);
+            }
+            else
+            {
+                LocLabels = new LocLabels() { LocLabel = diff.LocLabels.LocLabel };
+            }
+        }
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/RowType.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/RowType.cs
@@ -1,0 +1,34 @@
+﻿namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+public enum RowType
+{
+    Bit,
+    Managedproperty,
+    Multiselectoptionset,
+    Picklist,
+    State,
+    Status,
+    Virtual,
+    Owner,
+    Lookup,
+    Date,
+    Datetimeoffset,
+    Timestamp,
+    Varbinary,
+    Image,
+    Primarykey,
+    Smallint,
+    Tinyint,
+    Int,
+    Long,
+    Bigint,
+    Money,
+    Nvarchar,
+    Decimal,
+    Float,
+    Ntext,
+    Uniqueidentifier,
+    File,
+    Partylist,
+    Customer
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/Table.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/Table.cs
@@ -1,0 +1,86 @@
+﻿using DocumentFormat.OpenXml.Vml.Office;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using System.Xml.Serialization;
+using TALXIS.CLI.Data.DataModelConverter.Extensions;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+
+public enum TableType
+{
+    InSolution,
+    NotInSolution,
+    ConnectionTable
+}
+
+public class Table
+{
+    public Table() { }
+
+    public Table(XElement element)
+    {
+        LocalizedName = element.Elements("Name").FirstOrDefault(x => x.Name == "Name").Attribute("LocalizedName").Value.Replace(" ", "_").NormalizeString();
+        LogicalName = element.Element("Name")?.Value;
+        SetName = element.Elements("EntityInfo").Elements("entity").Elements("EntitySetName").ToList().Count != 0 ? element.Elements("EntityInfo").Elements("entity").Elements("EntitySetName").FirstOrDefault().Value : string.Empty;
+    }
+
+    public string LocalizedName { get; set; }
+    public string LogicalName { get; set; }
+    public string SetName { get; set; }
+    [JsonIgnore]
+    public Module ParentModule { get; set; }
+    public RibbonDiffXml ribbonDiff { get; set; }
+    public List<TableRow> Rows = [];
+    public TableType Type { get; set; }
+
+    public TableRow GetOrCreateRow(string rowName, RowType rowType, int maxLength = 0, string optionsetname = "")
+    {
+        var row = Rows.FirstOrDefault(x => string.Compare(x.Name, rowName, true) == 0);
+        if (row == null)
+        {
+            var tableRow = new TableRow(rowName, rowType);
+
+            if (maxLength > 0) tableRow.MaxLenght = maxLength;
+            if (!string.IsNullOrEmpty(optionsetname)) tableRow.OptionSetName = optionsetname;
+
+            Rows.Add(tableRow);
+        }
+        return Rows.FirstOrDefault(x => string.Compare(x.Name, rowName, true) == 0);
+    }
+
+    public void ParseMultipleRowsFromXml(List<XElement> xElements)
+    {
+        foreach (var element in xElements)
+        {
+            var row = TableRow.ParseXElement(element);
+            if (row != null)
+                Rows.Add(row);
+        }
+    }
+
+    public void ParseRibbonDiffXml(XElement ribbonDiffElement)
+    {
+        var serializer = new XmlSerializer(typeof(RibbonDiffXml));
+        using var reader = ribbonDiffElement.CreateReader();
+        var root = serializer.Deserialize(reader) as RibbonDiffXml ?? throw new InvalidOperationException("Failed to deserialize RibbonDiffXml.");
+
+        if (ribbonDiff != null)
+        {
+            ribbonDiff.Merge(root);
+        }
+        else
+        {
+            ribbonDiff = root;
+        }
+    }
+
+    public override string ToString()
+    {
+        return LogicalName;
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Model/TableRow.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Model/TableRow.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml.Linq;
+using TALXIS.CLI.Data.DataModelConverter.Extensions;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Model;
+
+
+public class TableRow
+{
+    public TableRow(string name, RowType rowType)
+    {
+        Name = name;
+        RowType = rowType;
+    }
+
+    public string Name { get; set; }
+    public int MaxLenght { get; set; }
+    public string OptionSetName { get; set; }
+    public RowType RowType { get; set; }
+
+    internal static TableRow? ParseXElement(XElement attribute)
+    {
+        string optionsetName = string.Empty;
+        RowType rowType;
+        int maxLength = 0;
+        var typeValue = attribute.Elements("Type")?.FirstOrDefault()?.Value;
+        switch (typeValue)
+        {
+            case "bit":
+                rowType = RowType.Bit;
+                optionsetName = attribute.Element("OptionSetName") == null ? attribute.Element("optionset") == null ? attribute.Elements("Type").FirstOrDefault().Value : attribute.Element("optionset").Attribute("Name").Value : attribute.Element("OptionSetName").Value;
+                break;
+            case "multiselectpicklist":
+                rowType = RowType.Multiselectoptionset;
+                optionsetName = attribute.Element("OptionSetName") == null ? attribute.Element("optionset") == null ? attribute.Elements("Type").FirstOrDefault().Value : attribute.Element("optionset").Attribute("Name").Value : attribute.Element("OptionSetName").Value;
+                break;
+            case "picklist":
+                rowType = RowType.Picklist;
+                optionsetName = attribute.Element("OptionSetName") == null ? attribute.Element("optionset") == null ? attribute.Elements("Type").FirstOrDefault().Value : attribute.Element("optionset").Attribute("Name").Value : attribute.Element("OptionSetName").Value;
+                break;
+            case "state":
+                rowType = RowType.State;
+                optionsetName = attribute.Element("OptionSetName") == null ? attribute.Element("optionset") == null ? attribute.Elements("Type").FirstOrDefault().Value : attribute.Element("optionset").Attribute("Name").Value : attribute.Element("OptionSetName").Value;
+                break;
+            case "status":
+                rowType = RowType.Status;
+                optionsetName = attribute.Element("OptionSetName") == null ? attribute.Element("optionset") == null ? attribute.Elements("Type").FirstOrDefault().Value : attribute.Element("optionset").Attribute("Name").Value : attribute.Element("OptionSetName").Value;
+                break;
+            case "virtual": //in case of default entities
+                rowType = RowType.Virtual;
+                break;
+            case "datetime":
+                if (attribute.Elements("Behavior").FirstOrDefault()?.Value == "2" || attribute.Elements("Behavior").FirstOrDefault()?.Value.ToLower() == "dateonly")
+                {
+                    rowType = RowType.Date;
+                }
+                else
+                {
+                    rowType = RowType.Datetimeoffset;
+                }
+                break;
+            case "primarykey":
+                rowType = RowType.Primarykey;
+                break;
+            case "lookup":
+                rowType = RowType.Lookup;
+                break;
+            case "uniqueidentifier":
+                rowType = RowType.Uniqueidentifier;
+                break;
+            case "owner":
+                rowType = RowType.Owner;
+                break;
+            case "nvarchar":
+                rowType = RowType.Nvarchar;
+
+                if (attribute.Elements("MaxLength").FirstOrDefault() != default)
+                {
+                    maxLength = int.Parse(attribute.Elements("MaxLength").FirstOrDefault()?.Value ?? "0");
+                }
+                else if (attribute.Elements("Length").FirstOrDefault() != default)
+                {
+                    maxLength = int.Parse(attribute.Elements("Length").FirstOrDefault()?.Value ?? "0");
+                }
+
+                break;
+            case "ntext":
+                rowType = RowType.Ntext;
+                if (attribute.Elements("MaxLength").FirstOrDefault() != default)
+                {
+                    maxLength = int.Parse(attribute.Elements("MaxLength").FirstOrDefault()?.Value ?? "0");
+                }
+                break;
+            default:
+                // Skip attributes with null or unrecognized type values
+                if (string.IsNullOrEmpty(typeValue))
+                    return null;
+
+                if (!Enum.TryParse<RowType>(typeValue.FirstCharToUpper(), out rowType))
+                {
+                    Console.WriteLine($"Warning: Unknown attribute type '{typeValue}' on '{attribute.Attribute("PhysicalName")?.Value}'. Skipping.");
+                    return null;
+                }
+                break;
+
+        }
+
+        return new TableRow(attribute.Attribute("PhysicalName").Value.ToLower(), rowType)
+        {
+            MaxLenght = maxLength,
+            OptionSetName = optionsetName
+        };
+
+    }
+
+    public override string ToString()
+    {
+        return Name;
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Translators/DBDiagramTranslator.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Translators/DBDiagramTranslator.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using TALXIS.CLI.Data.DataModelConverter.Model;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Translators;
+
+public static class DBDiagramTranslator
+{
+
+    public static Dictionary<string, string> CardinalityLookup = new Dictionary<string, string>()
+        {
+            {"OneToOne", "-"},
+            {"OneToMany", ">" },
+            {"ManyToOne", "<" }
+        };
+
+    public static string ToDbDiagramNotation(this Table table)
+    {
+        var result = $"\ntable {table.LogicalName} ";
+
+        switch (table.Type)
+        {
+            case TableType.InSolution:
+                result += $"[headercolor: {table.ParentModule?.Colorhex}] //{table.ParentModule?.ModuleName} \n";
+                break;
+            case TableType.NotInSolution:
+                result += "[headercolor: #c0392b] ";
+                break;
+            case TableType.ConnectionTable:
+                result += "[headercolor: #27ae60] ";
+                break;
+            default:
+                break;
+        }
+
+        result += "{\n";
+
+        foreach (var row in table.Rows)
+        {
+            result += row.ToDbDiagramNotation();
+        }
+
+        result += "}";
+
+        return result;
+
+    }
+
+    public static string ToDbDiagramNotation(this TableRow row)
+    {
+        var type = !string.IsNullOrEmpty(row.OptionSetName) ? row.OptionSetName : row.RowType.ToString();
+        return $"  {row.Name} {type} \n";
+    }
+
+    public static string ToDbDiagramNotation(this Relationship relationship)
+    {
+        return $"\nRef: \"{relationship.LeftSideTable?.LogicalName}\".\"{relationship.LeftSideRow?.Name}\" {CardinalityLookup[relationship.Cardinality]} \"{relationship.RighSideTable?.LogicalName}\".\"{relationship.RighSideRow?.Name}\"";
+
+    }
+
+    public static string ToDbDiagramNotation(this OptionsetRow row)
+    {
+        return $"\"{row.Value}\" [note:'{row.Label}']";
+    }
+
+    public static string ToDbDiagramNotation(this OptionsetEnum optionset)
+    {
+        var result = $"\nEnum {optionset.LocalizedName} {{";
+
+        foreach (var value in optionset.Values)
+        {
+            result += $"\n {value.ToDbDiagramNotation()}";
+        }
+
+        result += "\n}";
+
+        return result;
+
+    }
+}
+

--- a/src/TALXIS.CLI.Data/DataModelConverter/Translators/EDMXTranslator.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Translators/EDMXTranslator.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TALXIS.CLI.Data.DataModelConverter.Model;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Translators;
+
+public static class EDMXTranslator
+{
+    public static string ToEDMXNotation(this Table table)
+    {
+        var result = $"<EntityType Name=\"{table.LogicalName.ToLower()}\"";
+
+        var primaryKey = table.Rows.FirstOrDefault(x => x.RowType == RowType.Primarykey);
+
+        if (primaryKey.Name == "activityid")
+        {
+            result += " BaseType =\"mscrm.activitypointer\">";
+        }
+        else
+        {
+            result += " BaseType =\"mscrm.crmbaseentity\">";
+        }
+
+        if (primaryKey != default)
+        {
+            result += $"<Key><PropertyRef Name=\"{primaryKey.Name.ToLower()}\"/></Key>";
+        }
+
+        foreach (var row in table.Rows)
+        {
+            result += row.ToEDMXNotation();
+        }
+
+        return result;
+
+    }
+
+    public static string ToEDMXNotation(this TableRow row)
+    {
+
+        string result = "<Property Name=\"{0}\"";
+
+        switch (row.RowType)
+        {
+            case RowType.Partylist:
+            case RowType.Multiselectoptionset:
+                result += " Type=\"Edm.String\" Unicode=\"false\"/>";
+                break;
+            case RowType.Bit:
+                result += " Type=\"Edm.Boolean\"/>";
+                break;
+            case RowType.Managedproperty:
+                result += " Type = \"mscrm.BooleanManagedProperty\" />";
+                break;
+            case RowType.Smallint:
+            case RowType.Tinyint:
+            case RowType.Int:
+            case RowType.State:
+            case RowType.Status:
+            case RowType.Picklist:
+                result += " Type=\"Edm.Int32\"/>";
+                break;
+            case RowType.Lookup:
+            case RowType.Owner:
+                result = "<Property Name =\"_{0}_value\" Type=\"Edm.Guid\"/>";
+                break;
+            case RowType.Customer:
+            // Solve
+            case RowType.Nvarchar:
+            case RowType.Ntext:
+                result += " Type=\"Edm.String\" Unicode=\"false\"/>";
+                break;
+            case RowType.File:
+                return $"  <Property Name =\"_{row.Name}_value\" Type=\"Edm.Guid\"/> \n <Property Name =\"{row.Name}_name\" Type=\"Edm.String\" Unicode=\"false\"/>";
+            case RowType.Virtual:
+                return string.Empty;
+            case RowType.Datetimeoffset:
+                result += " Type=\"Edm.DateTimeOffset\"/>";
+                break;
+            case RowType.Date:
+                result += " Type=\"Edm.Date\"/>";
+                break;
+            case RowType.Primarykey:
+            case RowType.Uniqueidentifier:
+                result += " Type=\"Edm.Guid\"/>";
+                break;
+            case RowType.Money:
+            case RowType.Decimal:
+                result += " Type=\"Edm.Decimal\" Scale=\"Variable\"/>";
+                break;
+            case RowType.Float:
+                result += " Type=\"Edm.Double\"/>";
+                break;
+            case RowType.Long:
+            case RowType.Timestamp:
+            case RowType.Bigint:
+                result += " Type=\"Edm.Int64\"/>";
+                break;
+            case RowType.Varbinary:
+            case RowType.Image:
+                result += " Type=\"Edm.Binary\"/>";
+                break;
+            default:
+                break;
+        }
+
+        return string.Format(result, row.Name.ToLower());
+    }
+
+    public static string ToEDMXNotation(this Relationship relationship, Table table)
+    {
+        if (relationship.LeftSideTable == table)
+        {
+            return $"<NavigationProperty Name=\"{relationship.LeftSideRow.Name.ToLower()}\" Type=\"mscrm.{relationship.RighSideTable.LogicalName.ToLower()}\" Nullable=\"false\" Partner=\"{relationship.Name}\"><ReferentialConstraint Property=\"_{relationship.LeftSideRow.Name.ToLower()}_value\" ReferencedProperty=\"{relationship.RighSideRow.Name.ToLower()}\"/></NavigationProperty>";
+        }
+        else
+        {
+            return $"<NavigationProperty Name=\"{relationship.Name}\" Type=\"Collection(mscrm.{relationship.LeftSideTable.LogicalName.ToLower()})\" Partner=\"{relationship.LeftSideRow.Name}\"/>";
+        }
+    }
+
+    public static string ToEDMXNotationBinding(this Relationship relationship, Table table)
+    {
+
+        if (relationship.LeftSideTable == table)
+        {
+            return $"<NavigationPropertyBinding Path=\"{relationship.Name}\" Target=\"{relationship.RighSideTable.SetName.ToLower()}\"/>";
+        }
+        else
+        {
+            return $"<NavigationPropertyBinding Path=\"{relationship.Name}\" Target=\"{relationship.LeftSideTable.SetName.ToLower()}\"/>";
+        }
+
+    }
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/Translators/SQLTranslator.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/Translators/SQLTranslator.cs
@@ -1,0 +1,213 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TALXIS.CLI.Data.DataModelConverter.Model;
+
+namespace TALXIS.CLI.Data.DataModelConverter.Translators;
+
+public static class SQLTranslator
+{
+    private static Dictionary<RowType, string> translationTable = new Dictionary<RowType, string>()
+        {
+            { RowType.Primarykey, "uniqueidentifier PRIMARY KEY"},
+            { RowType.Partylist, "nvarchar (1000)"},
+        };
+
+
+    public static string TranslateToSql(RowType key)
+    {
+        if (translationTable.ContainsKey(key)) return translationTable[key];
+        return key.ToString().ToLower();
+    }
+
+    public static string ToSQLNotation(this Table table, List<OptionsetEnum> optionsets)
+    {
+        string result = string.IsNullOrEmpty(table.SetName) ? $"\nCREATE TABLE [{table.LogicalName}] (\n" : $"\nCREATE TABLE [{table.SetName}] (\n";
+
+        List<string> rows = [];
+        foreach (var row in table.Rows)
+        {
+            rows.Add(row.ToSQLNotation(optionsets));
+        }
+
+        result += string.Join(",\n", rows.Where(x => !string.IsNullOrEmpty(x)));
+
+        result += "\n)\nGO\n";
+
+        return result;
+
+    }
+
+    public static string ToEDSSQLNotation(this Table table, List<OptionsetEnum> optionsets, List<Relationship> relationships)
+    {
+        string result = string.IsNullOrEmpty(table.SetName) ? $"\nCREATE TABLE [{table.LogicalName}] (\n" : $"\nCREATE TABLE [{table.SetName}] (\n";
+
+        List<string> rows = [];
+        foreach (var row in table.Rows)
+        {
+            rows.Add(row.ToEDSSQLNotation(optionsets, relationships));
+        }
+
+        result += string.Join(",\n", rows.Where(x => !string.IsNullOrEmpty(x)));
+
+        result += "\n)\nGO\n";
+
+        return result;
+
+    }
+
+    public static string ToSQLNotation(this Relationship relationship)
+    {
+
+        var cardinality = DBDiagramTranslator.CardinalityLookup[relationship.Cardinality];
+        var result = string.Empty;
+
+        if (relationship.RighSideRow.RowType == RowType.Primarykey && relationship.LeftSideRow.RowType == RowType.Primarykey) return string.Empty;
+
+        if (cardinality == ">")
+        {
+
+            if (relationship.LeftSideRow.RowType == RowType.Customer)
+            {
+                result += $"\nALTER TABLE [{(string.IsNullOrEmpty(relationship.LeftSideTable?.SetName) ? relationship.LeftSideTable?.LogicalName : relationship.LeftSideTable?.SetName)}] ADD FOREIGN KEY ([_{relationship.LeftSideRow?.Name}_{relationship.RighSideTable.LogicalName.ToLower()}]) REFERENCES [{(string.IsNullOrEmpty(relationship.RighSideTable?.SetName) ? relationship.RighSideTable?.LogicalName : relationship.RighSideTable?.SetName)}] ([{relationship.RighSideRow?.Name}])";
+            }
+            else
+            {
+                result += $"\nALTER TABLE [{(string.IsNullOrEmpty(relationship.LeftSideTable?.SetName) ? relationship.LeftSideTable?.LogicalName : relationship.LeftSideTable?.SetName)}] ADD FOREIGN KEY ([_{relationship.LeftSideRow?.Name}_value]) REFERENCES [{(string.IsNullOrEmpty(relationship.RighSideTable?.SetName) ? relationship.RighSideTable?.LogicalName : relationship.RighSideTable?.SetName)}] ([{relationship.RighSideRow?.Name}])";
+            }
+
+        }
+
+        if (cardinality == "<")
+        {
+            if (relationship.RighSideRow.RowType == RowType.Customer)
+            {
+                result += $"\nALTER TABLE [{(string.IsNullOrEmpty(relationship.LeftSideTable?.SetName) ? relationship.LeftSideTable?.LogicalName : relationship.LeftSideTable?.SetName)}] ADD FOREIGN KEY ([_{relationship.RighSideRow?.Name}_{relationship.LeftSideTable.LogicalName.ToLower()}]) REFERENCES [{(string.IsNullOrEmpty(relationship.RighSideTable?.SetName) ? relationship.RighSideTable?.LogicalName : relationship.RighSideTable?.SetName)}] ([{relationship.RighSideRow?.Name}])";
+            }
+
+            else
+            {
+                result += $"\nALTER TABLE [{(string.IsNullOrEmpty(relationship.RighSideTable?.SetName) ? relationship.RighSideTable?.LogicalName : relationship.RighSideTable?.SetName)}] ADD FOREIGN KEY ([_{relationship.RighSideRow?.Name}_value]) REFERENCES [{(string.IsNullOrEmpty(relationship.LeftSideTable?.SetName) ? relationship.LeftSideTable?.LogicalName : relationship.LeftSideTable?.SetName)}] ([{relationship.LeftSideRow?.Name}])";
+
+            }
+        }
+
+        result += "\nGO\n";
+
+        return result;
+    }
+
+    public static string ToEDSSQLNotation(this TableRow row, List<OptionsetEnum> optionsets, List<Relationship> relationships)
+    {
+        switch (row.RowType)
+        {
+            case RowType.Multiselectoptionset:
+                return $"  [{row.Name}] nvarchar(255)";
+            case RowType.Bit:
+                return $"  [{row.Name}] bit";
+            case RowType.State:
+            case RowType.Status:
+            case RowType.Picklist:
+                var relevantPicklist = optionsets.FirstOrDefault(x => x.LocalizedName == row.OptionSetName || x.LocalizedName == row.RowType.ToString());
+                if (relevantPicklist == null)
+                    return $"  [{row.Name}] nvarchar(255)";
+                return $"  [{row.Name}] nvarchar(255) CHECK ([{row.Name}] IN ({string.Join(',', relevantPicklist.Values.Select(x => "'" + x.Value + "'"))}))";
+            case RowType.Managedproperty:
+                return $"  [{row.Name}] nvarchar(255) CHECK ([{row.Name}] IN ('0','1'))";
+            case RowType.Customer:
+                var result = $"  [_{row.Name}_value] nvarchar(255)";
+
+                foreach (var item in relationships.Where(x => x.LeftSideRow.Name == row.Name))
+                {
+                    result += $",\n [_{row.Name}_{item.RighSideTable.LogicalName.ToLower()}] uniqueidentifier";
+                }
+
+                return result;
+            case RowType.Lookup:
+            case RowType.Owner:
+            case RowType.Uniqueidentifier:
+                return $"  [_{row.Name}_value] uniqueidentifier";
+            case RowType.Nvarchar:
+            case RowType.Ntext:
+                return $"  [{row.Name}] nvarchar({(row.MaxLenght > 4000 ? "max" : row.MaxLenght.ToString())})";
+            case RowType.File:
+                return $"  [{row.Name}] uniqueidentifier,\n [{row.Name}_name] nvarchar (max)";
+            case RowType.Virtual:
+            case RowType.Varbinary:
+            case RowType.Timestamp:
+                return string.Empty;
+            case RowType.Long:
+            case RowType.Int:
+            case RowType.Smallint:
+            case RowType.Tinyint:
+                return $"  [{row.Name}] int";
+            case RowType.Date:
+                return $"  [{row.Name}] datetime";
+            case RowType.Datetimeoffset:
+                return $"  [{row.Name}] datetimeoffset";
+            case RowType.Money:
+            case RowType.Decimal:
+                return $"  [{row.Name}] decimal";
+            case RowType.Primarykey:
+            case RowType.Float:
+            case RowType.Partylist:
+            default:
+                return $"  [{row.Name}] {TranslateToSql(row.RowType)}";
+        }
+
+    }
+
+    public static string ToSQLNotation(this TableRow row, List<OptionsetEnum> optionsets)
+    {
+        switch (row.RowType)
+        {
+            case RowType.Multiselectoptionset:
+                return $"  [{row.Name}] nvarchar(255)";
+            case RowType.Bit:
+                return $"  [{row.Name}] bit";
+            case RowType.State:
+            case RowType.Status:
+            case RowType.Picklist:
+                var relevantPicklist = optionsets.FirstOrDefault(x => x.LocalizedName == row.OptionSetName || x.LocalizedName == row.RowType.ToString());
+                if (relevantPicklist == null)
+                    return $"  [{row.Name}] nvarchar(255)";
+                return $"  [{row.Name}] nvarchar(255) CHECK ([{row.Name}] IN ({string.Join(',', relevantPicklist.Values.Select(x => "'" + x.Value + "'"))}))";
+            case RowType.Managedproperty:
+                return $"  [{row.Name}] nvarchar(255) CHECK ([{row.Name}] IN ('0','1'))";
+            case RowType.Lookup:
+            case RowType.Owner:
+            case RowType.Customer:
+                return $"  [{row.Name}] uniqueidentifier";
+            case RowType.Nvarchar:
+            case RowType.Ntext:
+                return $"  [{row.Name}] nvarchar({(row.MaxLenght > 4000 ? "max" : row.MaxLenght.ToString())})";
+            case RowType.File:
+                return $"  [{row.Name}] uniqueidentifier,\n [{row.Name}_name] nvarchar (max)";
+            case RowType.Virtual:
+            case RowType.Varbinary:
+            case RowType.Timestamp:
+                return string.Empty;
+            case RowType.Long:
+            case RowType.Int:
+            case RowType.Smallint:
+            case RowType.Tinyint:
+                return $"  [{row.Name}] int";
+            case RowType.Date:
+                return $"  [{row.Name}] datetime";
+            case RowType.Datetimeoffset:
+                return $"  [{row.Name}] datetimeoffset";
+            case RowType.Money:
+            case RowType.Decimal:
+                return $"  [{row.Name}] decimal";
+            case RowType.Primarykey:
+            case RowType.Float:
+            case RowType.Uniqueidentifier:
+            case RowType.Partylist:
+            default:
+                return $"  [{row.Name}] {TranslateToSql(row.RowType)}";
+        }
+
+    }
+
+}

--- a/src/TALXIS.CLI.Data/DataModelConverter/XMLSchemas/OptionSetXmlSchema.cs
+++ b/src/TALXIS.CLI.Data/DataModelConverter/XMLSchemas/OptionSetXmlSchema.cs
@@ -1,0 +1,324 @@
+﻿
+// NOTE: Generated code may require at least .NET Framework 4.5 or .NET Core/Standard 2.0.
+using System.Xml.Linq;
+
+using System.Xml.Serialization;
+
+/// <remarks/>
+[System.SerializableAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+[System.Xml.Serialization.XmlRootAttribute(Namespace = "", IsNullable = false)]
+public partial class Optionset
+{
+
+    public static Optionset ParseOptionsetFromXElement(XElement element)
+    {
+        var serializer = new XmlSerializer(typeof(Optionset));
+        using var reader = element.CreateReader();
+        if (serializer.Deserialize(reader) is not Optionset result)
+            throw new InvalidOperationException("Failed to deserialize Optionset from XElement.");
+        return result;
+    }
+
+    private string optionSetTypeField;
+
+    private byte isGlobalField;
+
+    private string introducedVersionField;
+
+    private byte isCustomizableField;
+
+    private optionsetDisplayname[] displaynamesField;
+
+    private optionsetDescription[] descriptionsField;
+
+    private optionsetOption[] optionsField;
+
+    private string nameField;
+
+    private string localizedNameField;
+
+    /// <remarks/>
+    public string OptionSetType
+    {
+        get
+        {
+            return this.optionSetTypeField;
+        }
+        set
+        {
+            this.optionSetTypeField = value;
+        }
+    }
+
+    /// <remarks/>
+    public byte IsGlobal
+    {
+        get
+        {
+            return this.isGlobalField;
+        }
+        set
+        {
+            this.isGlobalField = value;
+        }
+    }
+
+    /// <remarks/>
+    public string IntroducedVersion
+    {
+        get
+        {
+            return this.introducedVersionField;
+        }
+        set
+        {
+            this.introducedVersionField = value;
+        }
+    }
+
+    /// <remarks/>
+    public byte IsCustomizable
+    {
+        get
+        {
+            return this.isCustomizableField;
+        }
+        set
+        {
+            this.isCustomizableField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayItemAttribute("displayname", IsNullable = false)]
+    public optionsetDisplayname[] displaynames
+    {
+        get
+        {
+            return this.displaynamesField;
+        }
+        set
+        {
+            this.displaynamesField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayItemAttribute("Description", IsNullable = false)]
+    public optionsetDescription[] Descriptions
+    {
+        get
+        {
+            return this.descriptionsField;
+        }
+        set
+        {
+            this.descriptionsField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayItemAttribute("option", IsNullable = false)]
+    public optionsetOption[] options
+    {
+        get
+        {
+            return this.optionsField;
+        }
+        set
+        {
+            this.optionsField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string Name
+    {
+        get
+        {
+            return this.nameField;
+        }
+        set
+        {
+            this.nameField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string localizedName
+    {
+        get
+        {
+            return this.localizedNameField;
+        }
+        set
+        {
+            this.localizedNameField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.SerializableAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+public partial class optionsetDisplayname
+{
+
+    private string descriptionField;
+
+    private ushort languagecodeField;
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string description
+    {
+        get
+        {
+            return this.descriptionField;
+        }
+        set
+        {
+            this.descriptionField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public ushort languagecode
+    {
+        get
+        {
+            return this.languagecodeField;
+        }
+        set
+        {
+            this.languagecodeField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.SerializableAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+public partial class optionsetDescription
+{
+
+    private string descriptionField;
+
+    private ushort languagecodeField;
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string description
+    {
+        get
+        {
+            return this.descriptionField;
+        }
+        set
+        {
+            this.descriptionField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public ushort languagecode
+    {
+        get
+        {
+            return this.languagecodeField;
+        }
+        set
+        {
+            this.languagecodeField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.SerializableAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+public partial class optionsetOption
+{
+
+    private optionsetOptionLabel[] labelsField;
+
+    private uint valueField;
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlArrayItemAttribute("label", IsNullable = false)]
+    public optionsetOptionLabel[] labels
+    {
+        get
+        {
+            return this.labelsField;
+        }
+        set
+        {
+            this.labelsField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public uint value
+    {
+        get
+        {
+            return this.valueField;
+        }
+        set
+        {
+            this.valueField = value;
+        }
+    }
+}
+
+/// <remarks/>
+[System.SerializableAttribute()]
+[System.ComponentModel.DesignerCategoryAttribute("code")]
+[System.Xml.Serialization.XmlTypeAttribute(AnonymousType = true)]
+public partial class optionsetOptionLabel
+{
+
+    private string descriptionField;
+
+    private ushort languagecodeField;
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public string description
+    {
+        get
+        {
+            return this.descriptionField;
+        }
+        set
+        {
+            this.descriptionField = value;
+        }
+    }
+
+    /// <remarks/>
+    [System.Xml.Serialization.XmlAttributeAttribute()]
+    public ushort languagecode
+    {
+        get
+        {
+            return this.languagecodeField;
+        }
+        set
+        {
+            this.languagecodeField = value;
+        }
+    }
+}
+

--- a/src/TALXIS.CLI.Data/TALXIS.CLI.Data.csproj
+++ b/src/TALXIS.CLI.Data/TALXIS.CLI.Data.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
     <PackageReference Include="DotMake.CommandLine" Version="2.6.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/TALXIS.CLI.Workspace/TALXIS.CLI.Workspace.csproj
+++ b/src/TALXIS.CLI.Workspace/TALXIS.CLI.Workspace.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TALXIS.CLI.Data\TALXIS.CLI.Data.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="DotMake.CommandLine" Version="2.6.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
     <PackageReference Include="Microsoft.TemplateEngine.IDE" Version="9.0.302" />

--- a/src/TALXIS.CLI/TxcCliCommand.cs
+++ b/src/TALXIS.CLI/TxcCliCommand.cs
@@ -4,7 +4,7 @@ namespace TALXIS.CLI;
 
 [CliCommand(
     Description = "Tool for automating development loops in Power Platform",
-    Children = new[] { typeof(Data.DataCliCommand), typeof(Workspace.WorkspaceCliCommand) },
+    Children = new[] { typeof(Data.DataCliCommand), typeof(Docs.DocsCliCommand), typeof(Workspace.WorkspaceCliCommand) },
     ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class TxcCliCommand

--- a/tests/TALXIS.CLI.IntegrationTests/CliRunner.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/CliRunner.cs
@@ -1,8 +1,14 @@
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace TALXIS.CLI.IntegrationTests;
+
+/// <summary>
+/// Result of a CLI command execution, including output and exit code.
+/// </summary>
+public record CliResult(int ExitCode, string Output, string Error);
 
 /// <summary>
 /// Executes CLI commands for testing purposes.
@@ -11,59 +17,85 @@ public static class CliRunner
 {
     private static readonly string CliProject = GetCliProjectPath();
 
-    public static async Task<string> RunAsync(string command)
+    /// <summary>
+    /// Runs a CLI command, splitting the command string by spaces.
+    /// Use the <see cref="string[]"/> overload when arguments may contain spaces (e.g. file paths).
+    /// Throws <see cref="InvalidOperationException"/> on non-zero exit code.
+    /// </summary>
+    public static Task<string> RunAsync(string command, string? workingDirectory = null)
+        => RunAsync(command.Split(' ', StringSplitOptions.RemoveEmptyEntries), workingDirectory);
+
+    /// <summary>
+    /// Runs a CLI command with explicit argument tokens.
+    /// Throws <see cref="InvalidOperationException"/> on non-zero exit code.
+    /// </summary>
+    public static async Task<string> RunAsync(string[] args, string? workingDirectory = null)
+    {
+        var result = await RunRawAsync(args, workingDirectory);
+
+        if (result.ExitCode != 0)
+        {
+            var errorMessage = $"CLI command failed: {string.Join(' ', args)}\nExit code: {result.ExitCode}";
+            if (!string.IsNullOrEmpty(result.Error))
+                errorMessage += $"\nError: {result.Error}";
+            if (!string.IsNullOrEmpty(result.Output))
+                errorMessage += $"\nOutput: {result.Output}";
+
+            throw new InvalidOperationException(errorMessage);
+        }
+
+        return result.Output;
+    }
+
+    /// <summary>
+    /// Runs a CLI command and returns the full result without throwing on failure.
+    /// Useful for asserting on expected error cases.
+    /// </summary>
+    public static Task<CliResult> RunRawAsync(string command, string? workingDirectory = null)
+        => RunRawAsync(command.Split(' ', StringSplitOptions.RemoveEmptyEntries), workingDirectory);
+
+    /// <summary>
+    /// Runs a CLI command with explicit argument tokens and returns the full result without throwing on failure.
+    /// </summary>
+    public static async Task<CliResult> RunRawAsync(string[] args, string? workingDirectory = null)
     {
         var psi = new ProcessStartInfo("dotnet")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            CreateNoWindow = true
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
         };
-        
+
         psi.ArgumentList.Add("run");
         psi.ArgumentList.Add("--project");
         psi.ArgumentList.Add(CliProject);
+        psi.ArgumentList.Add("--no-build");
         psi.ArgumentList.Add("--");
-        
-        var commandArgs = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        foreach (var arg in commandArgs)
-        {
+
+        foreach (var arg in args)
             psi.ArgumentList.Add(arg);
-        }
-        
-        using var process = Process.Start(psi);
+
+        using var process = Process.Start(psi)!;
         string output = await process.StandardOutput.ReadToEndAsync();
         string error = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
-        
-        if (process.ExitCode != 0)
-        {
-            var errorMessage = $"CLI command failed: {command}\nExit code: {process.ExitCode}";
-            if (!string.IsNullOrEmpty(error))
-                errorMessage += $"\nError: {error}";
-            if (!string.IsNullOrEmpty(output))
-                errorMessage += $"\nOutput: {output}";
-                
-            throw new InvalidOperationException(errorMessage);
-        }
-            
-        return output;
+
+        return new CliResult(process.ExitCode, output, error);
     }
 
     private static string GetCliProjectPath()
     {
         var baseDir = AppContext.BaseDirectory;
-        var dir = new System.IO.DirectoryInfo(baseDir);
-        
-        while (dir != null && !System.IO.File.Exists(System.IO.Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
-        {
+        var dir = new DirectoryInfo(baseDir);
+
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
             dir = dir.Parent;
-        }
-        
+
         if (dir == null)
             throw new InvalidOperationException("Could not find repository root");
-            
-        return System.IO.Path.Combine(dir.FullName, "src", "TALXIS.CLI", "TALXIS.CLI.csproj");
+
+        return Path.Combine(dir.FullName, "src", "TALXIS.CLI", "TALXIS.CLI.csproj");
     }
 }

--- a/tests/TALXIS.CLI.IntegrationTests/DataModelConvertTests.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/DataModelConvertTests.cs
@@ -1,0 +1,107 @@
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TALXIS.CLI.IntegrationTests;
+
+/// <summary>
+/// Integration tests for <c>txc data model convert</c>.
+/// Uses <see cref="TempWorkspaceFixture"/> to scaffold a real Power Platform solution
+/// with an entity and attributes, then verifies conversion to each supported format.
+/// </summary>
+[Collection("Sequential")]
+public class DataModelConvertTests : IClassFixture<TempWorkspaceFixture>
+{
+    private readonly TempWorkspaceFixture _fixture;
+
+    public DataModelConvertTests(TempWorkspaceFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Theory]
+    [InlineData("dbml", "table ")]
+    [InlineData("sql", "CREATE TABLE")]
+    [InlineData("edmx", "<edmx:Edmx")]
+    [InlineData("ribbon", "RibbonDiffXml")]
+    public async Task Convert_AllFormats_CreatesOutputFileWithExpectedContent(string format, string expectedContent)
+    {
+        var outputDir = Path.Combine(_fixture.TempDir, $"output-{format}");
+        Directory.CreateDirectory(outputDir);
+
+        await CliRunner.RunAsync(
+            ["data", "model", "convert",
+             "--input", _fixture.DeclarationsDir,
+             "--target", format,
+             "--output", outputDir]);
+
+        var outputFile = Path.Combine(outputDir, $"solution.{format}");
+        Assert.True(File.Exists(outputFile), $"Expected output file not found: {outputFile}");
+
+        var content = await File.ReadAllTextAsync(outputFile);
+        Assert.Contains(expectedContent, content);
+    }
+
+    [Fact]
+    public async Task Convert_DefaultOutput_WritesToExportsFolderAndUpdatesGitIgnore()
+    {
+        // Run from the solution dir so the default output resolves to <solutionDir>/exports/
+        await CliRunner.RunAsync(
+            ["data", "model", "convert",
+             "--input", _fixture.DeclarationsDir,
+             "--target", "dbml"],
+            _fixture.SolutionDir);
+
+        var exportsDir = Path.Combine(_fixture.SolutionDir, "exports");
+        var outputFile = Path.Combine(exportsDir, "solution.dbml");
+
+        Assert.True(Directory.Exists(exportsDir), "exports/ directory was not created");
+        Assert.True(File.Exists(outputFile), $"Expected output file not found: {outputFile}");
+
+        // Verify exports/ was added to the nearest .gitignore
+        var gitIgnorePath = Path.Combine(_fixture.TempDir, ".gitignore");
+        var gitIgnoreContent = await File.ReadAllTextAsync(gitIgnorePath);
+        Assert.Contains("exports/", gitIgnoreContent);
+    }
+
+    [Fact]
+    public async Task Convert_DefaultInput_UsesCurrentDirectory()
+    {
+        var outputDir = Path.Combine(_fixture.TempDir, "output-default-input");
+        Directory.CreateDirectory(outputDir);
+
+        // Run from DeclarationsDir — omitting --input should pick up the current directory
+        await CliRunner.RunAsync(
+            ["data", "model", "convert",
+             "--target", "dbml",
+             "--output", outputDir],
+            _fixture.DeclarationsDir);
+
+        var outputFile = Path.Combine(outputDir, "solution.dbml");
+        Assert.True(File.Exists(outputFile), $"Expected output file not found: {outputFile}");
+    }
+
+    [Fact]
+    public async Task Convert_InvalidTarget_ReturnsNonZeroExitCode()
+    {
+        var result = await CliRunner.RunRawAsync(
+            ["data", "model", "convert",
+             "--input", _fixture.DeclarationsDir,
+             "--target", "invalid-format",
+             "--output", _fixture.TempDir]);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+
+    [Fact]
+    public async Task Convert_NonExistentInput_ReturnsNonZeroExitCode()
+    {
+        var result = await CliRunner.RunRawAsync(
+            ["data", "model", "convert",
+             "--input", "/nonexistent/path/that/does/not/exist",
+             "--target", "dbml",
+             "--output", _fixture.TempDir]);
+
+        Assert.NotEqual(0, result.ExitCode);
+    }
+}

--- a/tests/TALXIS.CLI.IntegrationTests/EquivalenceTests.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/EquivalenceTests.cs
@@ -19,7 +19,7 @@ public class EquivalenceTests
     {
         var cliOutput = await CliRunner.RunAsync(cliCommand);
         
-        var mcpClient = await McpClient.InstanceAsync;
+        var mcpClient = await McpTestClient.InstanceAsync;
         var mcpResult = await mcpClient.CallToolAsync(mcpTool, mcpArgs);
         
         var mcpOutput = ExtractTextContent(mcpResult);

--- a/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
+using System.IO;
 using System.Threading.Tasks;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
@@ -9,21 +9,21 @@ using ModelContextProtocol.Protocol;
 namespace TALXIS.CLI.IntegrationTests;
 
 /// <summary>
-/// Singleton MCP client for testing purposes. Reuses the same connection across all tests.
+/// Singleton MCP client wrapper for testing purposes. Reuses the same connection across all tests.
 /// </summary>
-public sealed class McpClient : IAsyncDisposable
+public sealed class McpTestClient : IAsyncDisposable
 {
-    private static readonly Lazy<Task<McpClient>> _instance = new(CreateInstanceAsync);
-    private readonly IMcpClient _client;
+    private static readonly Lazy<Task<McpTestClient>> _instance = new(CreateInstanceAsync);
+    private readonly McpClient _client;
 
-    private McpClient(IMcpClient client)
+    private McpTestClient(McpClient client)
     {
         _client = client;
     }
 
-    public static Task<McpClient> InstanceAsync => _instance.Value;
+    public static Task<McpTestClient> InstanceAsync => _instance.Value;
 
-    private static async Task<McpClient> CreateInstanceAsync()
+    private static async Task<McpTestClient> CreateInstanceAsync()
     {
         var mcpProjectPath = GetMcpProjectPath();
         
@@ -37,20 +37,13 @@ public sealed class McpClient : IAsyncDisposable
             Arguments = ["run", "--project", mcpProjectPath]
         });
 
-        try
-        {
-            var client = await McpClientFactory.CreateAsync(transport);
-            return new McpClient(client);
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException($"Failed to create MCP client. This might be due to server startup issues. Error: {ex.Message}", ex);
-        }
+        var client = await McpClient.CreateAsync(transport);
+        return new McpTestClient(client);
     }
 
-    public async Task<CallToolResult> CallToolAsync(string toolName, Dictionary<string, object> arguments = null)
+    public async Task<CallToolResult> CallToolAsync(string toolName, Dictionary<string, object>? arguments = null)
     {
-        arguments = arguments ?? new Dictionary<string, object>();
+        arguments ??= new Dictionary<string, object>();
         return await _client.CallToolAsync(toolName, arguments);
     }
 
@@ -67,17 +60,15 @@ public sealed class McpClient : IAsyncDisposable
     private static string GetMcpProjectPath()
     {
         var baseDir = AppContext.BaseDirectory;
-        var dir = new System.IO.DirectoryInfo(baseDir);
-        
-        while (dir != null && !System.IO.File.Exists(System.IO.Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
-        {
+        var dir = new DirectoryInfo(baseDir);
+
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
             dir = dir.Parent;
-        }
-        
+
         if (dir == null)
             throw new InvalidOperationException("Could not find repository root");
-            
-        return System.IO.Path.Combine(dir.FullName, "src", "TALXIS.CLI.MCP", "TALXIS.CLI.MCP.csproj");
+
+        return Path.Combine(dir.FullName, "src", "TALXIS.CLI.MCP", "TALXIS.CLI.MCP.csproj");
     }
 
     /// <summary>

--- a/tests/TALXIS.CLI.IntegrationTests/McpTests.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/McpTests.cs
@@ -16,7 +16,7 @@ public class McpTests
     [Fact]
     public async Task ListTools_ReturnsExpectedTools()
     {
-        var client = await McpClient.InstanceAsync;
+        var client = await McpTestClient.InstanceAsync;
         
         var tools = await client.ListToolsAsync();
         var toolNames = tools.Select(t => t.Name).ToList();
@@ -28,7 +28,7 @@ public class McpTests
     [Fact]
     public async Task WorkspaceComponentList_ReturnsValidResponse()
     {
-        var client = await McpClient.InstanceAsync;
+        var client = await McpTestClient.InstanceAsync;
         
         var result = await client.CallToolAsync("workspace_component_type_list");
         
@@ -40,10 +40,10 @@ public class McpTests
     [Fact]
     public async Task WorkspaceComponentTypeExplain_ReturnsComponentDetails()
     {
-        var client = await McpClient.InstanceAsync;
-        var args = new Dictionary<string, object> { { "Type", "pp-entity" } };
-
-        var result = await client.CallToolAsync("workspace_component_type_explain", args);
+        var client = await McpTestClient.InstanceAsync;
+        var args = new Dictionary<string, object> { { "Name", "pp-entity" } };
+        
+        var result = await client.CallToolAsync("workspace_component_explain", args);
         
         Assert.NotNull(result.Content);
         Assert.NotEmpty(result.Content);

--- a/tests/TALXIS.CLI.IntegrationTests/TALXIS.CLI.IntegrationTests.csproj
+++ b/tests/TALXIS.CLI.IntegrationTests/TALXIS.CLI.IntegrationTests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/tests/TALXIS.CLI.IntegrationTests/TempWorkspaceFixture.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/TempWorkspaceFixture.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TALXIS.CLI.IntegrationTests;
+
+/// <summary>
+/// Scaffolds a temporary workspace with a Power Platform solution, entity and attributes
+/// using the txc CLI. Shared across all tests in <see cref="SolutionConvertTests"/>.
+///
+/// Setup sequence:
+///   1. Create a temp directory with a .sln (required by pp-solution post-actions)
+///   2. txc workspace component create pp-solution (--output srcDir/TestSolution)
+///   3. txc workspace component create pp-entity   (--output Declarations --name testentity)
+///   4. txc workspace component create pp-entity-attribute (x3 attribute types)
+///   5. Create a .gitignore so the auto-gitignore logic has a file to update
+/// </summary>
+public sealed class TempWorkspaceFixture : IAsyncLifetime
+{
+    private const string PublisherPrefix = "tst";
+    private const string PublisherName = "TestPublisher";
+    private const string EntityLogicalName = "testentity";
+
+    // Entity schema name uses publisher prefix (set by pp-entity template)
+    private string EntitySchemaName => $"{PublisherPrefix}_{EntityLogicalName}";
+
+    /// <summary>Root of the temporary workspace.</summary>
+    public string TempDir { get; private set; } = null!;
+
+    /// <summary>
+    /// Path to the scaffolded solution project folder.
+    /// The Declarations subfolder within is passed as <c>--input</c> to <c>txc workspace solution convert</c>.
+    /// </summary>
+    public string SolutionDir { get; private set; } = null!;
+
+    /// <summary>Path to the Declarations folder inside the solution (input for convert command).</summary>
+    public string DeclarationsDir => Path.Combine(SolutionDir, "Declarations");
+
+    public async Task InitializeAsync()
+    {
+        TempDir = Path.Combine(Path.GetTempPath(), $"txc-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(TempDir);
+
+        // Create a .gitignore so EnsureGitIgnored has a file to update
+        await File.WriteAllTextAsync(Path.Combine(TempDir, ".gitignore"), "obj/\nbin/\n");
+
+        // Init .sln — required by the pp-solution AddProjectsToSln post-action
+        await RunDotnetAsync(["new", "sln", "--name", "TestWorkspace"], TempDir);
+
+        var srcDir = Path.Combine(TempDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        // Scaffold Power Platform solution. Parent (srcDir) must exist; output must not exist yet.
+        SolutionDir = Path.Combine(srcDir, "TestSolution");
+        await CliRunner.RunAsync(
+            ["workspace", "component", "create", "pp-solution",
+             "--output", SolutionDir,
+             "--param", $"PublisherName={PublisherName}",
+             "--param", $"PublisherPrefix={PublisherPrefix}"]);
+
+        // Scaffold entity into the Declarations folder (scripts use ./Other/Solution.xml relative to it)
+        await CliRunner.RunAsync(
+            ["workspace", "component", "create", "pp-entity",
+             "--output", DeclarationsDir,
+             "--name", EntityLogicalName,
+             "--param", $"LogicalName={EntityLogicalName}",
+             "--param", $"LogicalNamePlural={EntityLogicalName}s",
+             "--param", "DisplayName=Test Entity",
+             "--param", "DisplayNamePlural=Test Entities",
+             "--param", $"PublisherPrefix={PublisherPrefix}",
+             "--param", "Behavior=New",
+             "--param", "SolutionRootPath=."]);
+
+        // Add a WholeNumber attribute
+        await AddAttributeAsync("count", "Count", "WholeNumber");
+
+        // Add another WholeNumber attribute
+        await AddAttributeAsync("quantity", "Quantity", "WholeNumber");
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(TempDir))
+            Directory.Delete(TempDir, recursive: true);
+        return Task.CompletedTask;
+    }
+
+    private Task AddAttributeAsync(string logicalName, string displayName, string attributeType, string? referencedEntityName = null)
+    {
+        var args = new List<string>
+        {
+            "workspace", "component", "create", "pp-entity-attribute",
+            "--output", DeclarationsDir,
+            "--name", logicalName,
+            "--param", $"EntitySchemaName={EntitySchemaName}",
+            "--param", $"LogicalName={logicalName}",
+            "--param", $"DisplayName={displayName}",
+            "--param", $"AttributeType={attributeType}",
+            "--param", $"PublisherPrefix={PublisherPrefix}",
+            "--param", "SolutionRootPath=."
+        };
+
+        if (referencedEntityName != null)
+        {
+            args.Add("--param");
+            args.Add($"ReferencedEntityName={referencedEntityName}");
+        }
+
+        return CliRunner.RunAsync([.. args]);
+    }
+
+    private static async Task RunDotnetAsync(string[] args, string workingDirectory)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
+
+        using var process = Process.Start(psi)!;
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException($"dotnet {string.Join(' ', args)} failed in {workingDirectory}");
+    }
+}


### PR DESCRIPTION
Closes #5

## Summary
Restructures and improves the contributor's DataVisualizer PR:

- **Renamed** `DataVisualizer` → `DataModelConverter`, merged into `TALXIS.CLI.Data` project
- **New command**: `txc data model convert --input <path> --target <dbml|sql|edmx|ribbon> --output <dir>`
- **Smart input resolution**: project folder (.csproj/.cdsproj + SolutionRootPath), declarations folder, or .zip file
- **Bug fixes** in contributor's code: Relationships dir guard, null TableRow for unknown types, optionset lookup by name
- **DBML fix**: column types now reference enum names so dbdiagram.io links them visually
- **MCP SDK v1.x** compatibility fix (IMcpClient removed)
- **Integration tests**: TempWorkspaceFixture + 8 DataModelConvertTests (18/18 pass)