### PR TITLE
fix(tests): align integration harness with CI configuration

### DIFF
--- a/tests/TALXIS.CLI.IntegrationTests/CliRunner.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/CliRunner.cs
@@ -15,7 +15,7 @@ public record CliResult(int ExitCode, string Output, string Error);
 /// </summary>
 public static class CliRunner
 {
-    private static readonly string CliProject = GetCliProjectPath();
+    private static readonly string CliProject = TestExecutionContext.GetProjectPath("src", "TALXIS.CLI", "TALXIS.CLI.csproj");
 
     /// <summary>
     /// Runs a CLI command, splitting the command string by spaces.
@@ -59,24 +59,7 @@ public static class CliRunner
     /// </summary>
     public static async Task<CliResult> RunRawAsync(string[] args, string? workingDirectory = null)
     {
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
-        };
-
-        psi.ArgumentList.Add("run");
-        psi.ArgumentList.Add("--project");
-        psi.ArgumentList.Add(CliProject);
-        psi.ArgumentList.Add("--no-build");
-        psi.ArgumentList.Add("--");
-
-        foreach (var arg in args)
-            psi.ArgumentList.Add(arg);
-
+        var psi = CreateProcessStartInfo(args, workingDirectory);
         using var process = Process.Start(psi)!;
 
         // Read stdout and stderr concurrently to avoid deadlocks when
@@ -92,17 +75,28 @@ public static class CliRunner
         return new CliResult(process.ExitCode, output, error);
     }
 
-    private static string GetCliProjectPath()
+    internal static ProcessStartInfo CreateProcessStartInfo(string[] args, string? workingDirectory = null)
     {
-        var baseDir = AppContext.BaseDirectory;
-        var dir = new DirectoryInfo(baseDir);
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory ?? Directory.GetCurrentDirectory()
+        };
 
-        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
-            dir = dir.Parent;
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add("--project");
+        psi.ArgumentList.Add(CliProject);
+        psi.ArgumentList.Add("--configuration");
+        psi.ArgumentList.Add(TestExecutionContext.BuildConfiguration);
+        psi.ArgumentList.Add("--no-build");
+        psi.ArgumentList.Add("--");
 
-        if (dir == null)
-            throw new InvalidOperationException("Could not find repository root");
+        foreach (var arg in args)
+            psi.ArgumentList.Add(arg);
 
-        return Path.Combine(dir.FullName, "src", "TALXIS.CLI", "TALXIS.CLI.csproj");
+        return psi;
     }
 }

--- a/tests/TALXIS.CLI.IntegrationTests/HarnessConfigurationTests.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/HarnessConfigurationTests.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace TALXIS.CLI.IntegrationTests;
+
+[Collection("Sequential")]
+public class HarnessConfigurationTests
+{
+    [Fact]
+    public void CliRunner_UsesCurrentTestBuildConfiguration()
+    {
+        var psi = CliRunner.CreateProcessStartInfo(new[] { "--help" });
+        var arguments = psi.ArgumentList.ToList();
+        var configurationFlagIndex = arguments.IndexOf("--configuration");
+
+        Assert.True(configurationFlagIndex >= 0);
+        Assert.Equal(TestExecutionContext.BuildConfiguration, arguments[configurationFlagIndex + 1]);
+        Assert.Contains("--no-build", arguments);
+    }
+
+    [Fact]
+    public void McpTestClient_UsesCurrentTestBuildConfiguration()
+    {
+        var arguments = McpTestClient.GetCommandArguments("dummy.csproj");
+        var configurationFlagIndex = Array.IndexOf(arguments, "--configuration");
+
+        Assert.True(configurationFlagIndex >= 0);
+        Assert.Equal(TestExecutionContext.BuildConfiguration, arguments[configurationFlagIndex + 1]);
+        Assert.Contains("--no-build", arguments);
+    }
+}

--- a/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;

--- a/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/McpTestClient.cs
@@ -26,13 +26,13 @@ public sealed class McpTestClient : IAsyncDisposable
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
 
-        var mcpProjectPath = GetMcpProjectPath();
+        var mcpProjectPath = TestExecutionContext.GetProjectPath("src", "TALXIS.CLI.MCP", "TALXIS.CLI.MCP.csproj");
 
         var transport = new StdioClientTransport(new StdioClientTransportOptions
         {
             Name = "TALXIS CLI MCP Test Client",
             Command = "dotnet",
-            Arguments = ["run", "--project", mcpProjectPath, "--no-build"]
+            Arguments = GetCommandArguments(mcpProjectPath)
         });
 
         var client = await McpClient.CreateAsync(transport, cancellationToken: cts.Token);
@@ -55,17 +55,14 @@ public sealed class McpTestClient : IAsyncDisposable
         await _client.DisposeAsync();
     }
 
-    private static string GetMcpProjectPath()
+    internal static string[] GetCommandArguments(string projectPath)
     {
-        var baseDir = AppContext.BaseDirectory;
-        var dir = new DirectoryInfo(baseDir);
-
-        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "TALXIS.CLI.sln")))
-            dir = dir.Parent;
-
-        if (dir == null)
-            throw new InvalidOperationException("Could not find repository root");
-
-        return Path.Combine(dir.FullName, "src", "TALXIS.CLI.MCP", "TALXIS.CLI.MCP.csproj");
+        return
+        [
+            "run",
+            "--project", projectPath,
+            "--configuration", TestExecutionContext.BuildConfiguration,
+            "--no-build"
+        ];
     }
 }

--- a/tests/TALXIS.CLI.IntegrationTests/TestExecutionContext.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/TestExecutionContext.cs
@@ -1,0 +1,52 @@
+using System;
+using System.IO;
+
+namespace TALXIS.CLI.IntegrationTests;
+
+internal static class TestExecutionContext
+{
+    private static readonly Lazy<string> _buildConfiguration = new(ResolveBuildConfiguration);
+    private static readonly Lazy<string> _repositoryRoot = new(ResolveRepositoryRoot);
+
+    public static string BuildConfiguration => _buildConfiguration.Value;
+
+    public static string RepositoryRoot => _repositoryRoot.Value;
+
+    public static string GetProjectPath(params string[] relativePathSegments)
+    {
+        var path = RepositoryRoot;
+
+        foreach (var segment in relativePathSegments)
+            path = Path.Combine(path, segment);
+
+        return path;
+    }
+
+    private static string ResolveBuildConfiguration()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            if (string.Equals(directory.Parent?.Name, "bin", StringComparison.OrdinalIgnoreCase))
+                return directory.Name;
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not determine test build configuration from AppContext.BaseDirectory");
+    }
+
+    private static string ResolveRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "TALXIS.CLI.sln")))
+            directory = directory.Parent;
+
+        if (directory == null)
+            throw new InvalidOperationException("Could not find repository root");
+
+        return directory.FullName;
+    }
+}


### PR DESCRIPTION
## Summary
- align integration subprocess helpers with the active test build configuration
- share test execution context so CLI and MCP helpers resolve repo root and configuration consistently
- add focused regression coverage for the harness argument wiring

## Why
The publish workflow builds and tests in Release with --no-build. The integration harness was still spawning dotnet run without an explicit configuration, which defaulted to Debug and caused the post-merge publish run for PR #10 to fail before package publishing.

## Verification
- dotnet restore TALXIS.CLI.sln
- dotnet build TALXIS.CLI.sln --configuration Release --no-restore
- dotnet test TALXIS.CLI.sln --configuration Release --no-build --logger 'trx;LogFileName=test_results.trx'
- dotnet pack src/TALXIS.CLI/TALXIS.CLI.csproj --configuration Release --no-build
- dotnet pack src/TALXIS.CLI.MCP/TALXIS.CLI.MCP.csproj --configuration Release --no-build

## Package version check
PR #10 already bumped the shared package version and the packed artifacts resolve to 1.3.0, so once this PR is merged the publish workflow should push a new package version instead of only hitting skip-duplicate.