### PR TITLE
fix: ConnectedOrgVersion returns 9.0.0.0 with token-provider auth

### DIFF
--- a/src/TALXIS.CLI.Platform.Xrm/PackageDeployerRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/PackageDeployerRunner.cs
@@ -123,10 +123,13 @@ public sealed class PackageDeployerRunner
                         _temporaryArtifactsDirectory);
                 }
 
+                // Always log the organization version — this also pre-warms
+                // the ConnectedOrgVersion cache before Package Deployer reads
+                // it during solution validation.
+                _logger.LogInformation("Organization version: {Version}", crmServiceClient.ConnectedOrgVersion);
                 if (_request.Verbose)
                 {
                     _logger.LogInformation("Connected to: {Url}", crmServiceClient.ConnectedOrgUriActual);
-                    _logger.LogInformation("Organization version: {Version}", crmServiceClient.ConnectedOrgVersion);
                     _logger.LogInformation("Organization ID: {OrgId}", crmServiceClient.ConnectedOrgId);
                 }
 

--- a/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
+++ b/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
@@ -154,9 +154,17 @@ public class CrmServiceClient : ServiceClient, IDisposable
 
     /// <summary>
     /// Hides the base <see cref="ServiceClient.ConnectedOrgVersion"/> which
-    /// can return 9.0.0.0 when the token-provider constructor path is used.
-    /// This version queries the server via RetrieveVersion if the base
-    /// property returns a stale/default value.
+    /// returns the hardcoded default <c>9.0.0.0</c> when the token-provider
+    /// constructor path is used (the SDK comments out
+    /// <c>GetServerVersion</c>/<c>RefreshInstanceDetails</c> for
+    /// <c>ExternalTokenManagement</c> auth).
+    /// <para>
+    /// This override issues a <c>RetrieveVersion</c> request to obtain the
+    /// real version from the response body. If that fails, it falls back to
+    /// accessing <see cref="ServiceClient.OrganizationDetail"/> which triggers
+    /// the SDK's lazy <c>RefreshInstanceDetails</c> call — that updates the
+    /// internal <c>OrganizationVersion</c> as a side-effect.
+    /// </para>
     /// </summary>
     public new Version ConnectedOrgVersion
     {
@@ -172,7 +180,9 @@ public class CrmServiceClient : ServiceClient, IDisposable
                 return baseVersion;
             }
 
-            // Base returned 9.0.0.0 or lower — query the actual version.
+            // Base returned 9.0.0.0 or lower — the SDK hardcodes this
+            // default in the ExternalTokenManagement path and never queries
+            // the server. Issue an explicit RetrieveVersion request.
             try
             {
                 var response = Execute(new OrganizationRequest("RetrieveVersion"));
@@ -186,7 +196,28 @@ public class CrmServiceClient : ServiceClient, IDisposable
             }
             catch
             {
-                // Fall through to base version on failure.
+                // RetrieveVersion failed — fall through to the lazy-loading
+                // fallback below.
+            }
+
+            // RetrieveVersion did not yield a usable version. Trigger the
+            // SDK's own lazy-loading mechanism: accessing OrganizationDetail
+            // causes ConnectionService.RefreshInstanceDetails to run, which
+            // calls RetrieveCurrentOrganization and updates the internal
+            // OrganizationVersion field.
+            try
+            {
+                _ = OrganizationDetail;
+                var refreshedVersion = base.ConnectedOrgVersion;
+                if (refreshedVersion > new Version(9, 0, 0, 0))
+                {
+                    _cachedOrgVersion = refreshedVersion;
+                    return refreshedVersion;
+                }
+            }
+            catch
+            {
+                // OrganizationDetail may throw if the service is unreachable.
             }
 
             _cachedOrgVersion = baseVersion;

--- a/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
+++ b/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
@@ -159,11 +159,11 @@ public class CrmServiceClient : ServiceClient, IDisposable
     /// <c>GetServerVersion</c>/<c>RefreshInstanceDetails</c> for
     /// <c>ExternalTokenManagement</c> auth).
     /// <para>
-    /// This override issues a <c>RetrieveVersion</c> request to obtain the
-    /// real version from the response body. If that fails, it falls back to
-    /// accessing <see cref="ServiceClient.OrganizationDetail"/> which triggers
-    /// the SDK's lazy <c>RefreshInstanceDetails</c> call — that updates the
-    /// internal <c>OrganizationVersion</c> as a side-effect.
+    /// This hidden property issues a <c>RetrieveVersion</c> request to obtain
+    /// the real version from the response body. If that fails, it falls back
+    /// to accessing <see cref="ServiceClient.OrganizationDetail"/> which
+    /// triggers the SDK's lazy <c>RefreshInstanceDetails</c> call — that
+    /// updates the internal <c>OrganizationVersion</c> as a side-effect.
     /// </para>
     /// </summary>
     public new Version ConnectedOrgVersion


### PR DESCRIPTION
Supersedes #13 with a corrected approach.

## Problem

The Dataverse `ServiceClient` hardcodes `OrganizationVersion = 9.0.0.0` in the `ExternalTokenManagement` (token-provider) constructor path — `GetServerVersion` and `RefreshInstanceDetails` are [commented out in the SDK source](https://github.com/microsoft/PowerPlatform-DataverseServiceClient/blob/master/src/GeneralTools/DataverseClient/Client/ConnectionService.cs#L1556-L1558). This causes Package Deployer to reject solutions requiring CDS ≥ 9.1 because it reads `CrmSvc.ConnectedOrgVersion` during solution validation and sees the default `9.0.0.0`.

## Why PR #13's approach is incorrect

PR #13 adds a post-warm re-read of `base.ConnectedOrgVersion` after the `Execute(RetrieveVersion)` call, claiming that `Execute` populates `OrganizationVersion` as a side-effect. **This is wrong** — the SDK source shows that `Execute` does not update `_connectionSvc.OrganizationVersion`; it stays hardcoded at `9.0.0.0` regardless of Execute calls.

## Correct fix

The existing shim's `Execute(RetrieveVersion)` fallback works in the common case (it gets the version from the response body). But if that call fails, there was no recovery path.

This PR adds a **second fallback** that accesses `ServiceClient.OrganizationDetail`, which triggers the SDK's lazy `ConnectedOrganizationDetail` getter → `RefreshInstanceDetails()` → `RetrieveCurrentOrganization` → updates `OrganizationVersion`. Then `base.ConnectedOrgVersion` returns the real version.

Also moves the org-version log line outside the `if (Verbose)` guard in `PackageDeployerRunner` for better diagnostics.

Closes #13