### PR TITLE
feat: Add Dataverse data operations under txc environment

### DIFF
--- a/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseBulkService.cs
+++ b/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseBulkService.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+
+namespace TALXIS.CLI.Core.Contracts.Dataverse;
+
+/// <summary>
+/// Result of a bulk operation — per-record outcomes.
+/// </summary>
+public sealed record BulkOperationResult(
+    int SucceededCount,
+    int FailedCount,
+    IReadOnlyList<Guid> CreatedIds);
+
+/// <summary>
+/// Bulk operations against a live Dataverse environment using
+/// <c>CreateMultiple</c>, <c>UpdateMultiple</c>, and <c>UpsertMultiple</c>
+/// SDK messages via <c>ServiceClient.Execute()</c>.
+/// </summary>
+public interface IDataverseBulkService
+{
+    /// <summary>
+    /// Creates multiple records of the same entity type in a single request
+    /// using the <c>CreateMultipleRequest</c> SDK message.
+    /// </summary>
+    Task<BulkOperationResult> CreateMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Updates multiple records of the same entity type in a single request
+    /// using the <c>UpdateMultipleRequest</c> SDK message.
+    /// </summary>
+    Task<BulkOperationResult> UpdateMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Upserts (creates or updates) multiple records of the same entity type
+    /// in a single request using the <c>UpsertMultipleRequest</c> SDK message.
+    /// </summary>
+    Task<BulkOperationResult> UpsertMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseEntityMetadataService.cs
+++ b/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseEntityMetadataService.cs
@@ -1,0 +1,54 @@
+namespace TALXIS.CLI.Core.Contracts.Dataverse;
+
+/// <summary>
+/// Summary row for an entity in the environment, returned by
+/// <see cref="IDataverseEntityMetadataService.ListEntitiesAsync"/>.
+/// </summary>
+public sealed record EntitySummaryRecord(
+    string LogicalName,
+    string? SchemaName,
+    string? DisplayName,
+    string? EntitySetName,
+    bool IsCustomEntity);
+
+/// <summary>
+/// Column/attribute metadata for a single entity, returned by
+/// <see cref="IDataverseEntityMetadataService.DescribeEntityAsync"/>.
+/// </summary>
+public sealed record EntityAttributeRecord(
+    string LogicalName,
+    string? SchemaName,
+    string? DisplayName,
+    string AttributeTypeName,
+    bool IsCustomAttribute,
+    bool IsPrimaryId,
+    bool IsPrimaryName,
+    int? MaxLength,
+    string? Description);
+
+/// <summary>
+/// Schema/metadata introspection for Dataverse entities. All calls go
+/// through <c>ServiceClient</c> using the metadata API
+/// (<c>RetrieveAllEntitiesRequest</c> / <c>RetrieveEntityRequest</c>).
+/// </summary>
+public interface IDataverseEntityMetadataService
+{
+    /// <summary>
+    /// Lists all entities in the environment, optionally filtering by
+    /// a search term (matched against logical name, schema name, or display name).
+    /// </summary>
+    Task<IReadOnlyList<EntitySummaryRecord>> ListEntitiesAsync(
+        string? profileName,
+        string? search,
+        bool includeSystem,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Describes columns/attributes for a specific entity.
+    /// </summary>
+    Task<IReadOnlyList<EntityAttributeRecord>> DescribeEntityAsync(
+        string? profileName,
+        string entityLogicalName,
+        bool includeSystem,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseQueryService.cs
+++ b/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseQueryService.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace TALXIS.CLI.Core.Contracts.Dataverse;
+
+/// <summary>
+/// Result of a Dataverse query — a list of records as JSON elements plus
+/// optional total count. Returned by all query methods on
+/// <see cref="IDataverseQueryService"/>.
+/// </summary>
+public sealed record DataverseQueryResult(
+    IReadOnlyList<JsonElement> Records,
+    int? TotalCount);
+
+/// <summary>
+/// Executes read-only queries against a live Dataverse environment.
+/// Supports SQL (Web API <c>?sql=</c>), FetchXML, and OData query modes.
+/// All calls go through <c>ServiceClient</c>.
+/// </summary>
+public interface IDataverseQueryService
+{
+    /// <summary>
+    /// Runs a T-SQL subset query via the Dataverse Web API <c>?sql=</c>
+    /// parameter. Automatically paginates and strips OData annotations
+    /// unless <paramref name="includeAnnotations"/> is <c>true</c>.
+    /// </summary>
+    Task<DataverseQueryResult> QuerySqlAsync(
+        string? profileName,
+        string sql,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Runs a FetchXML query via <c>RetrieveMultiple</c>. Automatically
+    /// paginates using paging cookies.
+    /// </summary>
+    Task<DataverseQueryResult> QueryFetchXmlAsync(
+        string? profileName,
+        string fetchXml,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Runs an OData query via <c>ServiceClient.ExecuteWebRequest</c>.
+    /// Automatically follows <c>@odata.nextLink</c> for pagination.
+    /// </summary>
+    Task<DataverseQueryResult> QueryODataAsync(
+        string? profileName,
+        string entitySetOrPath,
+        string? select,
+        string? filter,
+        string? orderBy,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseRecordService.cs
+++ b/src/TALXIS.CLI.Core/Contracts/Dataverse/IDataverseRecordService.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+
+namespace TALXIS.CLI.Core.Contracts.Dataverse;
+
+/// <summary>
+/// Single-record CRUD operations against a live Dataverse environment.
+/// All calls go through <c>ServiceClient</c>.
+/// </summary>
+public interface IDataverseRecordService
+{
+    /// <summary>
+    /// Retrieves a single record by entity logical name and ID.
+    /// Returns the record as a JSON object.
+    /// </summary>
+    Task<JsonElement> GetAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        string[]? columns,
+        bool includeAnnotations,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Creates a new record from a JSON object.
+    /// Returns the ID of the created record.
+    /// </summary>
+    Task<Guid> CreateAsync(
+        string? profileName,
+        string entityLogicalName,
+        JsonElement attributes,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Updates an existing record with the given attribute values.
+    /// </summary>
+    Task UpdateAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        JsonElement attributes,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Deletes a record by entity logical name and ID.
+    /// </summary>
+    Task DeleteAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/BulkInputHelper.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/BulkInputHelper.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Shared input-parsing logic used by all three bulk CLI commands.
+/// Validates that exactly one of <c>--file</c> / <c>--data</c> is supplied
+/// and deserializes the JSON array into a list of <see cref="JsonElement"/>.
+/// </summary>
+internal static class BulkInputHelper
+{
+    public static bool TryParseRecords(
+        string? filePath,
+        string? inlineData,
+        ILogger logger,
+        [NotNullWhen(true)] out List<JsonElement>? records)
+    {
+        records = null;
+
+        // Validate mutually-exclusive input sources.
+        if (string.IsNullOrWhiteSpace(filePath) && string.IsNullOrWhiteSpace(inlineData))
+        {
+            logger.LogError("Provide either --file or --data with a JSON array of records.");
+            return false;
+        }
+        if (!string.IsNullOrWhiteSpace(filePath) && !string.IsNullOrWhiteSpace(inlineData))
+        {
+            logger.LogError("Provide only one of --file or --data, not both.");
+            return false;
+        }
+
+        string json;
+        if (!string.IsNullOrWhiteSpace(filePath))
+        {
+            if (!File.Exists(filePath))
+            {
+                logger.LogError("File not found: {Path}", filePath);
+                return false;
+            }
+            json = File.ReadAllText(filePath);
+        }
+        else
+        {
+            json = inlineData!;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            {
+                logger.LogError("Expected a JSON array of records.");
+                return false;
+            }
+
+            records = new List<JsonElement>();
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                // Clone so the elements survive the JsonDocument disposal.
+                records.Add(element.Clone());
+            }
+
+            if (records.Count == 0)
+            {
+                logger.LogError("The JSON array is empty — nothing to process.");
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError("Invalid JSON: {Error}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/BulkOutputHelper.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/BulkOutputHelper.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Shared output-formatting logic for all three bulk CLI commands.
+/// </summary>
+internal static class BulkOutputHelper
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    public static void WriteResult(string operationName, BulkOperationResult result, bool asJson)
+    {
+        if (asJson)
+        {
+            var payload = new
+            {
+                operation = operationName,
+                succeeded = result.SucceededCount,
+                failed = result.FailedCount,
+                createdIds = result.CreatedIds.Select(id => id.ToString()).ToList()
+            };
+            OutputWriter.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+            return;
+        }
+
+        OutputWriter.WriteLine($"{operationName}: {result.SucceededCount} succeeded, {result.FailedCount} failed.");
+        if (result.CreatedIds.Count > 0)
+        {
+            OutputWriter.WriteLine("Created IDs:");
+            foreach (var id in result.CreatedIds)
+            {
+                OutputWriter.WriteLine($"  {id}");
+            }
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCliCommand.cs
@@ -1,0 +1,20 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Parent command for bulk operations (CreateMultiple, UpdateMultiple,
+/// UpsertMultiple) against a live Dataverse environment.
+/// </summary>
+[CliCommand(
+    Name = "bulk",
+    Description = "Bulk operations (CreateMultiple, UpdateMultiple, UpsertMultiple) against the environment.",
+    Children = new[] { typeof(EnvDataBulkCreateCliCommand), typeof(EnvDataBulkUpdateCliCommand), typeof(EnvDataBulkUpsertCliCommand) }
+)]
+public class EnvDataBulkCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCreateCliCommand.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Creates multiple records of the same entity type in a single request
+/// using the Dataverse <c>CreateMultiple</c> SDK message.
+/// </summary>
+[CliCommand(
+    Name = "create",
+    Description = "Create multiple records in a single CreateMultiple request."
+)]
+public class EnvDataBulkCreateCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataBulkCreateCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
+    public string? File { get; set; }
+
+    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    public string? Data { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as JSON.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        if (!BulkInputHelper.TryParseRecords(File, Data, _logger, out var records))
+            return 1;
+
+        BulkOperationResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseBulkService>();
+            result = await service.CreateMultipleAsync(Profile, Entity, records, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException or FileNotFoundException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "bulk create failed");
+            return 1;
+        }
+
+        BulkOutputHelper.WriteResult("CreateMultiple", result, Json);
+        return 0;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpdateCliCommand.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Updates multiple records of the same entity type in a single request
+/// using the Dataverse <c>UpdateMultiple</c> SDK message.
+/// </summary>
+[CliCommand(
+    Name = "update",
+    Description = "Update multiple records in a single UpdateMultiple request."
+)]
+public class EnvDataBulkUpdateCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataBulkUpdateCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
+    public string? File { get; set; }
+
+    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    public string? Data { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as JSON.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        if (!BulkInputHelper.TryParseRecords(File, Data, _logger, out var records))
+            return 1;
+
+        BulkOperationResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseBulkService>();
+            result = await service.UpdateMultipleAsync(Profile, Entity, records, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException or FileNotFoundException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "bulk update failed");
+            return 1;
+        }
+
+        BulkOutputHelper.WriteResult("UpdateMultiple", result, Json);
+        return 0;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpsertCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpsertCliCommand.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Bulk;
+
+/// <summary>
+/// Upserts (creates or updates) multiple records of the same entity type in
+/// a single request using the Dataverse <c>UpsertMultiple</c> SDK message.
+/// </summary>
+[CliCommand(
+    Name = "upsert",
+    Description = "Upsert multiple records in a single UpsertMultiple request."
+)]
+public class EnvDataBulkUpsertCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataBulkUpsertCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
+    public string? File { get; set; }
+
+    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    public string? Data { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as JSON.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        if (!BulkInputHelper.TryParseRecords(File, Data, _logger, out var records))
+            return 1;
+
+        BulkOperationResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseBulkService>();
+            result = await service.UpsertMultipleAsync(Profile, Entity, records, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException or FileNotFoundException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "bulk upsert failed");
+            return 1;
+        }
+
+        BulkOutputHelper.WriteResult("UpsertMultiple", result, Json);
+        return 0;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
@@ -1,0 +1,20 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Data;
+
+/// <summary>
+/// Parent command that groups all data operations against a live Dataverse
+/// environment — queries, single-record CRUD, and bulk operations.
+/// </summary>
+[CliCommand(
+    Name = "data",
+    Description = "Data operations against the live environment (query, record CRUD, bulk operations).",
+    Children = new[] { typeof(Query.EnvDataQueryCliCommand), typeof(Record.EnvDataRecordCliCommand), typeof(Bulk.EnvDataBulkCliCommand) }
+)]
+public class EnvDataCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryCliCommand.cs
@@ -1,0 +1,19 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Data.Query;
+
+/// <summary>
+/// Parent command for all query sub-commands (SQL, FetchXML, OData).
+/// </summary>
+[CliCommand(
+    Name = "query",
+    Description = "Execute data queries against the environment.",
+    Children = new[] { typeof(EnvDataQuerySqlCliCommand), typeof(EnvDataQueryFetchXmlCliCommand), typeof(EnvDataQueryODataCliCommand) }
+)]
+public class EnvDataQueryCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryFetchXmlCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryFetchXmlCliCommand.cs
@@ -1,0 +1,95 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Query;
+
+/// <summary>
+/// Executes a FetchXML query against the Dataverse environment via
+/// <c>RetrieveMultiple</c>. The FetchXML can be passed inline or read
+/// from a file with <c>--file</c>.
+/// </summary>
+/// <example>
+///   txc environment data query fetchxml "&lt;fetch&gt;&lt;entity name='account'&gt;&lt;attribute name='name'/&gt;&lt;/entity&gt;&lt;/fetch&gt;"
+///   txc env data query fetchxml --file ./query.xml --json
+/// </example>
+[CliCommand(
+    Name = "fetchxml",
+    Description = "Execute a FetchXML query against the Dataverse environment."
+)]
+public class EnvDataQueryFetchXmlCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataQueryFetchXmlCliCommand));
+
+    [CliArgument(Description = "The FetchXML query string (omit if using --file).", Required = false)]
+    public string? FetchXml { get; set; }
+
+    [CliOption(Name = "--file", Description = "Path to a file containing the FetchXML query.", Required = false)]
+    public string? File { get; set; }
+
+    [CliOption(Name = "--top", Description = "Maximum number of records to return.", Required = false)]
+    public int? Top { get; set; }
+
+    [CliOption(Name = "--include-annotations", Description = "Include OData annotations / formatted values in the output.", Required = false)]
+    public bool IncludeAnnotations { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        var fetchXml = ResolveFetchXml();
+        if (fetchXml is null)
+        {
+            _logger.LogError("Provide a FetchXML string as an argument or use --file to specify a file.");
+            return 1;
+        }
+
+        DataverseQueryResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseQueryService>();
+            result = await service.QueryFetchXmlAsync(Profile, fetchXml, Top, IncludeAnnotations, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment data query fetchxml failed");
+            return 1;
+        }
+
+        EnvDataQuerySqlCliCommand.OutputQueryResult(result, Json);
+        return 0;
+    }
+
+    /// <summary>
+    /// Resolves the FetchXML from either the inline argument or the --file
+    /// option. Returns <c>null</c> when neither is provided.
+    /// </summary>
+    private string? ResolveFetchXml()
+    {
+        if (!string.IsNullOrWhiteSpace(FetchXml))
+            return FetchXml;
+
+        if (!string.IsNullOrWhiteSpace(File))
+        {
+            if (!System.IO.File.Exists(File))
+            {
+                _logger.LogError("FetchXML file not found: {Path}", File);
+                return null;
+            }
+            return System.IO.File.ReadAllText(File);
+        }
+
+        return null;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryODataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryODataCliCommand.cs
@@ -1,0 +1,72 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Query;
+
+/// <summary>
+/// Executes an OData query against the Dataverse environment via
+/// <c>ServiceClient.ExecuteWebRequest</c>.
+/// </summary>
+/// <example>
+///   txc environment data query odata accounts --select "name,accountnumber" --filter "statecode eq 0" --top 10
+///   txc env data query odata contacts --select "fullname,emailaddress1" --json
+/// </example>
+[CliCommand(
+    Name = "odata",
+    Description = "Execute an OData query against the Dataverse environment."
+)]
+public class EnvDataQueryODataCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataQueryODataCliCommand));
+
+    [CliArgument(Description = "The entity set name or OData path to query.")]
+    public string Entity { get; set; } = string.Empty;
+
+    [CliOption(Name = "--select", Description = "Comma-separated list of columns to return ($select).", Required = false)]
+    public string? Select { get; set; }
+
+    [CliOption(Name = "--filter", Description = "OData $filter expression.", Required = false)]
+    public string? Filter { get; set; }
+
+    [CliOption(Name = "--order-by", Description = "OData $orderby expression.", Required = false)]
+    public string? OrderBy { get; set; }
+
+    [CliOption(Name = "--top", Description = "Maximum number of records to return ($top).", Required = false)]
+    public int? Top { get; set; }
+
+    [CliOption(Name = "--include-annotations", Description = "Include OData annotations in the output.", Required = false)]
+    public bool IncludeAnnotations { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        DataverseQueryResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseQueryService>();
+            result = await service.QueryODataAsync(
+                    Profile, Entity, Select, Filter, OrderBy, Top, IncludeAnnotations, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment data query odata failed");
+            return 1;
+        }
+
+        EnvDataQuerySqlCliCommand.OutputQueryResult(result, Json);
+        return 0;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQuerySqlCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQuerySqlCliCommand.cs
@@ -1,0 +1,161 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Query;
+
+/// <summary>
+/// Executes a T-SQL subset query against the Dataverse environment via
+/// the Web API <c>?sql=</c> parameter.
+/// </summary>
+/// <example>
+///   txc environment data query sql "SELECT name, accountnumber FROM account WHERE statecode = 0"
+///   txc env data query sql "SELECT TOP 10 fullname FROM contact" --json
+/// </example>
+[CliCommand(
+    Name = "sql",
+    Description = "Execute a SQL query against the Dataverse environment."
+)]
+public class EnvDataQuerySqlCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataQuerySqlCliCommand));
+
+    [CliArgument(Description = "The SQL query to execute (SELECT only).")]
+    public string Sql { get; set; } = string.Empty;
+
+    [CliOption(Name = "--top", Description = "Maximum number of records to return.", Required = false)]
+    public int? Top { get; set; }
+
+    [CliOption(Name = "--include-annotations", Description = "Include OData annotations in the output.", Required = false)]
+    public bool IncludeAnnotations { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the result as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        DataverseQueryResult result;
+        try
+        {
+            var service = TxcServices.Get<IDataverseQueryService>();
+            result = await service.QuerySqlAsync(Profile, Sql, Top, IncludeAnnotations, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment data query sql failed");
+            return 1;
+        }
+
+        OutputQueryResult(result, Json);
+        return 0;
+    }
+
+    /// <summary>
+    /// Outputs query results as JSON or as a dynamic text table.
+    /// Shared across all query leaf commands.
+    /// </summary>
+    internal static void OutputQueryResult(DataverseQueryResult result, bool json)
+    {
+        if (json)
+        {
+            OutputWriter.WriteLine(JsonSerializer.Serialize(result.Records, JsonOptions));
+            return;
+        }
+
+        if (result.Records.Count == 0)
+        {
+            OutputWriter.WriteLine("No records returned.");
+            return;
+        }
+
+        PrintDynamicTable(result.Records);
+    }
+
+    /// <summary>
+    /// Builds a text table whose columns are derived from the keys of the
+    /// first record in the result set.
+    /// </summary>
+    private static void PrintDynamicTable(IReadOnlyList<JsonElement> records)
+    {
+        // Collect column names from the first record.
+        var columns = new List<string>();
+        if (records[0].ValueKind == JsonValueKind.Object)
+        {
+            foreach (var prop in records[0].EnumerateObject())
+                columns.Add(prop.Name);
+        }
+
+        if (columns.Count == 0)
+        {
+            // Fallback: just dump as JSON lines.
+            foreach (var rec in records)
+                OutputWriter.WriteLine(rec.ToString());
+            return;
+        }
+
+        // Compute column widths (header length vs. max value length, capped at 40).
+        var widths = new int[columns.Count];
+        for (int c = 0; c < columns.Count; c++)
+        {
+            widths[c] = columns[c].Length;
+            foreach (var rec in records)
+            {
+                var val = GetCellValue(rec, columns[c]);
+                if (val.Length > widths[c])
+                    widths[c] = val.Length;
+            }
+            widths[c] = Math.Clamp(widths[c], columns[c].Length, 40);
+        }
+
+        // Header row.
+        var header = string.Join(" | ", columns.Select((col, i) => col.PadRight(widths[i])));
+        OutputWriter.WriteLine(header);
+        OutputWriter.WriteLine(new string('-', header.Length));
+
+        // Data rows.
+        foreach (var rec in records)
+        {
+            var cells = columns.Select((col, i) =>
+            {
+                var val = GetCellValue(rec, col);
+                return val.Length > widths[i]
+                    ? val[..(widths[i] - 1)] + "."
+                    : val.PadRight(widths[i]);
+            });
+            OutputWriter.WriteLine(string.Join(" | ", cells));
+        }
+
+        OutputWriter.WriteLine($"({records.Count} record{(records.Count == 1 ? "" : "s")})");
+    }
+
+    private static string GetCellValue(JsonElement record, string column)
+    {
+        if (record.ValueKind != JsonValueKind.Object)
+            return string.Empty;
+        if (!record.TryGetProperty(column, out var prop))
+            return string.Empty;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.Null => "(null)",
+            JsonValueKind.String => prop.GetString() ?? string.Empty,
+            _ => prop.ToString(),
+        };
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCliCommand.cs
@@ -1,0 +1,20 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Parent command for single-record CRUD operations against a live
+/// Dataverse environment.
+/// </summary>
+[CliCommand(
+    Name = "record",
+    Description = "Single-record CRUD operations against the environment.",
+    Children = new[] { typeof(EnvDataRecordGetCliCommand), typeof(EnvDataRecordCreateCliCommand), typeof(EnvDataRecordUpdateCliCommand), typeof(EnvDataRecordDeleteCliCommand) }
+)]
+public class EnvDataRecordCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Creates a single record from inline JSON or a JSON file.
+/// </summary>
+[CliCommand(
+    Name = "create",
+    Description = "Create a single record from JSON attributes."
+)]
+public class EnvDataRecordCreateCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordCreateCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliOption(Name = "--data", Description = "Inline JSON object with record attributes.", Required = false)]
+    public string? Data { get; set; }
+
+    [CliOption(Name = "--file", Description = "Path to a JSON file containing record attributes.", Required = false)]
+    public string? File { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        if (!TryParseAttributes(out var attributes))
+            return 1;
+
+        Guid createdId;
+        try
+        {
+            var service = TxcServices.Get<IDataverseRecordService>();
+            createdId = await service.CreateAsync(Profile, Entity, attributes, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException or FileNotFoundException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "record create failed");
+            return 1;
+        }
+
+        OutputWriter.WriteLine(createdId.ToString());
+        return 0;
+    }
+
+    /// <summary>
+    /// Validates that exactly one of <c>--data</c> / <c>--file</c> is provided
+    /// and parses the JSON into a <see cref="JsonElement"/>.
+    /// </summary>
+    private bool TryParseAttributes(out JsonElement attributes)
+    {
+        attributes = default;
+
+        bool hasData = !string.IsNullOrWhiteSpace(Data);
+        bool hasFile = !string.IsNullOrWhiteSpace(File);
+
+        if (hasData == hasFile)
+        {
+            _logger.LogError("Provide exactly one of --data or --file.");
+            return false;
+        }
+
+        string json;
+        if (hasFile)
+        {
+            if (!System.IO.File.Exists(File))
+            {
+                _logger.LogError("File not found: {Path}", File);
+                return false;
+            }
+            json = System.IO.File.ReadAllText(File!);
+        }
+        else
+        {
+            json = Data!;
+        }
+
+        try
+        {
+            attributes = JsonDocument.Parse(json).RootElement;
+            if (attributes.ValueKind != JsonValueKind.Object)
+            {
+                _logger.LogError("Expected a JSON object, got {Kind}.", attributes.ValueKind);
+                return false;
+            }
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError("Invalid JSON: {Error}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
@@ -57,52 +57,6 @@ public class EnvDataRecordCreateCliCommand : ProfiledCliCommand
         return 0;
     }
 
-    /// <summary>
-    /// Validates that exactly one of <c>--data</c> / <c>--file</c> is provided
-    /// and parses the JSON into a <see cref="JsonElement"/>.
-    /// </summary>
     private bool TryParseAttributes(out JsonElement attributes)
-    {
-        attributes = default;
-
-        bool hasData = !string.IsNullOrWhiteSpace(Data);
-        bool hasFile = !string.IsNullOrWhiteSpace(File);
-
-        if (hasData == hasFile)
-        {
-            _logger.LogError("Provide exactly one of --data or --file.");
-            return false;
-        }
-
-        string json;
-        if (hasFile)
-        {
-            if (!System.IO.File.Exists(File))
-            {
-                _logger.LogError("File not found: {Path}", File);
-                return false;
-            }
-            json = System.IO.File.ReadAllText(File!);
-        }
-        else
-        {
-            json = Data!;
-        }
-
-        try
-        {
-            attributes = JsonDocument.Parse(json).RootElement;
-            if (attributes.ValueKind != JsonValueKind.Object)
-            {
-                _logger.LogError("Expected a JSON object, got {Kind}.", attributes.ValueKind);
-                return false;
-            }
-            return true;
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogError("Invalid JSON: {Error}", ex.Message);
-            return false;
-        }
-    }
+        => RecordInputHelper.TryParseAttributes(Data, File, _logger, out attributes);
 }

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
@@ -1,0 +1,51 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Deletes a single record by entity logical name and record ID.
+/// </summary>
+[CliCommand(
+    Name = "delete",
+    Description = "Delete a single record by ID."
+)]
+public class EnvDataRecordDeleteCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordDeleteCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliArgument(Description = "The GUID of the record to delete.")]
+    public Guid RecordId { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        try
+        {
+            var service = TxcServices.Get<IDataverseRecordService>();
+            await service.DeleteAsync(Profile, Entity, RecordId, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "record delete failed");
+            return 1;
+        }
+
+        OutputWriter.WriteLine("Record deleted successfully.");
+        return 0;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Retrieves a single record by entity logical name and record ID.
+/// </summary>
+[CliCommand(
+    Name = "get",
+    Description = "Retrieve a single record by ID."
+)]
+public class EnvDataRecordGetCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordGetCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliArgument(Description = "The GUID of the record to retrieve.")]
+    public Guid RecordId { get; set; }
+
+    [CliOption(Name = "--columns", Description = "Comma-separated column names to retrieve.", Required = false)]
+    public string? Columns { get; set; }
+
+    [CliOption(Name = "--include-annotations", Description = "Include formatted values / OData annotations.", Required = false)]
+    public bool IncludeAnnotations { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the record as indented JSON.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        JsonElement result;
+        try
+        {
+            var columns = string.IsNullOrWhiteSpace(Columns)
+                ? null
+                : Columns.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            var service = TxcServices.Get<IDataverseRecordService>();
+            result = await service.GetAsync(Profile, Entity, RecordId, columns, IncludeAnnotations, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "record get failed");
+            return 1;
+        }
+
+        if (Json)
+        {
+            OutputWriter.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            PrintKeyValuePairs(result);
+        }
+
+        return 0;
+    }
+
+    private static void PrintKeyValuePairs(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            OutputWriter.WriteLine(element.GetRawText());
+            return;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            OutputWriter.WriteLine($"{property.Name} = {FormatValue(property.Value)}");
+        }
+    }
+
+    private static string FormatValue(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.String => value.GetString() ?? "(null)",
+        JsonValueKind.Number => value.GetRawText(),
+        JsonValueKind.True => "true",
+        JsonValueKind.False => "false",
+        JsonValueKind.Null => "(null)",
+        _ => value.GetRawText(),
+    };
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Updates a single record identified by entity logical name and record ID.
+/// </summary>
+[CliCommand(
+    Name = "update",
+    Description = "Update a single record by ID from JSON attributes."
+)]
+public class EnvDataRecordUpdateCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordUpdateCliCommand));
+
+    [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
+    public string Entity { get; set; } = null!;
+
+    [CliArgument(Description = "The GUID of the record to update.")]
+    public Guid RecordId { get; set; }
+
+    [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update.", Required = false)]
+    public string? Data { get; set; }
+
+    [CliOption(Name = "--file", Description = "Path to a JSON file containing attributes to update.", Required = false)]
+    public string? File { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        if (!TryParseAttributes(out var attributes))
+            return 1;
+
+        try
+        {
+            var service = TxcServices.Get<IDataverseRecordService>();
+            await service.UpdateAsync(Profile, Entity, RecordId, attributes, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException or FileNotFoundException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "record update failed");
+            return 1;
+        }
+
+        OutputWriter.WriteLine("Record updated successfully.");
+        return 0;
+    }
+
+    /// <summary>
+    /// Validates that exactly one of <c>--data</c> / <c>--file</c> is provided
+    /// and parses the JSON into a <see cref="JsonElement"/>.
+    /// </summary>
+    private bool TryParseAttributes(out JsonElement attributes)
+    {
+        attributes = default;
+
+        bool hasData = !string.IsNullOrWhiteSpace(Data);
+        bool hasFile = !string.IsNullOrWhiteSpace(File);
+
+        if (hasData == hasFile)
+        {
+            _logger.LogError("Provide exactly one of --data or --file.");
+            return false;
+        }
+
+        string json;
+        if (hasFile)
+        {
+            if (!System.IO.File.Exists(File))
+            {
+                _logger.LogError("File not found: {Path}", File);
+                return false;
+            }
+            json = System.IO.File.ReadAllText(File!);
+        }
+        else
+        {
+            json = Data!;
+        }
+
+        try
+        {
+            attributes = JsonDocument.Parse(json).RootElement;
+            if (attributes.ValueKind != JsonValueKind.Object)
+            {
+                _logger.LogError("Expected a JSON object, got {Kind}.", attributes.ValueKind);
+                return false;
+            }
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError("Invalid JSON: {Error}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -59,52 +59,6 @@ public class EnvDataRecordUpdateCliCommand : ProfiledCliCommand
         return 0;
     }
 
-    /// <summary>
-    /// Validates that exactly one of <c>--data</c> / <c>--file</c> is provided
-    /// and parses the JSON into a <see cref="JsonElement"/>.
-    /// </summary>
     private bool TryParseAttributes(out JsonElement attributes)
-    {
-        attributes = default;
-
-        bool hasData = !string.IsNullOrWhiteSpace(Data);
-        bool hasFile = !string.IsNullOrWhiteSpace(File);
-
-        if (hasData == hasFile)
-        {
-            _logger.LogError("Provide exactly one of --data or --file.");
-            return false;
-        }
-
-        string json;
-        if (hasFile)
-        {
-            if (!System.IO.File.Exists(File))
-            {
-                _logger.LogError("File not found: {Path}", File);
-                return false;
-            }
-            json = System.IO.File.ReadAllText(File!);
-        }
-        else
-        {
-            json = Data!;
-        }
-
-        try
-        {
-            attributes = JsonDocument.Parse(json).RootElement;
-            if (attributes.ValueKind != JsonValueKind.Object)
-            {
-                _logger.LogError("Expected a JSON object, got {Kind}.", attributes.ValueKind);
-                return false;
-            }
-            return true;
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogError("Invalid JSON: {Error}", ex.Message);
-            return false;
-        }
-    }
+        => RecordInputHelper.TryParseAttributes(Data, File, _logger, out attributes);
 }

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/RecordInputHelper.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/RecordInputHelper.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Data.Record;
+
+/// <summary>
+/// Shared input parsing for record create/update commands.
+/// Validates <c>--data</c> / <c>--file</c> mutual exclusion and parses
+/// the JSON into a <see cref="JsonElement"/>.
+/// </summary>
+internal static class RecordInputHelper
+{
+    /// <summary>
+    /// Validates that exactly one of <paramref name="data"/> / <paramref name="file"/>
+    /// is provided and parses the JSON into a <see cref="JsonElement"/> object.
+    /// </summary>
+    public static bool TryParseAttributes(
+        string? data,
+        string? file,
+        ILogger logger,
+        out JsonElement attributes)
+    {
+        attributes = default;
+
+        bool hasData = !string.IsNullOrWhiteSpace(data);
+        bool hasFile = !string.IsNullOrWhiteSpace(file);
+
+        if (hasData == hasFile)
+        {
+            logger.LogError("Provide exactly one of --data or --file.");
+            return false;
+        }
+
+        string json;
+        if (hasFile)
+        {
+            if (!File.Exists(file))
+            {
+                logger.LogError("File not found: {Path}", file);
+                return false;
+            }
+            json = File.ReadAllText(file!);
+        }
+        else
+        {
+            json = data!;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                logger.LogError("Expected a JSON object, got {Kind}.", document.RootElement.ValueKind);
+                return false;
+            }
+
+            // Clone so the element remains valid after the JsonDocument is disposed.
+            attributes = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError("Invalid JSON: {Error}", ex.Message);
+            return false;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityCliCommand.cs
@@ -1,0 +1,20 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Entity;
+
+/// <summary>
+/// Parent command for entity discovery and schema introspection.
+/// Usage: <c>txc environment entity [list|describe]</c>
+/// </summary>
+[CliCommand(
+    Name = "entity",
+    Description = "Entity discovery and schema metadata for the live environment.",
+    Children = new[] { typeof(EntityListCliCommand), typeof(EntityDescribeCliCommand) }
+)]
+public class EntityCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityDescribeCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityDescribeCliCommand.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Entity;
+
+/// <summary>
+/// Describes the columns/attributes of a specific entity.
+/// Usage: <c>txc environment entity describe &lt;entity&gt; [--include-system] [--json]</c>
+/// </summary>
+[CliCommand(
+    Name = "describe",
+    Description = "Describe columns/attributes of an entity."
+)]
+public class EntityDescribeCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EntityDescribeCliCommand));
+
+    [CliArgument(Name = "entity", Description = "The logical name of the entity to describe.")]
+    public string Entity { get; set; } = null!;
+
+    [CliOption(Name = "--include-system", Description = "Include non-customizable system attributes in the output.", Required = false)]
+    public bool IncludeSystem { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the list as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        IReadOnlyList<EntityAttributeRecord> rows;
+        try
+        {
+            var service = TxcServices.Get<IDataverseEntityMetadataService>();
+            rows = await service.DescribeEntityAsync(Profile, Entity, IncludeSystem, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment entity describe failed");
+            return 1;
+        }
+
+        if (Json)
+        {
+            OutputWriter.WriteLine(JsonSerializer.Serialize(rows, JsonOptions));
+            return 0;
+        }
+
+        PrintAttributesTable(rows);
+        return 0;
+    }
+
+    private static void PrintAttributesTable(IReadOnlyList<EntityAttributeRecord> rows)
+    {
+        if (rows.Count == 0)
+        {
+            OutputWriter.WriteLine("No attributes found.");
+            return;
+        }
+
+        int logicalWidth = Math.Clamp(rows.Max(r => r.LogicalName.Length), 12, 48);
+        int typeWidth = Math.Clamp(rows.Max(r => r.AttributeTypeName.Length), 4, 30);
+        int displayWidth = Math.Clamp(rows.Max(r => (r.DisplayName ?? "").Length), 12, 40);
+        int customWidth = 6;
+        int pkWidth = 2;
+        int nameWidth = 4;
+        int maxLenWidth = 10;
+
+        string header =
+            $"{"Logical Name".PadRight(logicalWidth)} | " +
+            $"{"Type".PadRight(typeWidth)} | " +
+            $"{"Display Name".PadRight(displayWidth)} | " +
+            $"{"Custom".PadRight(customWidth)} | " +
+            $"{"PK".PadRight(pkWidth)} | " +
+            $"{"Name".PadRight(nameWidth)} | " +
+            $"{"Max Length".PadRight(maxLenWidth)}";
+        OutputWriter.WriteLine(header);
+        OutputWriter.WriteLine(new string('-', header.Length));
+
+        foreach (var r in rows)
+        {
+            string logical = Truncate(r.LogicalName, logicalWidth);
+            string type = Truncate(r.AttributeTypeName, typeWidth);
+            string display = Truncate(r.DisplayName ?? "", displayWidth);
+            string custom = r.IsCustomAttribute ? "true" : "false";
+            string pk = r.IsPrimaryId ? "*" : "";
+            string name = r.IsPrimaryName ? "*" : "";
+            string maxLen = r.MaxLength.HasValue ? r.MaxLength.Value.ToString() : "";
+
+            OutputWriter.WriteLine(
+                $"{logical.PadRight(logicalWidth)} | " +
+                $"{type.PadRight(typeWidth)} | " +
+                $"{display.PadRight(displayWidth)} | " +
+                $"{custom.PadRight(customWidth)} | " +
+                $"{pk.PadRight(pkWidth)} | " +
+                $"{name.PadRight(nameWidth)} | " +
+                $"{maxLen.PadRight(maxLenWidth)}");
+        }
+    }
+
+    /// <summary>Truncate a string to fit the column width, appending a dot if trimmed.</summary>
+    private static string Truncate(string value, int maxWidth) =>
+        value.Length > maxWidth ? value[..(maxWidth - 1)] + "." : value;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+}

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityListCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityListCliCommand.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Entity;
+
+/// <summary>
+/// Lists entities in the connected Dataverse environment.
+/// Usage: <c>txc environment entity list [--search &lt;term&gt;] [--include-system] [--json]</c>
+/// </summary>
+[CliCommand(
+    Name = "list",
+    Description = "List entities in the target environment."
+)]
+public class EntityListCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(EntityListCliCommand));
+
+    [CliOption(Name = "--search", Description = "Filter entities by logical name, schema name, or display name.", Required = false)]
+    public string? Search { get; set; }
+
+    [CliOption(Name = "--include-system", Description = "Include non-customizable system entities in the output.", Required = false)]
+    public bool IncludeSystem { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the list as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        IReadOnlyList<EntitySummaryRecord> rows;
+        try
+        {
+            var service = TxcServices.Get<IDataverseEntityMetadataService>();
+            rows = await service.ListEntitiesAsync(Profile, Search, IncludeSystem, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment entity list failed");
+            return 1;
+        }
+
+        if (Json)
+        {
+            OutputWriter.WriteLine(JsonSerializer.Serialize(rows, JsonOptions));
+            return 0;
+        }
+
+        PrintEntitiesTable(rows);
+        return 0;
+    }
+
+    private static void PrintEntitiesTable(IReadOnlyList<EntitySummaryRecord> rows)
+    {
+        if (rows.Count == 0)
+        {
+            OutputWriter.WriteLine("No entities found.");
+            return;
+        }
+
+        int logicalWidth = Math.Clamp(rows.Max(r => r.LogicalName.Length), 12, 48);
+        int schemaWidth = Math.Clamp(rows.Max(r => (r.SchemaName ?? "").Length), 11, 48);
+        int displayWidth = Math.Clamp(rows.Max(r => (r.DisplayName ?? "").Length), 12, 40);
+        int entitySetWidth = Math.Clamp(rows.Max(r => (r.EntitySetName ?? "").Length), 14, 48);
+        int customWidth = 6;
+
+        string header =
+            $"{"Logical Name".PadRight(logicalWidth)} | " +
+            $"{"Schema Name".PadRight(schemaWidth)} | " +
+            $"{"Display Name".PadRight(displayWidth)} | " +
+            $"{"Entity Set Name".PadRight(entitySetWidth)} | " +
+            $"{"Custom".PadRight(customWidth)}";
+        OutputWriter.WriteLine(header);
+        OutputWriter.WriteLine(new string('-', header.Length));
+
+        foreach (var r in rows)
+        {
+            string logical = Truncate(r.LogicalName, logicalWidth);
+            string schema = Truncate(r.SchemaName ?? "", schemaWidth);
+            string display = Truncate(r.DisplayName ?? "", displayWidth);
+            string entitySet = Truncate(r.EntitySetName ?? "", entitySetWidth);
+            string custom = r.IsCustomEntity ? "true" : "false";
+
+            OutputWriter.WriteLine(
+                $"{logical.PadRight(logicalWidth)} | " +
+                $"{schema.PadRight(schemaWidth)} | " +
+                $"{display.PadRight(displayWidth)} | " +
+                $"{entitySet.PadRight(entitySetWidth)} | " +
+                $"{custom.PadRight(customWidth)}");
+        }
+    }
+
+    /// <summary>Truncate a string to fit the column width, appending a dot if trimmed.</summary>
+    private static string Truncate(string value, int maxWidth) =>
+        value.Length > maxWidth ? value[..(maxWidth - 1)] + "." : value;
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+}

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
@@ -6,7 +6,7 @@ namespace TALXIS.CLI.Features.Environment;
     Name = "environment",
     Alias = "env",
     Description = "Manage the footprint of your project in a live target environment (packages, solutions, deployment history).",
-    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand) }
+    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand), typeof(Data.EnvDataCliCommand), typeof(Entity.EntityCliCommand) }
 )]
 public class EnvironmentCliCommand
 {

--- a/src/TALXIS.CLI.Platform.Dataverse.Application/DependencyInjection/TxcServicesBootstrap.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Application/DependencyInjection/TxcServicesBootstrap.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using TALXIS.CLI.Core.DependencyInjection;
 using TALXIS.CLI.Logging;
+using TALXIS.CLI.Platform.Dataverse.Data.DependencyInjection;
 using TALXIS.CLI.Platform.Dataverse.Runtime.DependencyInjection;
 
 namespace TALXIS.CLI.Platform.Dataverse.Application.DependencyInjection;
@@ -28,6 +29,7 @@ public static class TxcServicesBootstrap
         services.AddTxcConfigCore();
         services.AddTxcDataverseProvider();
         services.AddTxcDataverseApplication();
+        services.AddTxcDataverseData();
 
         var provider = services.BuildServiceProvider();
         TxcServices.Initialize(provider);

--- a/src/TALXIS.CLI.Platform.Dataverse.Application/TALXIS.CLI.Platform.Dataverse.Application.csproj
+++ b/src/TALXIS.CLI.Platform.Dataverse.Application/TALXIS.CLI.Platform.Dataverse.Application.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TALXIS.CLI.Core\TALXIS.CLI.Core.csproj" />
     <ProjectReference Include="..\TALXIS.CLI.Logging\TALXIS.CLI.Logging.csproj" />
+    <ProjectReference Include="..\TALXIS.CLI.Platform.Dataverse.Data\TALXIS.CLI.Platform.Dataverse.Data.csproj" />
     <ProjectReference Include="..\TALXIS.CLI.Platform.Dataverse.Runtime\TALXIS.CLI.Platform.Dataverse.Runtime.csproj" />
     <ProjectReference Include="..\TALXIS.CLI.Platform.Xrm\TALXIS.CLI.Platform.Xrm.csproj" />
   </ItemGroup>

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseBulkService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseBulkService.cs
@@ -1,0 +1,112 @@
+using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Platform.Dataverse.Runtime;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data;
+
+/// <summary>
+/// Dataverse implementation of <see cref="IDataverseBulkService"/>.
+/// Delegates to the SDK <c>CreateMultiple</c>, <c>UpdateMultiple</c>, and
+/// <c>UpsertMultiple</c> messages via <see cref="DataverseCommandBridge"/>.
+/// </summary>
+internal sealed class DataverseBulkService : IDataverseBulkService
+{
+    /// <inheritdoc />
+    public async Task<BulkOperationResult> CreateMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var entities = new EntityCollection(
+            records.Select(r => EntityJsonConverter.JsonToEntity(entityLogicalName, r)).ToList())
+        {
+            EntityName = entityLogicalName
+        };
+
+        var request = new CreateMultipleRequest { Targets = entities };
+        var response = (CreateMultipleResponse)await conn.Client.ExecuteAsync(request, ct).ConfigureAwait(false);
+
+        return new BulkOperationResult(
+            SucceededCount: response.Ids.Length,
+            FailedCount: records.Count - response.Ids.Length,
+            CreatedIds: response.Ids.ToList());
+    }
+
+    /// <inheritdoc />
+    public async Task<BulkOperationResult> UpdateMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        // Each record must contain the entity primary ID field so the SDK
+        // knows which record to update.  The ID is resolved inside
+        // EntityJsonConverter.JsonToEntity via the standard attribute mapping;
+        // the caller is responsible for including the primary key field
+        // (e.g. "accountid") in the JSON payload.
+        var entities = new EntityCollection(
+            records.Select(r => EntityJsonConverter.JsonToEntity(entityLogicalName, r)).ToList())
+        {
+            EntityName = entityLogicalName
+        };
+
+        var request = new UpdateMultipleRequest { Targets = entities };
+        await conn.Client.ExecuteAsync(request, ct).ConfigureAwait(false);
+
+        // UpdateMultipleResponse does not return per-record IDs.
+        return new BulkOperationResult(
+            SucceededCount: records.Count,
+            FailedCount: 0,
+            CreatedIds: Array.Empty<Guid>());
+    }
+
+    /// <inheritdoc />
+    public async Task<BulkOperationResult> UpsertMultipleAsync(
+        string? profileName,
+        string entityLogicalName,
+        IReadOnlyList<JsonElement> records,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var entities = new EntityCollection(
+            records.Select(r => EntityJsonConverter.JsonToEntity(entityLogicalName, r)).ToList())
+        {
+            EntityName = entityLogicalName
+        };
+
+        var request = new UpsertMultipleRequest { Targets = entities };
+        var response = (UpsertMultipleResponse)await conn.Client.ExecuteAsync(request, ct).ConfigureAwait(false);
+
+        // Each UpsertResult indicates whether the record was Created or Updated
+        // and exposes the record ID for created records.
+        var createdIds = new List<Guid>();
+        int created = 0;
+        int updated = 0;
+
+        foreach (UpsertResponse result in response.Results.Cast<UpsertResponse>())
+        {
+            if (result.RecordCreated)
+            {
+                created++;
+                createdIds.Add(result.Target.Id);
+            }
+            else
+            {
+                updated++;
+            }
+        }
+
+        return new BulkOperationResult(
+            SucceededCount: created + updated,
+            FailedCount: records.Count - (created + updated),
+            CreatedIds: createdIds);
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseEntityMetadataService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseEntityMetadataService.cs
@@ -1,0 +1,105 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Platform.Dataverse.Runtime;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data;
+
+/// <summary>
+/// Dataverse implementation of <see cref="IDataverseEntityMetadataService"/>.
+/// Uses the metadata API (<c>RetrieveAllEntitiesRequest</c> /
+/// <c>RetrieveEntityRequest</c>) to provide entity discovery and schema
+/// introspection for the connected environment.
+/// </summary>
+internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataService
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EntitySummaryRecord>> ListEntitiesAsync(
+        string? profileName, string? search, bool includeSystem, CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var request = new RetrieveAllEntitiesRequest
+        {
+            EntityFilters = EntityFilters.Entity,
+            RetrieveAsIfPublished = true
+        };
+
+        var response = (RetrieveAllEntitiesResponse)
+            await conn.Client.ExecuteAsync(request, ct).ConfigureAwait(false);
+
+        IEnumerable<EntityMetadata> entities = response.EntityMetadata;
+
+        // Filter out non-customizable system entities unless explicitly requested.
+        if (!includeSystem)
+        {
+            entities = entities.Where(e =>
+                e.IsCustomEntity == true || e.IsCustomizable?.Value == true);
+        }
+
+        // Apply search filter across logical name, schema name, and display name.
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            entities = entities.Where(e =>
+                Contains(e.LogicalName, search) ||
+                Contains(e.SchemaName, search) ||
+                Contains(e.DisplayName?.UserLocalizedLabel?.Label, search));
+        }
+
+        return entities
+            .OrderBy(e => e.LogicalName, StringComparer.OrdinalIgnoreCase)
+            .Select(e => new EntitySummaryRecord(
+                LogicalName: e.LogicalName,
+                SchemaName: e.SchemaName,
+                DisplayName: e.DisplayName?.UserLocalizedLabel?.Label,
+                EntitySetName: e.EntitySetName,
+                IsCustomEntity: e.IsCustomEntity == true))
+            .ToList();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EntityAttributeRecord>> DescribeEntityAsync(
+        string? profileName, string entityLogicalName, bool includeSystem, CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var request = new RetrieveEntityRequest
+        {
+            LogicalName = entityLogicalName,
+            EntityFilters = EntityFilters.Attributes,
+            RetrieveAsIfPublished = true
+        };
+
+        var response = (RetrieveEntityResponse)
+            await conn.Client.ExecuteAsync(request, ct).ConfigureAwait(false);
+
+        var entityMeta = response.EntityMetadata;
+        IEnumerable<AttributeMetadata> attributes = entityMeta.Attributes;
+
+        // Filter out non-customizable system attributes unless explicitly requested.
+        if (!includeSystem)
+        {
+            attributes = attributes.Where(a =>
+                a.IsCustomAttribute == true || a.IsCustomizable?.Value == true);
+        }
+
+        return attributes
+            .OrderBy(a => a.LogicalName, StringComparer.OrdinalIgnoreCase)
+            .Select(a => new EntityAttributeRecord(
+                LogicalName: a.LogicalName,
+                SchemaName: a.SchemaName,
+                DisplayName: a.DisplayName?.UserLocalizedLabel?.Label,
+                AttributeTypeName: a.AttributeTypeName?.Value ?? a.AttributeType?.ToString() ?? "Unknown",
+                IsCustomAttribute: a.IsCustomAttribute == true,
+                IsPrimaryId: a.LogicalName == entityMeta.PrimaryIdAttribute,
+                IsPrimaryName: a.LogicalName == entityMeta.PrimaryNameAttribute,
+                MaxLength: a is StringAttributeMetadata strAttr ? strAttr.MaxLength : null,
+                Description: a.Description?.UserLocalizedLabel?.Label))
+            .ToList();
+    }
+
+    /// <summary>Case-insensitive contains check that handles null values safely.</summary>
+    private static bool Contains(string? value, string search) =>
+        value is not null && value.Contains(search, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
@@ -1,0 +1,416 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Query;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Platform.Dataverse.Runtime;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data;
+
+/// <summary>
+/// Dataverse implementation of <see cref="IDataverseQueryService"/>.
+/// Executes read-only SQL, FetchXML, and OData queries via the
+/// <c>ServiceClient</c> obtained through <see cref="DataverseCommandBridge"/>.
+/// </summary>
+internal sealed class DataverseQueryService : IDataverseQueryService
+{
+    /// <summary>
+    /// Regex that detects SQL write operations. Only SELECT queries are allowed.
+    /// </summary>
+    private static readonly Regex WriteOperationPattern = new(
+        @"\b(INSERT|UPDATE|DELETE|DROP|ALTER|TRUNCATE|MERGE)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Prefixes used by OData/Dataverse annotations that are stripped from
+    /// results unless the caller explicitly asks for them.
+    /// </summary>
+    private static readonly string[] AnnotationPrefixes = { "@odata.", "@OData.", "@Microsoft." };
+
+    // ───────────────────────────── SQL ──────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<DataverseQueryResult> QuerySqlAsync(
+        string? profileName,
+        string sql,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sql);
+        ValidateSqlReadOnly(sql);
+
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        // Resolve the entity set name from the table's logical name so the
+        // Web API request targets the correct OData entity set.
+        var entitySetName = ResolveEntitySetName(conn, sql);
+
+        var headers = BuildHeaders(includeAnnotations);
+        var queryPath = $"{entitySetName}?sql={Uri.EscapeDataString(sql)}";
+        var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+
+        var records = new List<JsonElement>();
+        ParseValueArray(response, records);
+
+        // Follow @odata.nextLink pages until exhausted or top limit reached.
+        await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
+
+        if (!includeAnnotations)
+            StripAnnotations(records);
+
+        if (top.HasValue && records.Count > top.Value)
+            records.RemoveRange(top.Value, records.Count - top.Value);
+
+        return new DataverseQueryResult(records, records.Count);
+    }
+
+    // ──────────────────────────── FetchXML ──────────────────────────
+
+    /// <inheritdoc />
+    public async Task<DataverseQueryResult> QueryFetchXmlAsync(
+        string? profileName,
+        string fetchXml,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fetchXml);
+
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var records = new List<JsonElement>();
+        bool hasFetchTop = HasTopAttribute(fetchXml);
+        int page = 1;
+        string? pagingCookie = null;
+
+        while (true)
+        {
+            var pagedXml = ApplyPaging(fetchXml, page, pagingCookie);
+            var fetchExpr = new FetchExpression(pagedXml);
+            var response = await conn.Client.RetrieveMultipleAsync(fetchExpr, ct).ConfigureAwait(false);
+
+            foreach (var entity in response.Entities)
+            {
+                records.Add(EntityToJsonElement(entity, includeAnnotations));
+
+                if (top.HasValue && records.Count >= top.Value)
+                    return new DataverseQueryResult(records, records.Count);
+            }
+
+            // When the FetchXML has a top attribute, Dataverse handles the
+            // row limit server-side and does not support paging alongside it.
+            if (hasFetchTop || !response.MoreRecords)
+                break;
+
+            pagingCookie = response.PagingCookie;
+            page++;
+        }
+
+        return new DataverseQueryResult(records, records.Count);
+    }
+
+    // ──────────────────────────── OData ─────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<DataverseQueryResult> QueryODataAsync(
+        string? profileName,
+        string entitySetOrPath,
+        string? select,
+        string? filter,
+        string? orderBy,
+        int? top,
+        bool includeAnnotations,
+        CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entitySetOrPath);
+
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var queryPath = BuildODataQueryPath(entitySetOrPath, select, filter, orderBy, top);
+        var headers = BuildHeaders(includeAnnotations);
+        var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+
+        var records = new List<JsonElement>();
+        ParseValueArray(response, records);
+
+        // Only follow nextLink if the caller did not specify $top — if they
+        // did, the server-side limit already constrains the result set.
+        if (!top.HasValue)
+            await FollowNextLinksAsync(conn, response, records, top: null, headers, ct).ConfigureAwait(false);
+
+        if (!includeAnnotations)
+            StripAnnotations(records);
+
+        return new DataverseQueryResult(records, records.Count);
+    }
+
+    // ──────────────────────── Private helpers ───────────────────────
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> when the SQL text
+    /// contains write-oriented keywords. Only SELECT queries are allowed.
+    /// </summary>
+    private static void ValidateSqlReadOnly(string sql)
+    {
+        if (WriteOperationPattern.IsMatch(sql))
+            throw new InvalidOperationException(
+                "Write operations (INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE, MERGE) are not allowed. Only SELECT queries are supported.");
+    }
+
+    /// <summary>
+    /// Extracts the table logical name from the SQL FROM clause and
+    /// retrieves its <c>EntitySetName</c> via entity metadata.
+    /// </summary>
+    private static string ResolveEntitySetName(DataverseConnection conn, string sql)
+    {
+        // Simple regex to grab the first table name after FROM.
+        var match = Regex.Match(sql, @"\bFROM\s+(\w+)", RegexOptions.IgnoreCase);
+        if (!match.Success)
+            throw new InvalidOperationException("Could not parse a table name from the SQL FROM clause.");
+
+        var tableName = match.Groups[1].Value.ToLowerInvariant();
+
+        var metaRequest = new RetrieveEntityRequest
+        {
+            LogicalName = tableName,
+            EntityFilters = EntityFilters.Entity,
+        };
+
+        var metaResponse = (RetrieveEntityResponse)conn.Client.Execute(metaRequest);
+        return metaResponse.EntityMetadata.EntitySetName;
+    }
+
+    /// <summary>
+    /// Builds custom HTTP headers for ExecuteWebRequest calls.
+    /// The Dataverse <c>ServiceClient.ExecuteWebRequest</c> expects headers
+    /// as <c>Dictionary&lt;string, List&lt;string&gt;&gt;</c>.
+    /// </summary>
+    private static Dictionary<string, List<string>> BuildHeaders(bool includeAnnotations)
+    {
+        var headers = new Dictionary<string, List<string>>();
+        if (includeAnnotations)
+            headers["Prefer"] = new List<string> { "odata.include-annotations=*" };
+        return headers;
+    }
+
+    /// <summary>
+    /// Constructs the OData query path from individual query parameters.
+    /// </summary>
+    private static string BuildODataQueryPath(
+        string entitySetOrPath, string? select, string? filter, string? orderBy, int? top)
+    {
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(select))
+            parts.Add($"$select={select}");
+        if (!string.IsNullOrWhiteSpace(filter))
+            parts.Add($"$filter={filter}");
+        if (!string.IsNullOrWhiteSpace(orderBy))
+            parts.Add($"$orderby={orderBy}");
+        if (top.HasValue)
+            parts.Add($"$top={top.Value}");
+
+        return parts.Count > 0
+            ? $"{entitySetOrPath}?{string.Join("&", parts)}"
+            : entitySetOrPath;
+    }
+
+    /// <summary>
+    /// Parses the <c>value</c> array from a Web API JSON response.
+    /// </summary>
+    private static void ParseValueArray(HttpResponseMessage response, List<JsonElement> target)
+    {
+        var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        using var doc = JsonDocument.Parse(content);
+
+        if (doc.RootElement.TryGetProperty("value", out var valueArray) &&
+            valueArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in valueArray.EnumerateArray())
+                target.Add(item.Clone());
+        }
+    }
+
+    /// <summary>
+    /// Follows <c>@odata.nextLink</c> URLs for automatic pagination.
+    /// NextLink URLs are absolute; we extract the relative path to pass
+    /// to <see cref="Microsoft.PowerPlatform.Dataverse.Client.ServiceClient.ExecuteWebRequest"/>.
+    /// </summary>
+    private static async Task FollowNextLinksAsync(
+        DataverseConnection conn,
+        HttpResponseMessage lastResponse,
+        List<JsonElement> records,
+        int? top,
+        Dictionary<string, List<string>> headers,
+        CancellationToken ct)
+    {
+        var currentResponse = lastResponse;
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var content = await currentResponse.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(content);
+
+            if (!doc.RootElement.TryGetProperty("@odata.nextLink", out var nextLinkElement))
+                break;
+
+            var nextLinkUrl = nextLinkElement.GetString();
+            if (string.IsNullOrWhiteSpace(nextLinkUrl))
+                break;
+
+            // Extract relative path from the absolute nextLink URL.
+            var relativePath = ExtractRelativePath(nextLinkUrl, conn);
+
+            currentResponse = conn.Client.ExecuteWebRequest(HttpMethod.Get, relativePath, string.Empty, headers);
+            ParseValueArray(currentResponse, records);
+
+            if (top.HasValue && records.Count >= top.Value)
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Extracts the relative path from an absolute nextLink URL by stripping
+    /// the base URI of the Dataverse environment.
+    /// </summary>
+    private static string ExtractRelativePath(string absoluteUrl, DataverseConnection conn)
+    {
+        if (Uri.TryCreate(absoluteUrl, UriKind.Absolute, out var uri))
+        {
+            // The ConnectedOrgUriActual gives us the org service URL; the Web API
+            // path is relative to the org root. We strip the scheme + host portion.
+            return uri.PathAndQuery.TrimStart('/');
+        }
+
+        // If it's already relative, just return it.
+        return absoluteUrl;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the FetchXML root has a <c>top</c> attribute,
+    /// meaning the server controls the row limit and paging must not be added
+    /// (Dataverse rejects <c>top</c> + <c>page</c> together).
+    /// </summary>
+    private static bool HasTopAttribute(string fetchXml)
+    {
+        var doc = XDocument.Parse(fetchXml);
+        return doc.Root?.Attribute("top") is not null;
+    }
+
+    /// <summary>
+    /// Applies paging information (page number and paging cookie) to a
+    /// FetchXML query string for multi-page retrieval. Skipped when the
+    /// FetchXML already contains a <c>top</c> attribute.
+    /// </summary>
+    private static string ApplyPaging(string fetchXml, int page, string? pagingCookie)
+    {
+        var doc = XDocument.Parse(fetchXml);
+        var fetchElement = doc.Root
+            ?? throw new InvalidOperationException("FetchXML document has no root element.");
+
+        // Do not add paging when the FetchXML already has a top attribute —
+        // Dataverse rejects the combination.
+        if (fetchElement.Attribute("top") is not null)
+            return fetchXml;
+
+        fetchElement.SetAttributeValue("page", page);
+
+        if (!string.IsNullOrWhiteSpace(pagingCookie))
+            fetchElement.SetAttributeValue("paging-cookie", pagingCookie);
+
+        return doc.ToString(SaveOptions.DisableFormatting);
+    }
+
+    /// <summary>
+    /// Converts a Dataverse <see cref="Entity"/> to a <see cref="JsonElement"/>
+    /// by serializing its attributes as a flat dictionary.
+    /// </summary>
+    private static JsonElement EntityToJsonElement(Entity entity, bool includeAnnotations)
+    {
+        var dict = new Dictionary<string, object?>();
+
+        foreach (var attr in entity.Attributes)
+        {
+            dict[attr.Key] = ConvertAttributeValue(attr.Value);
+        }
+
+        // Include formatted values (annotations) when requested.
+        if (includeAnnotations && entity.FormattedValues.Count > 0)
+        {
+            foreach (var fv in entity.FormattedValues)
+                dict[$"{fv.Key}@OData.Community.Display.V1.FormattedValue"] = fv.Value;
+        }
+
+        var json = JsonSerializer.Serialize(dict);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>
+    /// Converts SDK attribute values to JSON-safe primitives.
+    /// </summary>
+    private static object? ConvertAttributeValue(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            EntityReference er => new { Id = er.Id, LogicalName = er.LogicalName, Name = er.Name },
+            OptionSetValue osv => osv.Value,
+            Money m => m.Value,
+            AliasedValue av => ConvertAttributeValue(av.Value),
+            _ => value,
+        };
+    }
+
+    /// <summary>
+    /// Removes OData/Microsoft annotation keys from each record's properties.
+    /// Called by default unless <c>includeAnnotations</c> is <c>true</c>.
+    /// </summary>
+    private static void StripAnnotations(List<JsonElement> records)
+    {
+        for (int i = 0; i < records.Count; i++)
+        {
+            if (records[i].ValueKind != JsonValueKind.Object)
+                continue;
+
+            var dict = new Dictionary<string, JsonElement>();
+            bool hasAnnotations = false;
+
+            foreach (var prop in records[i].EnumerateObject())
+            {
+                if (IsAnnotationKey(prop.Name))
+                {
+                    hasAnnotations = true;
+                    continue;
+                }
+                dict[prop.Name] = prop.Value.Clone();
+            }
+
+            if (hasAnnotations)
+            {
+                var json = JsonSerializer.Serialize(dict);
+                using var doc = JsonDocument.Parse(json);
+                records[i] = doc.RootElement.Clone();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when the property name is an OData/Dataverse annotation.
+    /// </summary>
+    private static bool IsAnnotationKey(string key)
+    {
+        foreach (var prefix in AnnotationPrefixes)
+        {
+            if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
@@ -55,7 +55,7 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
 
         var records = new List<JsonElement>();
-        ParseValueArray(response, records);
+        await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
 
         // Follow @odata.nextLink pages until exhausted or top limit reached.
         await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
@@ -136,15 +136,19 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
 
         var records = new List<JsonElement>();
-        ParseValueArray(response, records);
+        await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
 
-        // Only follow nextLink if the caller did not specify $top — if they
-        // did, the server-side limit already constrains the result set.
-        if (!top.HasValue)
-            await FollowNextLinksAsync(conn, response, records, top: null, headers, ct).ConfigureAwait(false);
+        // Dataverse can still return @odata.nextLink when $top is specified
+        // (for example when the requested top exceeds the server page size).
+        // Always follow pagination links and let the helper stop once the
+        // requested number of records has been accumulated.
+        await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
 
         if (!includeAnnotations)
             StripAnnotations(records);
+
+        if (top.HasValue && records.Count > top.Value)
+            records.RemoveRange(top.Value, records.Count - top.Value);
 
         return new DataverseQueryResult(records, records.Count);
     }
@@ -206,11 +210,11 @@ internal sealed class DataverseQueryService : IDataverseQueryService
     {
         var parts = new List<string>();
         if (!string.IsNullOrWhiteSpace(select))
-            parts.Add($"$select={select}");
+            parts.Add($"$select={Uri.EscapeDataString(select)}");
         if (!string.IsNullOrWhiteSpace(filter))
-            parts.Add($"$filter={filter}");
+            parts.Add($"$filter={Uri.EscapeDataString(filter)}");
         if (!string.IsNullOrWhiteSpace(orderBy))
-            parts.Add($"$orderby={orderBy}");
+            parts.Add($"$orderby={Uri.EscapeDataString(orderBy)}");
         if (top.HasValue)
             parts.Add($"$top={top.Value}");
 
@@ -222,9 +226,12 @@ internal sealed class DataverseQueryService : IDataverseQueryService
     /// <summary>
     /// Parses the <c>value</c> array from a Web API JSON response.
     /// </summary>
-    private static void ParseValueArray(HttpResponseMessage response, List<JsonElement> target)
+    private static async Task ParseValueArrayAsync(
+        HttpResponseMessage response,
+        List<JsonElement> target,
+        CancellationToken ct)
     {
-        var content = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         using var doc = JsonDocument.Parse(content);
 
         if (doc.RootElement.TryGetProperty("value", out var valueArray) &&
@@ -268,7 +275,7 @@ internal sealed class DataverseQueryService : IDataverseQueryService
             var relativePath = ExtractRelativePath(nextLinkUrl, conn);
 
             currentResponse = conn.Client.ExecuteWebRequest(HttpMethod.Get, relativePath, string.Empty, headers);
-            ParseValueArray(currentResponse, records);
+            await ParseValueArrayAsync(currentResponse, records, ct).ConfigureAwait(false);
 
             if (top.HasValue && records.Count >= top.Value)
                 break;
@@ -277,19 +284,35 @@ internal sealed class DataverseQueryService : IDataverseQueryService
 
     /// <summary>
     /// Extracts the relative path from an absolute nextLink URL by stripping
-    /// the base URI of the Dataverse environment.
+    /// the base URI and the Web API prefix so the returned path matches the
+    /// entity-relative format expected by <c>ExecuteWebRequest</c>.
     /// </summary>
     private static string ExtractRelativePath(string absoluteUrl, DataverseConnection conn)
     {
         if (Uri.TryCreate(absoluteUrl, UriKind.Absolute, out var uri))
         {
-            // The ConnectedOrgUriActual gives us the org service URL; the Web API
-            // path is relative to the org root. We strip the scheme + host portion.
-            return uri.PathAndQuery.TrimStart('/');
+            return NormalizeWebApiRelativePath(uri.PathAndQuery);
         }
 
-        // If it's already relative, just return it.
-        return absoluteUrl;
+        return NormalizeWebApiRelativePath(absoluteUrl);
+    }
+
+    /// <summary>
+    /// Normalizes a Dataverse Web API path so it matches the format expected by
+    /// <c>ExecuteWebRequest</c>, for example <c>accounts?$select=name</c> instead
+    /// of <c>api/data/v9.2/accounts?$select=name</c>.
+    /// </summary>
+    private static string NormalizeWebApiRelativePath(string path)
+    {
+        var normalizedPath = path.TrimStart('/');
+
+        // Dataverse next links can include the Web API route prefix. Strip it so
+        // pagination requests use the same relative path shape as initial requests.
+        return Regex.Replace(
+            normalizedPath,
+            @"^api/data/v\d+\.\d+/",
+            string.Empty,
+            RegexOptions.IgnoreCase);
     }
 
     /// <summary>

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseRecordService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseRecordService.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Platform.Dataverse.Runtime;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data;
+
+/// <summary>
+/// Implements single-record CRUD operations against a live Dataverse
+/// environment using the <c>ServiceClient</c> SDK.
+/// </summary>
+internal sealed class DataverseRecordService : IDataverseRecordService
+{
+    public async Task<JsonElement> GetAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        string[]? columns,
+        bool includeAnnotations,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var columnSet = columns is { Length: > 0 }
+            ? new ColumnSet(columns)
+            : new ColumnSet(true);
+
+        var entity = await conn.Client.RetrieveAsync(
+            entityLogicalName, recordId, columnSet, ct).ConfigureAwait(false);
+
+        return EntityJsonConverter.EntityToJson(entity, includeAnnotations);
+    }
+
+    public async Task<Guid> CreateAsync(
+        string? profileName,
+        string entityLogicalName,
+        JsonElement attributes,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var entity = EntityJsonConverter.JsonToEntity(entityLogicalName, attributes);
+
+        return await conn.Client.CreateAsync(entity, ct).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        JsonElement attributes,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        var entity = EntityJsonConverter.JsonToEntity(entityLogicalName, attributes, recordId);
+
+        await conn.Client.UpdateAsync(entity, ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(
+        string? profileName,
+        string entityLogicalName,
+        Guid recordId,
+        CancellationToken ct)
+    {
+        using var conn = await DataverseCommandBridge.ConnectAsync(profileName, ct).ConfigureAwait(false);
+
+        await conn.Client.DeleteAsync(entityLogicalName, recordId, ct).ConfigureAwait(false);
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DependencyInjection/DataverseDataServiceCollectionExtensions.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DependencyInjection/DataverseDataServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data.DependencyInjection;
+
+/// <summary>
+/// Registers the data-plane Dataverse services (query, record CRUD, bulk
+/// operations, entity metadata). Call after <c>AddTxcDataverseProvider()</c>.
+/// </summary>
+public static class DataverseDataServiceCollectionExtensions
+{
+    public static IServiceCollection AddTxcDataverseData(this IServiceCollection services)
+    {
+        services.AddSingleton<IDataverseQueryService, DataverseQueryService>();
+        services.AddSingleton<IDataverseRecordService, DataverseRecordService>();
+        services.AddSingleton<IDataverseBulkService, DataverseBulkService>();
+        services.AddSingleton<IDataverseEntityMetadataService, DataverseEntityMetadataService>();
+        return services;
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/EntityJsonConverter.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/EntityJsonConverter.cs
@@ -34,10 +34,15 @@ internal static class EntityJsonConverter
             // Detect the primary key field by the common Dataverse convention
             // "{entityLogicalName}id" and set Entity.Id instead of passing a
             // raw string — the SDK expects a Guid for primary key attributes.
-            if (value is string s &&
-                Guid.TryParse(s, out var parsedGuid) &&
-                prop.Name.Equals($"{entityLogicalName}id", StringComparison.OrdinalIgnoreCase))
+            bool isPrimaryKey = prop.Name.Equals($"{entityLogicalName}id", StringComparison.OrdinalIgnoreCase);
+            if (isPrimaryKey && value is string s && Guid.TryParse(s, out var parsedGuid))
             {
+                // When an explicit id was provided by the caller (e.g. record update),
+                // validate that the JSON field matches to avoid targeting the wrong record.
+                if (id.HasValue && parsedGuid != id.Value)
+                    throw new InvalidOperationException(
+                        $"The '{prop.Name}' value '{parsedGuid}' in the JSON does not match the explicit record ID '{id.Value}'.");
+
                 entity.Id = parsedGuid;
                 entity[prop.Name] = parsedGuid;
             }

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/EntityJsonConverter.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/EntityJsonConverter.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using Microsoft.Xrm.Sdk;
+
+namespace TALXIS.CLI.Platform.Dataverse.Data;
+
+/// <summary>
+/// Converts between <see cref="JsonElement"/> (the CLI/JSON world) and
+/// <see cref="Entity"/> (the Dataverse SDK world).
+/// </summary>
+internal static class EntityJsonConverter
+{
+    /// <summary>
+    /// Builds a Dataverse <see cref="Entity"/> from a flat JSON object.
+    /// </summary>
+    /// <param name="entityLogicalName">Logical name of the target entity (e.g. <c>account</c>).</param>
+    /// <param name="json">A JSON object whose properties map to entity attributes.</param>
+    /// <param name="id">Optional explicit record ID; when set, <see cref="Entity.Id"/> is assigned.</param>
+    public static Entity JsonToEntity(string entityLogicalName, JsonElement json, Guid? id = null)
+    {
+        if (json.ValueKind != JsonValueKind.Object)
+            throw new ArgumentException("Expected a JSON object representing a single record.", nameof(json));
+
+        var entity = new Entity(entityLogicalName);
+
+        if (id.HasValue)
+            entity.Id = id.Value;
+
+        foreach (var prop in json.EnumerateObject())
+        {
+            var value = ConvertJsonValue(prop.Value);
+            if (value is null)
+                continue;
+
+            // Detect the primary key field by the common Dataverse convention
+            // "{entityLogicalName}id" and set Entity.Id instead of passing a
+            // raw string — the SDK expects a Guid for primary key attributes.
+            if (value is string s &&
+                Guid.TryParse(s, out var parsedGuid) &&
+                prop.Name.Equals($"{entityLogicalName}id", StringComparison.OrdinalIgnoreCase))
+            {
+                entity.Id = parsedGuid;
+                entity[prop.Name] = parsedGuid;
+            }
+            else
+            {
+                entity[prop.Name] = value;
+            }
+        }
+
+        return entity;
+    }
+
+    /// <summary>
+    /// Serializes a Dataverse <see cref="Entity"/> back to a <see cref="JsonElement"/>.
+    /// </summary>
+    /// <param name="entity">The SDK entity to convert.</param>
+    /// <param name="includeAnnotations">
+    /// When <c>true</c>, <see cref="Entity.FormattedValues"/> are emitted as
+    /// <c>{key}@OData.Community.Display.V1.FormattedValue</c> properties.
+    /// </param>
+    public static JsonElement EntityToJson(Entity entity, bool includeAnnotations = false)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+
+            foreach (var attr in entity.Attributes)
+            {
+                WriteAttribute(writer, attr.Key, attr.Value);
+            }
+
+            if (includeAnnotations)
+            {
+                foreach (var fv in entity.FormattedValues)
+                {
+                    writer.WriteString($"{fv.Key}@OData.Community.Display.V1.FormattedValue", fv.Value);
+                }
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return JsonDocument.Parse(stream.ToArray()).RootElement.Clone();
+    }
+
+    private static object? ConvertJsonValue(JsonElement element)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.String:
+                return element.GetString();
+
+            case JsonValueKind.Number:
+                // Try integer types first, then floating-point.
+                if (element.TryGetInt32(out var i32)) return i32;
+                if (element.TryGetInt64(out var i64)) return i64;
+                if (element.TryGetDecimal(out var dec)) return dec;
+                return element.GetDouble();
+
+            case JsonValueKind.True:
+            case JsonValueKind.False:
+                return element.GetBoolean();
+
+            case JsonValueKind.Object:
+                // Convention: an object with "Id" + "LogicalName" is an EntityReference.
+                if (element.TryGetProperty("Id", out var idProp) &&
+                    element.TryGetProperty("LogicalName", out var lnProp) &&
+                    lnProp.ValueKind == JsonValueKind.String)
+                {
+                    var refId = idProp.ValueKind == JsonValueKind.String
+                        ? Guid.Parse(idProp.GetString()!)
+                        : throw new InvalidOperationException("EntityReference 'Id' must be a string (GUID).");
+
+                    return new EntityReference(lnProp.GetString()!, refId);
+                }
+                // Unrecognised object — skip rather than throw.
+                return null;
+
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+
+            case JsonValueKind.Array:
+                // Arrays are not directly supported as attribute values.
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    private static void WriteAttribute(Utf8JsonWriter writer, string key, object? value)
+    {
+        switch (value)
+        {
+            case null:
+                writer.WriteNull(key);
+                break;
+            case string s:
+                writer.WriteString(key, s);
+                break;
+            case int i:
+                writer.WriteNumber(key, i);
+                break;
+            case long l:
+                writer.WriteNumber(key, l);
+                break;
+            case double d:
+                writer.WriteNumber(key, d);
+                break;
+            case decimal m:
+                writer.WriteNumber(key, m);
+                break;
+            case bool b:
+                writer.WriteBoolean(key, b);
+                break;
+            case DateTime dt:
+                writer.WriteString(key, dt);
+                break;
+            case Guid g:
+                writer.WriteString(key, g);
+                break;
+            case EntityReference er:
+                writer.WriteStartObject(key);
+                writer.WriteString("Id", er.Id);
+                writer.WriteString("LogicalName", er.LogicalName);
+                writer.WriteEndObject();
+                break;
+            case OptionSetValue osv:
+                writer.WriteNumber(key, osv.Value);
+                break;
+            case Money money:
+                writer.WriteNumber(key, money.Value);
+                break;
+            default:
+                // Fall back to ToString() for types we don't explicitly handle.
+                writer.WriteString(key, value.ToString());
+                break;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/TALXIS.CLI.Platform.Dataverse.Data.csproj
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/TALXIS.CLI.Platform.Dataverse.Data.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.10" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\TALXIS.CLI.Core\TALXIS.CLI.Core.csproj" />
     <ProjectReference Include="..\TALXIS.CLI.Platform.Dataverse.Runtime\TALXIS.CLI.Platform.Dataverse.Runtime.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Adds full data operations against live Dataverse environments under `txc environment data` and `txc environment entity`.

### New commands

| Command | Description |
|---------|-------------|
| `txc env data query sql <sql>` | SQL query via Web API `?sql=` parameter (T-SQL subset) |
| `txc env data query fetchxml <xml\|--file>` | FetchXML query via `RetrieveMultiple` |
| `txc env data query odata <entity> [--select/--filter/--order-by/--top]` | OData query via `ExecuteWebRequest` |
| `txc env data record get <id> --entity <name>` | Retrieve single record |
| `txc env data record create --entity <name> --data/--file` | Create record from JSON |
| `txc env data record update <id> --entity <name> --data/--file` | Update record from JSON |
| `txc env data record delete <id> --entity <name>` | Delete record |
| `txc env data bulk create --entity <name> --data/--file` | `CreateMultiple` from JSON array |
| `txc env data bulk update --entity <name> --data/--file` | `UpdateMultiple` from JSON array |
| `txc env data bulk upsert --entity <name> --data/--file` | `UpsertMultiple` from JSON array |
| `txc env entity list [--search] [--include-system]` | List entities in environment |
| `txc env entity describe <entity> [--include-system]` | Show entity columns/attributes |

### Architecture

- **All requests through `ServiceClient`** — no direct HTTP calls
- **Service contracts** in `Core/Contracts/Dataverse/` (4 interfaces)
- **Service layer** in `Platform.Dataverse.Data/` (query, record, bulk, entity metadata services + JSON↔Entity converter)
- **CLI commands** in `Features.Environment/` (Data/ and Entity/ subdirectories)
- **DI wiring** via `AddTxcDataverseData()` in bootstrapper

### Features

- SQL write guardrails (blocks INSERT/UPDATE/DELETE/DROP)
- Automatic pagination (OData nextLink + FetchXML paging cookies)
- OData annotation stripping by default (`--include-annotations` to keep)
- Table + JSON output (`--json` flag)
- Bulk operations ready for `DeleteMultiple` when available for standard tables

### Tested against

All 12 commands tested against `https://org2928f636.crm.dynamics.com` — full CRUD lifecycle, bulk operations, error handling, and edge cases verified.