### PR TITLE
feat: add environment setting list/update commands and EnvironmentId support

### DIFF
--- a/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
@@ -38,6 +38,7 @@ public sealed class ConnectionUpsertService
         string? environmentUrl,
         CloudInstance? cloud,
         string? organizationId,
+        string? environmentId,
         string? tenantId,
         string? description,
         CancellationToken ct)
@@ -67,6 +68,15 @@ public sealed class ConnectionUpsertService
                 $"--organization-id must be a GUID: '{organizationId}'.");
         }
 
+        Guid? parsedEnvironmentId = null;
+        if (!string.IsNullOrWhiteSpace(environmentId))
+        {
+            if (!Guid.TryParse(environmentId, out var eid))
+                return new ConnectionUpsertResult(null,
+                    $"--environment-id must be a GUID: '{environmentId}'.");
+            parsedEnvironmentId = eid;
+        }
+
         var connection = new Connection
         {
             Id = trimmed!,
@@ -75,6 +85,7 @@ public sealed class ConnectionUpsertService
             EnvironmentUrl = envUri.ToString().TrimEnd('/'),
             Cloud = cloud ?? CloudInstance.Public,
             OrganizationId = organizationId,
+            EnvironmentId = parsedEnvironmentId,
             TenantId = tenantId,
         };
 

--- a/src/TALXIS.CLI.Core/Model/Connection.cs
+++ b/src/TALXIS.CLI.Core/Model/Connection.cs
@@ -19,6 +19,14 @@ public sealed class Connection
     // ExtraFields below round-trips any unknown future keys without loss).
     public string? EnvironmentUrl { get; set; }
     public string? OrganizationId { get; set; }
+
+    /// <summary>
+    /// Power Platform environment GUID used by the control plane API
+    /// (<c>api.powerplatform.com/environmentmanagement/environments/{id}</c>).
+    /// Populated during live-check or explicitly via <c>--environment-id</c>.
+    /// </summary>
+    public Guid? EnvironmentId { get; set; }
+
     public CloudInstance? Cloud { get; set; }
     public string? TenantId { get; set; }
 

--- a/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementSettingsService.cs
+++ b/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementSettingsService.cs
@@ -1,0 +1,38 @@
+namespace TALXIS.CLI.Core.Platforms.PowerPlatform;
+
+/// <summary>
+/// A single environment management setting returned by the Power Platform
+/// control plane API (<c>api.powerplatform.com/environmentmanagement</c>).
+/// </summary>
+public sealed record EnvironmentManagementSetting(string Name, object? Value);
+
+/// <summary>
+/// Lists and updates environment management settings via the Power Platform
+/// control plane API. These are governance/feature-toggle settings
+/// (e.g. <c>powerApps_AllowCodeApps</c>, Copilot Studio flags, SAS IP
+/// restrictions) — distinct from the Dataverse Organization table columns
+/// that <c>pac env list-settings</c> surfaces.
+/// </summary>
+public interface IEnvironmentManagementSettingsService
+{
+    /// <summary>
+    /// Lists environment management settings. When <paramref name="selectFilter"/>
+    /// is provided it is passed as the <c>$select</c> OData query parameter to
+    /// restrict the returned properties.
+    /// </summary>
+    Task<IReadOnlyList<EnvironmentManagementSetting>> ListAsync(
+        string? profileName,
+        string? selectFilter,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Updates a single environment management setting via PATCH.
+    /// The <paramref name="value"/> string is auto-coerced to the
+    /// appropriate JSON type (bool / int / string).
+    /// </summary>
+    Task UpdateAsync(
+        string? profileName,
+        string settingName,
+        string value,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
@@ -41,7 +41,7 @@ public class ConnectionCreateCliCommand
     [CliOption(Name = "--organization-id", Aliases = new[] { "--org-id" }, Description = "Dataverse organization id (GUID). Optional.", Required = false)]
     public string? OrganizationId { get; set; }
 
-    [CliOption(Name = "--environment-id", Aliases = new[] { "--env-id" }, Description = "Power Platform environment id (GUID) used by the control plane API. Optional — resolved automatically during live check if omitted.", Required = false)]
+    [CliOption(Name = "--environment-id", Aliases = new[] { "--env-id" }, Description = "Power Platform environment id (GUID) used by the control plane API. Optional — if omitted, it may be resolved later during `txc config profile create --url ...` bootstrap or at runtime when calling control-plane commands.", Required = false)]
     public string? EnvironmentId { get; set; }
 
     [CliOption(Name = "--tenant", Description = "Entra tenant id or domain. Optional — defaults to the credential's tenant at resolve time.", Required = false)]

--- a/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
@@ -41,6 +41,9 @@ public class ConnectionCreateCliCommand
     [CliOption(Name = "--organization-id", Aliases = new[] { "--org-id" }, Description = "Dataverse organization id (GUID). Optional.", Required = false)]
     public string? OrganizationId { get; set; }
 
+    [CliOption(Name = "--environment-id", Aliases = new[] { "--env-id" }, Description = "Power Platform environment id (GUID) used by the control plane API. Optional — resolved automatically during live check if omitted.", Required = false)]
+    public string? EnvironmentId { get; set; }
+
     [CliOption(Name = "--tenant", Description = "Entra tenant id or domain. Optional — defaults to the credential's tenant at resolve time.", Required = false)]
     public string? TenantId { get; set; }
 
@@ -58,6 +61,7 @@ public class ConnectionCreateCliCommand
                 EnvironmentUrl,
                 Cloud,
                 OrganizationId,
+                EnvironmentId,
                 TenantId,
                 Description,
                 CancellationToken.None).ConfigureAwait(false);
@@ -80,6 +84,7 @@ public class ConnectionCreateCliCommand
                     environmentUrl = connection.EnvironmentUrl,
                     cloud = connection.Cloud,
                     organizationId = connection.OrganizationId,
+                    environmentId = connection.EnvironmentId,
                     tenantId = connection.TenantId,
                     description = connection.Description,
                 },

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
@@ -6,7 +6,7 @@ namespace TALXIS.CLI.Features.Environment;
     Name = "environment",
     Alias = "env",
     Description = "Manage the footprint of your project in a live target environment (packages, solutions, deployment history).",
-    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand), typeof(Data.EnvDataCliCommand), typeof(Entity.EntityCliCommand) }
+    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand), typeof(Data.EnvDataCliCommand), typeof(Entity.EntityCliCommand), typeof(Setting.SettingCliCommand) }
 )]
 public class EnvironmentCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Setting/SettingCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Setting/SettingCliCommand.cs
@@ -1,0 +1,20 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Environment.Setting;
+
+/// <summary>
+/// <c>txc environment setting</c> — manage environment management settings
+/// via the Power Platform control plane API.
+/// </summary>
+[CliCommand(
+    Name = "setting",
+    Description = "Manage environment management settings (Power Platform control plane).",
+    Children = new[] { typeof(SettingListCliCommand), typeof(SettingUpdateCliCommand) }
+)]
+public class SettingCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Setting/SettingListCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Setting/SettingListCliCommand.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Platforms.PowerPlatform;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Setting;
+
+/// <summary>
+/// <c>txc environment setting list</c> — lists environment management
+/// settings from the Power Platform control plane API.
+/// </summary>
+[CliCommand(
+    Name = "list",
+    Description = "List environment management settings (control plane)."
+)]
+public class SettingListCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(SettingListCliCommand));
+
+    [CliOption(Name = "--filter", Aliases = new[] { "-f" }, Description = "Show only settings whose name contains this substring.", Required = false)]
+    public string? Filter { get; set; }
+
+    [CliOption(Name = "--json", Description = "Emit the list as indented JSON instead of a text table.", Required = false)]
+    public bool Json { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        IReadOnlyList<EnvironmentManagementSetting> settings;
+        try
+        {
+            var service = TxcServices.Get<IEnvironmentManagementSettingsService>();
+            settings = await service.ListAsync(Profile, selectFilter: null, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment setting list failed");
+            return 1;
+        }
+
+        if (!string.IsNullOrWhiteSpace(Filter))
+        {
+            settings = settings
+                .Where(s => s.Name.Contains(Filter, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        if (Json)
+        {
+            var dict = settings.ToDictionary(s => s.Name, s => s.Value);
+            OutputWriter.WriteLine(JsonSerializer.Serialize(dict, JsonOptions));
+            return 0;
+        }
+
+        PrintSettingsTable(settings);
+        return 0;
+    }
+
+    private static void PrintSettingsTable(IReadOnlyList<EnvironmentManagementSetting> settings)
+    {
+        if (settings.Count == 0)
+        {
+            OutputWriter.WriteLine("No environment management settings found.");
+            return;
+        }
+
+        int nameWidth = Math.Clamp(settings.Max(s => s.Name.Length), 20, 60);
+        string header = $"{"Setting".PadRight(nameWidth)} | Value";
+        OutputWriter.WriteLine(header);
+        OutputWriter.WriteLine(new string('-', header.Length + 20));
+
+        foreach (var s in settings.OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            string name = s.Name.Length > nameWidth
+                ? s.Name[..(nameWidth - 1)] + "."
+                : s.Name;
+            string value = s.Value?.ToString() ?? "(null)";
+            OutputWriter.WriteLine($"{name.PadRight(nameWidth)} | {value}");
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+}

--- a/src/TALXIS.CLI.Features.Environment/Setting/SettingUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Setting/SettingUpdateCliCommand.cs
@@ -1,0 +1,52 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Platforms.PowerPlatform;
+using TALXIS.CLI.Features.Config.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Setting;
+
+/// <summary>
+/// <c>txc environment setting update</c> — updates a single environment
+/// management setting via the Power Platform control plane API.
+/// </summary>
+[CliCommand(
+    Name = "update",
+    Description = "Update an environment management setting (control plane)."
+)]
+public class SettingUpdateCliCommand : ProfiledCliCommand
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(SettingUpdateCliCommand));
+
+    [CliOption(Name = "--name", Aliases = new[] { "-n" }, Description = "Name of the setting to update (e.g. powerApps_AllowCodeApps).", Required = true)]
+    public required string Name { get; set; }
+
+    [CliOption(Name = "--value", Aliases = new[] { "-v" }, Description = "Value to set. Booleans (true/false) and integers are auto-coerced.", Required = true)]
+    public required string Value { get; set; }
+
+    public async Task<int> RunAsync()
+    {
+        try
+        {
+            var service = TxcServices.Get<IEnvironmentManagementSettingsService>();
+            await service.UpdateAsync(Profile, Name, Value, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            OutputWriter.WriteLine($"Setting '{Name}' updated to '{Value}'.");
+            return 0;
+        }
+        catch (Exception ex) when (ex is ConfigurationResolutionException or InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogError("{Error}", ex.Message);
+            return 1;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "environment setting update failed");
+            return 1;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
@@ -88,6 +88,7 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
             request.EnvironmentUrl,
             cloud,
             organizationId: null,
+            environmentId: names.EnvironmentId?.ToString(),
             tenantId: request.TenantId ?? acquired.TenantId,
             description: request.Description,
             ct).ConfigureAwait(false);
@@ -98,7 +99,7 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
         return new ProfileBootstrapResult(names.ProfileName, acquired.Credential, upsert.Connection, acquired.Upn, null);
     }
 
-    private sealed record BindingNames(string ProfileName, string ConnectionName);
+    private sealed record BindingNames(string ProfileName, string ConnectionName, Guid? EnvironmentId = null);
 
     private async Task<BindingNames?> ResolveBindingNamesAsync(
         ProfileBootstrapRequest request,
@@ -120,6 +121,7 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
             return new BindingNames(existingProfile.Id, existingProfile.ConnectionRef!);
 
         string? preferredBase = null;
+        Guid? resolvedEnvironmentId = null;
         var ephemeralConnection = new Connection
         {
             Id = "(ephemeral)",
@@ -135,7 +137,10 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 .TryGetByEnvironmentUrlAsync(ephemeralConnection, acquired.Credential, environmentUrl, ct)
                 .ConfigureAwait(false);
             if (environment is not null)
+            {
                 preferredBase = ProviderUrlResolver.DeriveDefaultName(environment.DisplayName, request.EnvironmentUrl);
+                resolvedEnvironmentId = environment.EnvironmentId;
+            }
         }
         catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
         {
@@ -157,7 +162,7 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                     await _profiles.GetAsync(candidate, existsCt).ConfigureAwait(false) is not null,
                 ct).ConfigureAwait(false);
 
-            return new BindingNames(profileName, existingConnection.Id);
+            return new BindingNames(profileName, existingConnection.Id, resolvedEnvironmentId);
         }
 
         // Keep profile + connection names aligned so the mental model is
@@ -169,7 +174,7 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 || await _connectionStore.GetAsync(candidate, existsCt).ConfigureAwait(false) is not null,
             ct).ConfigureAwait(false);
 
-        return new BindingNames(sharedName, sharedName);
+        return new BindingNames(sharedName, sharedName, resolvedEnvironmentId);
     }
 
     private async Task<Connection?> FindExistingConnectionAsync(

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
@@ -50,6 +50,9 @@ public static class DataverseProviderServiceCollectionExtensions
         services.AddSingleton<IAccessTokenService>(sp => sp.GetRequiredService<DataverseAccessTokenService>());
         services.AddSingleton<IDataverseConnectionFactory, DataverseConnectionFactory>();
         services.AddSingleton<IPowerPlatformEnvironmentCatalog, PowerPlatformEnvironmentCatalog>();
+        services.AddSingleton<EnvironmentManagementSettingsClient>();
+        services.AddSingleton<TALXIS.CLI.Core.Platforms.PowerPlatform.IEnvironmentManagementSettingsService,
+            EnvironmentManagementSettingsService>();
         services.AddSingleton<IDataverseLiveChecker, DataverseLiveChecker>();
         services.AddSingleton<IInteractiveLoginService, DataverseInteractiveLoginService>();
         services.AddSingleton<TALXIS.CLI.Core.Bootstrapping.IConnectionProviderBootstrapper,

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsClient.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsClient.cs
@@ -1,0 +1,165 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Core.Platforms.PowerPlatform;
+
+namespace TALXIS.CLI.Platform.PowerPlatform.Control;
+
+/// <summary>
+/// Low-level HTTP client for the Power Platform environment management
+/// settings API (<c>api.powerplatform.com/environmentmanagement</c>).
+/// Stateless — callers supply connection, credential, and environment ID.
+/// </summary>
+public sealed class EnvironmentManagementSettingsClient
+{
+    private const string ApiVersion = "2022-03-01-preview";
+    private static readonly Uri PowerPlatformApiAudience = new("https://api.powerplatform.com/");
+
+    private readonly IAccessTokenService _tokens;
+    private readonly IHttpClientFactoryWrapper _httpFactory;
+
+    public EnvironmentManagementSettingsClient(
+        IAccessTokenService tokens,
+        IHttpClientFactoryWrapper? httpFactory = null)
+    {
+        _tokens = tokens ?? throw new ArgumentNullException(nameof(tokens));
+        _httpFactory = httpFactory ?? DefaultHttpClientFactoryWrapper.Instance;
+    }
+
+    /// <summary>
+    /// GET environment management settings. Returns flattened name-value
+    /// pairs from the first item in the <c>objectResult</c> array.
+    /// </summary>
+    public async Task<IReadOnlyList<EnvironmentManagementSetting>> ListAsync(
+        Connection connection,
+        Credential credential,
+        Guid environmentId,
+        string? selectFilter,
+        CancellationToken ct)
+    {
+        var baseUri = GetBaseUri(connection.Cloud ?? CloudInstance.Public);
+        var url = $"{baseUri}environmentmanagement/environments/{environmentId}/settings?api-version={ApiVersion}";
+        if (!string.IsNullOrWhiteSpace(selectFilter))
+            url += $"&$select={Uri.EscapeDataString(selectFilter)}";
+
+        var token = await _tokens.AcquireForResourceAsync(connection, credential, PowerPlatformApiAudience, ct)
+            .ConfigureAwait(false);
+
+        using var http = _httpFactory.Create();
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        using var response = await http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct)
+            .ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Environment management settings GET failed ({(int)response.StatusCode} {response.ReasonPhrase}): {Truncate(body, 500)}");
+
+        return ParseListResponse(body);
+    }
+
+    /// <summary>
+    /// PATCH a single environment management setting.
+    /// </summary>
+    public async Task UpdateAsync(
+        Connection connection,
+        Credential credential,
+        Guid environmentId,
+        string settingName,
+        string value,
+        CancellationToken ct)
+    {
+        var baseUri = GetBaseUri(connection.Cloud ?? CloudInstance.Public);
+        var url = $"{baseUri}environmentmanagement/environments/{environmentId}/settings?api-version={ApiVersion}";
+
+        var token = await _tokens.AcquireForResourceAsync(connection, credential, PowerPlatformApiAudience, ct)
+            .ConfigureAwait(false);
+
+        var payload = new JsonObject { [settingName] = CoerceValue(value) };
+
+        using var http = _httpFactory.Create();
+        using var request = new HttpRequestMessage(HttpMethod.Patch, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+
+        using var response = await http.SendAsync(request, HttpCompletionOption.ResponseContentRead, ct)
+            .ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Environment management settings PATCH failed ({(int)response.StatusCode} {response.ReasonPhrase}): {Truncate(body, 500)}");
+    }
+
+    /// <summary>
+    /// Parses the <c>GetEnvironmentManagementSettingResponse</c> envelope and
+    /// flattens the first <c>objectResult</c> item into name-value pairs.
+    /// Skips <c>id</c> and <c>tenantId</c> since they are identifiers, not settings.
+    /// </summary>
+    internal static IReadOnlyList<EnvironmentManagementSetting> ParseListResponse(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (!root.TryGetProperty("objectResult", out var objectResult)
+            || objectResult.ValueKind != JsonValueKind.Array)
+        {
+            return Array.Empty<EnvironmentManagementSetting>();
+        }
+
+        var settings = new List<EnvironmentManagementSetting>();
+        foreach (var item in objectResult.EnumerateArray())
+        {
+            foreach (var prop in item.EnumerateObject())
+            {
+                // Skip envelope identifiers — they are not settings.
+                if (prop.Name is "id" or "tenantId")
+                    continue;
+
+                object? value = prop.Value.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Number => prop.Value.TryGetInt32(out var i) ? i : prop.Value.GetDouble(),
+                    JsonValueKind.String => prop.Value.GetString(),
+                    JsonValueKind.Null => null,
+                    _ => prop.Value.GetRawText(),
+                };
+
+                settings.Add(new EnvironmentManagementSetting(prop.Name, value));
+            }
+        }
+
+        return settings;
+    }
+
+    /// <summary>
+    /// Auto-coerces a string value to the appropriate <see cref="JsonNode"/>
+    /// type: <c>true</c>/<c>false</c> → bool, numeric → int, else string.
+    /// </summary>
+    internal static JsonNode CoerceValue(string value)
+    {
+        if (bool.TryParse(value, out var b))
+            return JsonValue.Create(b);
+        if (int.TryParse(value, out var i))
+            return JsonValue.Create(i);
+        return JsonValue.Create(value)!;
+    }
+
+    private static Uri GetBaseUri(CloudInstance cloud) => cloud switch
+    {
+        CloudInstance.Public or CloudInstance.Gcc => new Uri("https://api.powerplatform.com/"),
+        _ => throw new NotSupportedException(
+            $"Environment management settings API is not wired for cloud '{cloud}' in this release."),
+    };
+
+    private static string Truncate(string s, int max)
+        => string.IsNullOrEmpty(s) ? string.Empty : (s.Length <= max ? s : s[..max] + "...");
+}

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsClient.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsClient.cs
@@ -114,27 +114,34 @@ public sealed class EnvironmentManagementSettingsClient
             return Array.Empty<EnvironmentManagementSetting>();
         }
 
-        var settings = new List<EnvironmentManagementSetting>();
-        foreach (var item in objectResult.EnumerateArray())
+        var items = objectResult.EnumerateArray();
+        if (!items.MoveNext() || items.Current.ValueKind != JsonValueKind.Object)
         {
-            foreach (var prop in item.EnumerateObject())
+            return Array.Empty<EnvironmentManagementSetting>();
+        }
+
+        // The API contract for this method is to flatten settings from the first
+        // objectResult entry only. Ignore any additional array entries to avoid
+        // merging unrelated properties into a single settings collection.
+        var firstItem = items.Current;
+        var settings = new List<EnvironmentManagementSetting>();
+        foreach (var prop in firstItem.EnumerateObject())
+        {
+            // Skip envelope identifiers — they are not settings.
+            if (prop.Name is "id" or "tenantId")
+                continue;
+
+            object? value = prop.Value.ValueKind switch
             {
-                // Skip envelope identifiers — they are not settings.
-                if (prop.Name is "id" or "tenantId")
-                    continue;
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Number => prop.Value.TryGetInt32(out var i) ? i : prop.Value.GetDouble(),
+                JsonValueKind.String => prop.Value.GetString(),
+                JsonValueKind.Null => null,
+                _ => prop.Value.GetRawText(),
+            };
 
-                object? value = prop.Value.ValueKind switch
-                {
-                    JsonValueKind.True => true,
-                    JsonValueKind.False => false,
-                    JsonValueKind.Number => prop.Value.TryGetInt32(out var i) ? i : prop.Value.GetDouble(),
-                    JsonValueKind.String => prop.Value.GetString(),
-                    JsonValueKind.Null => null,
-                    _ => prop.Value.GetRawText(),
-                };
-
-                settings.Add(new EnvironmentManagementSetting(prop.Name, value));
-            }
+            settings.Add(new EnvironmentManagementSetting(prop.Name, value));
         }
 
         return settings;

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsService.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementSettingsService.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Core.Platforms.PowerPlatform;
+
+namespace TALXIS.CLI.Platform.PowerPlatform.Control;
+
+/// <summary>
+/// Implements <see cref="IEnvironmentManagementSettingsService"/> by resolving
+/// the caller's profile, looking up (or lazily resolving) the environment
+/// GUID, and delegating to <see cref="EnvironmentManagementSettingsClient"/>.
+/// </summary>
+public sealed class EnvironmentManagementSettingsService : IEnvironmentManagementSettingsService
+{
+    private readonly IConfigurationResolver _resolver;
+    private readonly EnvironmentManagementSettingsClient _client;
+    private readonly IPowerPlatformEnvironmentCatalog _catalog;
+    private readonly ILogger<EnvironmentManagementSettingsService> _logger;
+
+    public EnvironmentManagementSettingsService(
+        IConfigurationResolver resolver,
+        EnvironmentManagementSettingsClient client,
+        IPowerPlatformEnvironmentCatalog catalog,
+        ILogger<EnvironmentManagementSettingsService>? logger = null)
+    {
+        _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _logger = logger ?? NullLogger<EnvironmentManagementSettingsService>.Instance;
+    }
+
+    public async Task<IReadOnlyList<EnvironmentManagementSetting>> ListAsync(
+        string? profileName, string? selectFilter, CancellationToken ct)
+    {
+        var ctx = await _resolver.ResolveAsync(profileName, ct).ConfigureAwait(false);
+        var envId = await ResolveEnvironmentIdAsync(ctx, ct).ConfigureAwait(false);
+
+        _logger.LogDebug("Listing environment management settings for environment {EnvironmentId}.", envId);
+        return await _client.ListAsync(ctx.Connection, ctx.Credential, envId, selectFilter, ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(
+        string? profileName, string settingName, string value, CancellationToken ct)
+    {
+        var ctx = await _resolver.ResolveAsync(profileName, ct).ConfigureAwait(false);
+        var envId = await ResolveEnvironmentIdAsync(ctx, ct).ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "Updating environment management setting '{Setting}' to '{Value}' for environment {EnvironmentId}.",
+            settingName, value, envId);
+        await _client.UpdateAsync(ctx.Connection, ctx.Credential, envId, settingName, value, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Returns the environment GUID from the connection if stored, otherwise
+    /// resolves it via <see cref="IPowerPlatformEnvironmentCatalog"/> using
+    /// the environment URL.
+    /// </summary>
+    private async Task<Guid> ResolveEnvironmentIdAsync(ResolvedProfileContext ctx, CancellationToken ct)
+    {
+        if (ctx.Connection.EnvironmentId.HasValue)
+            return ctx.Connection.EnvironmentId.Value;
+
+        if (string.IsNullOrWhiteSpace(ctx.Connection.EnvironmentUrl))
+            throw new InvalidOperationException(
+                $"Connection '{ctx.Connection.Id}' has no EnvironmentUrl or EnvironmentId. " +
+                "Cannot resolve the Power Platform environment for the control plane API.");
+
+        if (!Uri.TryCreate(ctx.Connection.EnvironmentUrl, UriKind.Absolute, out var envUri))
+            throw new InvalidOperationException(
+                $"Connection '{ctx.Connection.Id}' EnvironmentUrl '{ctx.Connection.EnvironmentUrl}' is not a valid URI.");
+
+        _logger.LogInformation(
+            "EnvironmentId not stored on connection '{ConnectionId}'. Resolving via Power Platform catalog...",
+            ctx.Connection.Id);
+
+        var env = await _catalog
+            .TryGetByEnvironmentUrlAsync(ctx.Connection, ctx.Credential, envUri, ct)
+            .ConfigureAwait(false);
+
+        if (env is null)
+            throw new InvalidOperationException(
+                $"Could not resolve Power Platform environment for URL '{ctx.Connection.EnvironmentUrl}'. " +
+                "Set --environment-id on the connection or verify the URL.");
+
+        _logger.LogInformation(
+            "Resolved EnvironmentId {EnvironmentId} for '{EnvironmentUrl}'. " +
+            "Consider running 'txc config connection create' with --environment-id to avoid this lookup.",
+            env.EnvironmentId, ctx.Connection.EnvironmentUrl);
+
+        return env.EnvironmentId;
+    }
+}

--- a/tests/TALXIS.CLI.Tests/Config/Providers/PowerPlatform/EnvironmentManagementSettingsClientTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Providers/PowerPlatform/EnvironmentManagementSettingsClientTests.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using System.Text.Json.Nodes;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Platform.PowerPlatform.Control;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Config.Providers.PowerPlatform;
+
+public sealed class EnvironmentManagementSettingsClientTests
+{
+    #region ParseListResponse
+
+    [Fact]
+    public void ParseListResponse_NormalResponse_ReturnsFlattenedSettings()
+    {
+        var json = """
+        {
+            "objectResult": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "tenantId": "00000000-0000-0000-0000-000000000002",
+                    "isGroupCreationEnabled": true,
+                    "maxRetryCount": 5,
+                    "displayName": "Contoso"
+                }
+            ]
+        }
+        """;
+
+        var result = EnvironmentManagementSettingsClient.ParseListResponse(json);
+
+        Assert.Equal(3, result.Count);
+
+        var byName = result.ToDictionary(s => s.Name, s => s.Value);
+        Assert.True((bool)byName["isGroupCreationEnabled"]!);
+        Assert.Equal(5.0, (double)byName["maxRetryCount"]!);
+        Assert.Equal("Contoso", (string)byName["displayName"]!);
+    }
+
+    [Fact]
+    public void ParseListResponse_EmptyObjectResultArray_ReturnsEmpty()
+    {
+        var json = """{ "objectResult": [] }""";
+
+        var result = EnvironmentManagementSettingsClient.ParseListResponse(json);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseListResponse_MissingObjectResult_ReturnsEmpty()
+    {
+        var json = """{ "someOtherProperty": 42 }""";
+
+        var result = EnvironmentManagementSettingsClient.ParseListResponse(json);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ParseListResponse_SkipsEnvelopeProperties()
+    {
+        var json = """
+        {
+            "objectResult": [
+                {
+                    "id": "envelope-id",
+                    "tenantId": "envelope-tenant",
+                    "someSetting": "value"
+                }
+            ]
+        }
+        """;
+
+        var result = EnvironmentManagementSettingsClient.ParseListResponse(json);
+
+        Assert.Single(result);
+        Assert.Equal("someSetting", result[0].Name);
+        Assert.DoesNotContain(result, s => s.Name == "id");
+        Assert.DoesNotContain(result, s => s.Name == "tenantId");
+    }
+
+    [Fact]
+    public void ParseListResponse_OnlyProcessesFirstItem()
+    {
+        // Second array entry has a property that should NOT appear in results.
+        var json = """
+        {
+            "objectResult": [
+                {
+                    "settingA": true
+                },
+                {
+                    "settingB": false
+                }
+            ]
+        }
+        """;
+
+        var result = EnvironmentManagementSettingsClient.ParseListResponse(json);
+
+        Assert.Single(result);
+        Assert.Equal("settingA", result[0].Name);
+        Assert.DoesNotContain(result, s => s.Name == "settingB");
+    }
+
+    #endregion
+
+    #region CoerceValue
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    public void CoerceValue_BooleanStrings_ReturnsBoolNode(string input, bool expected)
+    {
+        var node = EnvironmentManagementSettingsClient.CoerceValue(input);
+
+        Assert.Equal(expected, node.GetValue<bool>());
+    }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("42", 42)]
+    [InlineData("-1", -1)]
+    public void CoerceValue_IntegerStrings_ReturnsIntNode(string input, int expected)
+    {
+        var node = EnvironmentManagementSettingsClient.CoerceValue(input);
+
+        Assert.Equal(expected, node.GetValue<int>());
+    }
+
+    [Theory]
+    [InlineData("hello")]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    public void CoerceValue_PlainStrings_ReturnsStringNode(string input)
+    {
+        var node = EnvironmentManagementSettingsClient.CoerceValue(input);
+
+        Assert.Equal(input, node.GetValue<string>());
+    }
+
+    #endregion
+
+    #region ListAsync round-trip
+
+    [Fact]
+    public async Task ListAsync_RoundTrip_ParsesResponseCorrectly()
+    {
+        var responseJson = """
+        {
+            "objectResult": [
+                {
+                    "id": "env-id",
+                    "tenantId": "tenant-id",
+                    "isFeatureEnabled": true,
+                    "maxItems": 100,
+                    "label": "test-label"
+                }
+            ]
+        }
+        """;
+
+        var tokens = new FakeAccessTokenService();
+        var http = new FakeHttpClientFactoryWrapper(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseJson)
+        });
+
+        var sut = new EnvironmentManagementSettingsClient(tokens, http);
+
+        var result = await sut.ListAsync(
+            new Connection
+            {
+                Id = "conn",
+                Provider = ProviderKind.Dataverse,
+                EnvironmentUrl = "https://contoso.crm.dynamics.com/",
+                Cloud = CloudInstance.Public,
+            },
+            new Credential
+            {
+                Id = "cred",
+                Kind = CredentialKind.InteractiveBrowser,
+            },
+            Guid.NewGuid(),
+            selectFilter: null,
+            CancellationToken.None);
+
+        // id and tenantId should be excluded
+        Assert.Equal(3, result.Count);
+
+        var byName = result.ToDictionary(s => s.Name, s => s.Value);
+        Assert.True((bool)byName["isFeatureEnabled"]!);
+        Assert.Equal(100.0, (double)byName["maxItems"]!);
+        Assert.Equal("test-label", (string)byName["label"]!);
+    }
+
+    #endregion
+
+    #region Test doubles
+
+    private sealed class FakeAccessTokenService : IAccessTokenService
+    {
+        public Task<string> AcquireForResourceAsync(Connection connection, Credential credential, Uri resourceUri, CancellationToken ct)
+            => Task.FromResult("fake-token");
+    }
+
+    private sealed class FakeHttpClientFactoryWrapper : IHttpClientFactoryWrapper
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpClientFactoryWrapper(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        public HttpClient Create() => new(new FakeHttpMessageHandler(_handler));
+    }
+
+    private sealed class FakeHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _handler;
+
+        public FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            _handler = handler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_handler(request));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Adds `txc environment setting list` and `txc environment setting update` commands for managing Power Platform environment settings via the Environment Management API.

### New CLI commands
- `txc environment setting list [--filter <name>] [--json] [--profile <p>]`
- `txc environment setting update --name <setting> --value <value> [--profile <p>]`

### Changes
- **6 new files**: `IEnvironmentManagementSettingsService` interface + DTO, `EnvironmentManagementSettingsClient` (HTTP client for `api.powerplatform.com/environmentmanagement`), `EnvironmentManagementSettingsService`, and 3 CLI command classes
- **7 modified files**: Added `Guid? EnvironmentId` to `Connection` model, `--environment-id` CLI option, auto-populate EnvironmentId from catalog during bootstrap, DI registrations

### Notes
- Branch rebased onto master (original 4 commits were already merged via PRs #14 and #15)
- All 439 tests pass, solution builds cleanly