### PR TITLE
feat: token expiration mitigation, config model improvements, and production environment protection

### DIFF
--- a/src/TALXIS.CLI.Core/Abstractions/IEnvironmentTypeResolver.cs
+++ b/src/TALXIS.CLI.Core/Abstractions/IEnvironmentTypeResolver.cs
@@ -1,0 +1,20 @@
+using TALXIS.CLI.Core.Model;
+
+namespace TALXIS.CLI.Core.Abstractions;
+
+/// <summary>
+/// Resolves the current environment type (Production, Sandbox, etc.) for a
+/// connection by querying the provider's control plane API. Implemented by
+/// each platform adapter (Dataverse → Power Platform admin API, etc.).
+/// </summary>
+public interface IEnvironmentTypeResolver
+{
+    /// <summary>
+    /// Queries the control plane for the environment type and updates the
+    /// connection's <see cref="Connection.EnvironmentType"/> (and related
+    /// metadata like <see cref="Connection.DisplayName"/>) in-place.
+    /// Persists the updated connection to the store.
+    /// Returns the resolved environment type, or null if the lookup failed.
+    /// </summary>
+    Task<EnvironmentType?> RefreshAsync(Connection connection, Credential credential, CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
@@ -41,7 +41,9 @@ public sealed class ConnectionUpsertService
         string? environmentId,
         string? tenantId,
         string? description,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? displayName = null,
+        EnvironmentType? environmentType = null)
     {
         var trimmed = name?.Trim();
         if (string.IsNullOrEmpty(trimmed))
@@ -77,16 +79,24 @@ public sealed class ConnectionUpsertService
             parsedEnvironmentId = eid;
         }
 
+        // Check if a connection already exists to preserve CreatedAt.
+        var existing = await _store.GetAsync(trimmed!, ct).ConfigureAwait(false);
+        var now = DateTimeOffset.UtcNow;
+
         var connection = new Connection
         {
             Id = trimmed!,
             Provider = provider,
-            Description = description,
+            Description = description ?? displayName,
             EnvironmentUrl = envUri.ToString().TrimEnd('/'),
             Cloud = cloud ?? CloudInstance.Public,
             OrganizationId = organizationId,
             EnvironmentId = parsedEnvironmentId,
             TenantId = tenantId,
+            DisplayName = displayName,
+            EnvironmentType = environmentType,
+            CreatedAt = existing?.CreatedAt ?? now,
+            UpdatedAt = now,
         };
 
         await _store.UpsertAsync(connection, ct).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Core/Bootstrapping/InteractiveCredentialBootstrapper.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/InteractiveCredentialBootstrapper.cs
@@ -56,7 +56,8 @@ public static class InteractiveCredentialBootstrapper
                 : explicitAlias!.Trim();
         }
 
-        var credential = existing ?? new Credential();
+        var now = DateTimeOffset.UtcNow;
+        var credential = existing ?? new Credential { CreatedAt = now };
         credential.Id = alias;
         credential.Kind = CredentialKind.InteractiveBrowser;
         credential.TenantId = result.TenantId;
@@ -69,6 +70,7 @@ public static class InteractiveCredentialBootstrapper
             : result.AccountId;
         credential.InteractiveUpn = result.Upn;
         credential.Description = $"Interactive sign-in ({result.Upn})";
+        credential.UpdatedAt = now;
 
         await store.UpsertAsync(credential, ct).ConfigureAwait(false);
         return new InteractiveCredentialResult(credential, result.Upn, result.TenantId);

--- a/src/TALXIS.CLI.Core/Bootstrapping/ProviderUrlResolver.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/ProviderUrlResolver.cs
@@ -64,37 +64,46 @@ public static class ProviderUrlResolver
 
     /// <summary>
     /// Derives a default profile/connection name from the Power Platform
-    /// environment display name plus the URL host's first DNS label. When
-    /// no display name is available, falls back to the first DNS label only.
-    /// Names are lowercased, non-alphanumeric runs collapse to <c>-</c>, and
-    /// the result is capped at 64 characters.
+    /// environment display name, URL host, and tenant domain. The result
+    /// includes the tenant short name so multi-customer users can
+    /// distinguish environments across tenants at a glance. Names are
+    /// lowercased, non-alphanumeric runs collapse to <c>-</c>, and the
+    /// result is capped at 64 characters.
     /// </summary>
-    public static string? DeriveDefaultName(string? environmentDisplayName, string? url)
+    /// <example>
+    /// <c>DeriveDefaultName("TALXIS Dev", "https://org123.crm4.dynamics.com", "contoso")</c>
+    /// → <c>"talxis-dev-contoso"</c>
+    /// </example>
+    public static string? DeriveDefaultName(string? environmentDisplayName, string? url, string? tenantDomain = null)
     {
         var hostSlug = DeriveHostSlug(url);
         var displaySlug = Slugify(environmentDisplayName);
+        var tenantSlug = Slugify(tenantDomain);
 
-        if (string.IsNullOrEmpty(displaySlug))
-            return hostSlug;
-        if (string.IsNullOrEmpty(hostSlug))
-            return displaySlug;
-        if (string.Equals(displaySlug, hostSlug, StringComparison.Ordinal))
-            return displaySlug;
-        if (displaySlug.Split('-', StringSplitOptions.RemoveEmptyEntries)
-            .Contains(hostSlug, StringComparer.Ordinal))
-            return TruncateSlug(displaySlug);
+        // Build the base slug from display name or host.
+        string? baseSlug;
+        if (!string.IsNullOrEmpty(displaySlug))
+        {
+            baseSlug = displaySlug;
+        }
+        else
+        {
+            baseSlug = hostSlug;
+        }
 
-        var maxDisplayLength = MaxDefaultNameLength - hostSlug.Length - 1;
-        if (maxDisplayLength <= 0)
-            return TruncateSlug(hostSlug);
+        if (string.IsNullOrEmpty(baseSlug))
+            return null;
 
-        var displayPrefix = displaySlug.Length <= maxDisplayLength
-            ? displaySlug
-            : TrimTrailingDash(displaySlug[..maxDisplayLength]);
+        // Append tenant domain if available and not already part of the slug.
+        if (!string.IsNullOrEmpty(tenantSlug)
+            && !baseSlug.Split('-', StringSplitOptions.RemoveEmptyEntries)
+                .Contains(tenantSlug, StringComparer.Ordinal))
+        {
+            var combined = $"{baseSlug}-{tenantSlug}";
+            return TruncateSlug(combined);
+        }
 
-        return string.IsNullOrEmpty(displayPrefix)
-            ? TruncateSlug(hostSlug)
-            : $"{displayPrefix}-{hostSlug}";
+        return TruncateSlug(baseSlug);
     }
 
     /// <summary>

--- a/src/TALXIS.CLI.Core/Identity/MsalTokenCacheBinder.cs
+++ b/src/TALXIS.CLI.Core/Identity/MsalTokenCacheBinder.cs
@@ -9,10 +9,15 @@ using TALXIS.CLI.Core.Vault;
 namespace TALXIS.CLI.Core.Identity;
 
 /// <summary>
-/// Holds the process-wide <see cref="MsalCacheHelper"/> for the MSAL token
-/// cache file (<c>txc.msal.tokens.v1.dat</c>). Keeping this as a DI singleton
-/// is critical on macOS: every new helper instantiation is an additional
-/// Keychain prompt (see <c>session/files/keychain-prompt-research.md</c>).
+/// Holds the process-wide <see cref="MsalCacheHelper"/> instances for the MSAL
+/// token cache files. Two separate caches are maintained:
+/// <list type="bullet">
+///   <item><c>txc.msal.tokens.v1.dat</c> — user (public client) tokens with refresh tokens</item>
+///   <item><c>txc.msal.spn-tokens.v1.dat</c> — confidential client (SPN) app tokens</item>
+/// </list>
+/// Keeping this as a DI singleton is critical on macOS: every new helper
+/// instantiation is an additional Keychain prompt (see
+/// <c>session/files/keychain-prompt-research.md</c>).
 /// </summary>
 /// <remarks>
 /// This binder is distinct from <see cref="Vault.MsalBackedCredentialVault"/>:
@@ -23,22 +28,24 @@ namespace TALXIS.CLI.Core.Identity;
 public sealed class MsalTokenCacheBinder : ITokenCacheStore
 {
     private readonly MsalCacheHelper _helper;
+    private readonly MsalCacheHelper? _spnHelper;
 
     /// <summary>Diagnostic hook for tests.</summary>
     internal MsalCacheHelper Helper => _helper;
 
     public bool UsesPlaintextFallback { get; }
 
-    private MsalTokenCacheBinder(MsalCacheHelper helper, bool usesPlaintextFallback)
+    private MsalTokenCacheBinder(MsalCacheHelper helper, MsalCacheHelper? spnHelper, bool usesPlaintextFallback)
     {
         _helper = helper;
+        _spnHelper = spnHelper;
         UsesPlaintextFallback = usesPlaintextFallback;
     }
 
     /// <summary>
-    /// Attach the shared MSAL token cache to a newly-built public- or
-    /// confidential-client application. Safe to call many times across clients
-    /// — the underlying helper is shared.
+    /// Attach the shared MSAL user token cache to a newly-built public-client
+    /// application. Safe to call many times across clients — the underlying
+    /// helper is shared.
     /// </summary>
     public void Attach(Microsoft.Identity.Client.ITokenCache cache)
     {
@@ -47,11 +54,25 @@ public sealed class MsalTokenCacheBinder : ITokenCacheStore
     }
 
     /// <summary>
-    /// Clears the persisted MSAL token cache file for txc.
+    /// Attach the shared MSAL app token cache to a newly-built confidential-client
+    /// application. Uses a separate cache file (<c>txc.msal.spn-tokens.v1.dat</c>)
+    /// so SPN tokens persist across CLI invocations independently of user tokens.
+    /// Falls back to the user cache helper if the SPN cache was not initialized.
+    /// </summary>
+    public void AttachAppCache(Microsoft.Identity.Client.ITokenCache appTokenCache)
+    {
+        ArgumentNullException.ThrowIfNull(appTokenCache);
+        var helper = _spnHelper ?? _helper;
+        helper.RegisterCache(appTokenCache);
+    }
+
+    /// <summary>
+    /// Clears the persisted MSAL token cache files for txc.
     /// </summary>
     public void Clear()
     {
         _helper.Clear();
+        _spnHelper?.Clear();
     }
 
     public static async Task<MsalTokenCacheBinder> CreateAsync(
@@ -66,7 +87,21 @@ public sealed class MsalTokenCacheBinder : ITokenCacheStore
 
         var options = VaultOptions.MsalTokenCache(env);
         var helper = await MsalCacheHelperFactory.CreateAsync(options, paths, logger, ct).ConfigureAwait(false);
-        return new MsalTokenCacheBinder(helper, options.UsePlaintextFallback);
+
+        // SPN cache is best-effort — if it fails (e.g. Keychain issues),
+        // fall back to the user cache helper for app tokens too.
+        MsalCacheHelper? spnHelper = null;
+        try
+        {
+            var spnOptions = VaultOptions.MsalSpnTokenCache(env);
+            spnHelper = await MsalCacheHelperFactory.CreateAsync(spnOptions, paths, logger, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to create SPN token cache; confidential-client tokens will share the user cache file.");
+        }
+
+        return new MsalTokenCacheBinder(helper, spnHelper, options.UsePlaintextFallback);
     }
 
     /// <summary>Test-only factory that accepts an explicit <see cref="VaultOptions"/>.</summary>
@@ -81,6 +116,6 @@ public sealed class MsalTokenCacheBinder : ITokenCacheStore
         logger ??= NullLogger<MsalTokenCacheBinder>.Instance;
 
         var helper = await MsalCacheHelperFactory.CreateAsync(options, paths, logger, ct).ConfigureAwait(false);
-        return new MsalTokenCacheBinder(helper, options.UsePlaintextFallback);
+        return new MsalTokenCacheBinder(helper, spnHelper: null, options.UsePlaintextFallback);
     }
 }

--- a/src/TALXIS.CLI.Core/Model/Connection.cs
+++ b/src/TALXIS.CLI.Core/Model/Connection.cs
@@ -30,6 +30,29 @@ public sealed class Connection
     public CloudInstance? Cloud { get; set; }
     public string? TenantId { get; set; }
 
+    /// <summary>
+    /// Human-readable environment display name from the Power Platform catalog.
+    /// Populated during bootstrap or live-check. Used as the primary source for
+    /// connection/profile slug derivation.
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Power Platform environment lifecycle type (<c>Production</c>,
+    /// <c>Sandbox</c>, <c>Trial</c>, <c>Developer</c>, <c>Default</c>).
+    /// Resolved from the Power Platform admin API's
+    /// <c>properties.environmentSku</c> field. When null, destructive
+    /// operations treat the environment as Production (fail-safe).
+    /// Can be overridden via <c>--environment-type</c> on connection create.
+    /// </summary>
+    public EnvironmentType? EnvironmentType { get; set; }
+
+    /// <summary>When the connection was first persisted.</summary>
+    public DateTimeOffset? CreatedAt { get; set; }
+
+    /// <summary>When the connection was last updated.</summary>
+    public DateTimeOffset? UpdatedAt { get; set; }
+
     /// <summary>Captured but unprocessed fields (forward-compat).</summary>
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? ExtraFields { get; set; }

--- a/src/TALXIS.CLI.Core/Model/Credential.cs
+++ b/src/TALXIS.CLI.Core/Model/Credential.cs
@@ -18,5 +18,28 @@ public sealed class Credential
 
     public string? CertificatePath { get; set; }
 
+    /// <summary>
+    /// Optional audience (resource) this credential targets, e.g.
+    /// <c>https://org.crm.dynamics.com</c>. When set, scopes can be
+    /// validated upfront and requested during interactive login to avoid
+    /// deferred consent failures with conditional access policies.
+    /// </summary>
+    public string? Audience { get; set; }
+
+    /// <summary>
+    /// Optional OIDC scopes the credential was consented for. When present,
+    /// used for token acquisition instead of deriving scopes dynamically
+    /// from the resource URI at runtime. Backward-compatible: existing
+    /// credentials without this field continue to work with dynamic scope
+    /// resolution.
+    /// </summary>
+    public string[]? Scopes { get; set; }
+
     public SecretRef? SecretRef { get; set; }
+
+    /// <summary>When the credential was first persisted.</summary>
+    public DateTimeOffset? CreatedAt { get; set; }
+
+    /// <summary>When the credential was last updated (e.g. re-login, secret rotation).</summary>
+    public DateTimeOffset? UpdatedAt { get; set; }
 }

--- a/src/TALXIS.CLI.Core/Model/EnvironmentType.cs
+++ b/src/TALXIS.CLI.Core/Model/EnvironmentType.cs
@@ -1,0 +1,21 @@
+namespace TALXIS.CLI.Core.Model;
+
+/// <summary>
+/// Power Platform environment lifecycle type. Determines whether
+/// destructive operations require explicit confirmation. Values match
+/// the <c>properties.environmentSku</c> field returned by the Power
+/// Platform admin API.
+/// </summary>
+public enum EnvironmentType
+{
+    /// <summary>Full production environment — destructive operations are blocked by default.</summary>
+    Production,
+    /// <summary>Sandbox environment — safe for testing, no destructive guard.</summary>
+    Sandbox,
+    /// <summary>Trial environment — time-limited, no destructive guard.</summary>
+    Trial,
+    /// <summary>Developer environment — single-user dev, no destructive guard.</summary>
+    Developer,
+    /// <summary>Default environment — auto-provisioned per tenant; treated as Production for safety.</summary>
+    Default,
+}

--- a/src/TALXIS.CLI.Core/Model/Profile.cs
+++ b/src/TALXIS.CLI.Core/Model/Profile.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace TALXIS.CLI.Core.Model;
 
 /// <summary>
@@ -10,4 +13,14 @@ public sealed class Profile
     public string ConnectionRef { get; set; } = string.Empty;
     public string CredentialRef { get; set; } = string.Empty;
     public string? Description { get; set; }
+
+    /// <summary>When the profile was first persisted.</summary>
+    public DateTimeOffset? CreatedAt { get; set; }
+
+    /// <summary>When the profile was last updated.</summary>
+    public DateTimeOffset? UpdatedAt { get; set; }
+
+    /// <summary>Captured but unprocessed fields (forward-compat).</summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? ExtraFields { get; set; }
 }

--- a/src/TALXIS.CLI.Core/Shared/ProfiledCliCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/ProfiledCliCommand.cs
@@ -1,4 +1,9 @@
+using System.Text.RegularExpressions;
 using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Model;
 
 namespace TALXIS.CLI.Core;
 
@@ -23,9 +28,26 @@ namespace TALXIS.CLI.Core;
 /// of this refactor: agent prompts only have to know "pass
 /// <c>--profile &lt;x&gt;</c> if you want a specific target" and every
 /// command behaves identically.
+/// <para>
+/// Commands annotated with <see cref="CliDestructiveAttribute"/>
+/// are blocked at runtime when the target environment is Production or
+/// Default (or unknown), unless <c>--allow-production</c> is passed.
+/// Detection uses both the API-reported <see cref="EnvironmentType"/> and
+/// name-based heuristics (keywords in DisplayName / EnvironmentUrl).
+/// </para>
 /// </remarks>
 public abstract class ProfiledCliCommand : TxcLeafCommand
 {
+    /// <summary>
+    /// Case-insensitive pattern matching production-related keywords in
+    /// environment display names and URL hostnames. Matches whole words
+    /// or common abbreviations like <c>prd</c>, <c>prod</c>, <c>production</c>,
+    /// <c>live</c>.
+    /// </summary>
+    private static readonly Regex ProductionNamePattern = new(
+        @"\b(prod|production|prd|live)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     [CliOption(
         Name = "--profile",
         Aliases = new[] { "-p" },
@@ -38,4 +60,78 @@ public abstract class ProfiledCliCommand : TxcLeafCommand
         Description = "Emit verbose logging for this invocation.",
         Required = false)]
     public bool Verbose { get; set; }
+
+    [CliOption(
+        Name = "--allow-production",
+        Description = "Allow destructive operations against Production or Default environments.",
+        Required = false)]
+    public bool AllowProduction { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> if the environment should be treated as production
+    /// based on its API-reported type OR name-based heuristics.
+    /// Null type (unknown) is treated as Production for fail-safe.
+    /// </summary>
+    public static bool IsProductionLike(EnvironmentType? envType, string? displayName = null, string? environmentUrl = null)
+    {
+        // API-reported type check.
+        if (envType is null or EnvironmentType.Production or EnvironmentType.Default)
+            return true;
+
+        // Name-based heuristic: check display name and URL hostname for
+        // production keywords even if the API type says Sandbox.
+        if (!string.IsNullOrWhiteSpace(displayName) && ProductionNamePattern.IsMatch(displayName))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(environmentUrl) &&
+            Uri.TryCreate(environmentUrl, UriKind.Absolute, out var uri) &&
+            ProductionNamePattern.IsMatch(uri.Host))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Pre-execution guard: blocks destructive commands against production-like
+    /// environments unless <c>--allow-production</c> is passed.
+    /// </summary>
+    protected override async Task<int?> PreExecuteAsync()
+    {
+        if (!Attribute.IsDefined(GetType(), typeof(CliDestructiveAttribute)))
+            return null;
+
+        try
+        {
+            var resolver = TxcServices.Get<IConfigurationResolver>();
+            var context = await resolver.ResolveAsync(Profile, CancellationToken.None).ConfigureAwait(false);
+            var connection = context.Connection;
+
+            if (!IsProductionLike(connection.EnvironmentType, connection.DisplayName, connection.EnvironmentUrl))
+                return null;
+
+            if (AllowProduction)
+            {
+                Logger.LogWarning(
+                    "Destructive operation allowed against {EnvType} environment '{ConnectionId}' ({Url}) via --allow-production.",
+                    connection.EnvironmentType?.ToString() ?? "Unknown",
+                    connection.Id,
+                    connection.EnvironmentUrl);
+                return null;
+            }
+
+            var envLabel = connection.DisplayName ?? connection.EnvironmentUrl ?? connection.Id;
+            var typeLabel = connection.EnvironmentType?.ToString() ?? "Unknown (treated as Production)";
+            Logger.LogError(
+                "Blocked: this is a destructive operation targeting {EnvType} environment '{EnvLabel}'. " +
+                "Pass --allow-production to confirm, or switch to a non-production profile.",
+                typeLabel, envLabel);
+            return ExitValidationError;
+        }
+        catch (ConfigurationResolutionException)
+        {
+            // If we can't resolve the profile, let ExecuteAsync handle it —
+            // it will produce a better error message.
+            return null;
+        }
+    }
 }

--- a/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
@@ -64,16 +64,26 @@ public abstract class TxcLeafCommand
         if (formatError.HasValue)
             return formatError.Value;
 
+        // Production guard runs first so users aren't prompted with --yes
+        // only to be immediately blocked for missing --allow-production.
+        try
+        {
+            var guardResult = await PreExecuteAsync().ConfigureAwait(false);
+            if (guardResult.HasValue)
+                return guardResult.Value;
+        }
+        catch (Exception ex) when (ex is Abstractions.ConfigurationResolutionException)
+        {
+            // If profile resolution fails in the guard, fall through — ExecuteAsync
+            // will produce a better error message.
+        }
+
         var confirmError = await CheckDestructiveConfirmationAsync().ConfigureAwait(false);
         if (confirmError.HasValue)
             return confirmError.Value;
 
         try
         {
-            var guardResult = await PreExecuteAsync().ConfigureAwait(false);
-            if (guardResult.HasValue)
-                return guardResult.Value;
-
             return await ExecuteAsync().ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is Abstractions.ConfigurationResolutionException)

--- a/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
@@ -70,6 +70,10 @@ public abstract class TxcLeafCommand
 
         try
         {
+            var guardResult = await PreExecuteAsync().ConfigureAwait(false);
+            if (guardResult.HasValue)
+                return guardResult.Value;
+
             return await ExecuteAsync().ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is Abstractions.ConfigurationResolutionException)
@@ -93,6 +97,14 @@ public abstract class TxcLeafCommand
             return ExitError;
         }
     }
+
+    /// <summary>
+    /// Pre-execution hook called before <see cref="ExecuteAsync"/>. Override
+    /// in derived base classes to add cross-cutting guards (e.g. production
+    /// environment protection). Return <c>null</c> to proceed, or an exit
+    /// code to short-circuit.
+    /// </summary>
+    protected virtual Task<int?> PreExecuteAsync() => Task.FromResult<int?>(null);
 
     /// <summary>
     /// Implement command logic here. Return <see cref="ExitSuccess"/>,

--- a/src/TALXIS.CLI.Core/Storage/ConnectionStore.cs
+++ b/src/TALXIS.CLI.Core/Storage/ConnectionStore.cs
@@ -31,6 +31,9 @@ public sealed class ConnectionStore : IConnectionStore
         try
         {
             var collection = await JsonFile.ReadOrDefaultAsync<ConnectionCollection>(_path, ct).ConfigureAwait(false);
+            var existing = collection.Connections.FirstOrDefault(c => string.Equals(c.Id, connection.Id, StringComparison.OrdinalIgnoreCase));
+            connection.CreatedAt ??= existing?.CreatedAt ?? DateTimeOffset.UtcNow;
+            connection.UpdatedAt = DateTimeOffset.UtcNow;
             collection.Connections.RemoveAll(c => string.Equals(c.Id, connection.Id, StringComparison.OrdinalIgnoreCase));
             collection.Connections.Add(connection);
             await JsonFile.WriteAtomicAsync(_path, collection, ct).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Core/Storage/CredentialStore.cs
+++ b/src/TALXIS.CLI.Core/Storage/CredentialStore.cs
@@ -31,6 +31,9 @@ public sealed class CredentialStore : ICredentialStore
         try
         {
             var collection = await JsonFile.ReadOrDefaultAsync<CredentialCollection>(_path, ct).ConfigureAwait(false);
+            var existing = collection.Credentials.FirstOrDefault(c => string.Equals(c.Id, credential.Id, StringComparison.OrdinalIgnoreCase));
+            credential.CreatedAt ??= existing?.CreatedAt ?? DateTimeOffset.UtcNow;
+            credential.UpdatedAt = DateTimeOffset.UtcNow;
             collection.Credentials.RemoveAll(c => string.Equals(c.Id, credential.Id, StringComparison.OrdinalIgnoreCase));
             collection.Credentials.Add(credential);
             await JsonFile.WriteAtomicAsync(_path, collection, ct).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Core/Storage/ProfileStore.cs
+++ b/src/TALXIS.CLI.Core/Storage/ProfileStore.cs
@@ -31,6 +31,9 @@ public sealed class ProfileStore : IProfileStore
         try
         {
             var collection = await JsonFile.ReadOrDefaultAsync<ProfileCollection>(_path, ct).ConfigureAwait(false);
+            var existing = collection.Profiles.FirstOrDefault(p => string.Equals(p.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
+            profile.CreatedAt ??= existing?.CreatedAt ?? DateTimeOffset.UtcNow;
+            profile.UpdatedAt = DateTimeOffset.UtcNow;
             collection.Profiles.RemoveAll(p => string.Equals(p.Id, profile.Id, StringComparison.OrdinalIgnoreCase));
             collection.Profiles.Add(profile);
             await JsonFile.WriteAtomicAsync(_path, collection, ct).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Core/Vault/VaultOptions.cs
+++ b/src/TALXIS.CLI.Core/Vault/VaultOptions.cs
@@ -89,6 +89,27 @@ public sealed record VaultOptions
     }
 
     /// <summary>
+    /// Options for the MSAL confidential-client (SPN) token cache
+    /// (<c>txc.msal.spn-tokens.v1.dat</c>). Separate from the user token cache
+    /// so that app-token lifetimes and blast radius are independent, matching
+    /// the PAC CLI layout (<c>tokencache_spn_msalv3.dat</c>).
+    /// </summary>
+    public static VaultOptions MsalSpnTokenCache(IEnvironmentReader env)
+    {
+        ArgumentNullException.ThrowIfNull(env);
+        var (plaintext, reason) = ResolvePlaintextOptIn(env);
+        return new VaultOptions
+        {
+            CacheFileName = "txc.msal.spn-tokens.v1.dat",
+            KeychainAccount = "msal-spn-tokens",
+            LinuxKeyringLabel = "TALXIS CLI MSAL SPN token cache",
+            LinuxCacheKind = "TXC_Msal_Spn_Token_Cache",
+            UsePlaintextFallback = plaintext,
+            PlaintextReason = reason,
+        };
+    }
+
+    /// <summary>
     /// Env var names honored to pick plaintext / file-based storage. Intentionally
     /// public so the (future) `--plaintext-fallback` flag can set the same value.
     /// </summary>

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthShowCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthShowCliCommand.cs
@@ -3,14 +3,16 @@ using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
 using TALXIS.CLI.Core.Abstractions;
 using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Model;
 using TALXIS.CLI.Logging;
 
 namespace TALXIS.CLI.Features.Config.Auth;
 
 /// <summary>
 /// <c>txc config auth show &lt;alias&gt;</c> — prints one credential's
-/// non-secret fields as JSON. Exit code 2 if the alias is not found so
-/// scripts can distinguish "missing" from "internal error" (1).
+/// non-secret fields as JSON, plus optional token health diagnostics.
+/// Exit code 2 if the alias is not found so scripts can distinguish
+/// "missing" from "internal error" (1).
 /// </summary>
 [CliReadOnly]
 [CliCommand(
@@ -24,6 +26,9 @@ public class AuthShowCliCommand : TxcLeafCommand
 
     [CliArgument(Description = "Credential alias (id).")]
     public required string Alias { get; set; }
+
+    [CliOption(Name = "--check-token", Description = "Attempt a silent token acquisition and report expiry/status.", Required = false)]
+    public bool CheckToken { get; set; }
 
     protected override async Task<int> ExecuteAsync()
     {
@@ -41,6 +46,12 @@ public class AuthShowCliCommand : TxcLeafCommand
             return ExitValidationError;
         }
 
+        object? tokenDiagnostics = null;
+        if (CheckToken)
+        {
+            tokenDiagnostics = await ProbeTokenHealthAsync(cred).ConfigureAwait(false);
+        }
+
         var projected = new
         {
             id = cred.Id,
@@ -49,11 +60,105 @@ public class AuthShowCliCommand : TxcLeafCommand
             applicationId = cred.ApplicationId,
             cloud = cred.Cloud,
             description = cred.Description,
+            audience = cred.Audience,
+            scopes = cred.Scopes,
             certificatePath = cred.CertificatePath,
             secretRef = cred.SecretRef?.Uri,
+            tokenHealth = tokenDiagnostics,
         };
 
         OutputFormatter.WriteData(projected);
         return ExitSuccess;
+    }
+
+    /// <summary>
+    /// Attempts a silent token acquisition against a connection linked to this
+    /// credential via a profile, and returns a diagnostic summary.
+    /// </summary>
+    private async Task<object> ProbeTokenHealthAsync(Credential cred)
+    {
+        try
+        {
+            var profileStore = TxcServices.Get<IProfileStore>();
+            var connectionStore = TxcServices.Get<IConnectionStore>();
+            var tokenService = TxcServices.Get<IAccessTokenService>();
+
+            var profiles = await profileStore.ListAsync(CancellationToken.None).ConfigureAwait(false);
+
+            // Find a profile that references this credential.
+            var matchingProfile = profiles
+                .FirstOrDefault(p => string.Equals(p.CredentialRef, cred.Id, StringComparison.OrdinalIgnoreCase));
+
+            if (matchingProfile is null)
+            {
+                return new { status = "skipped", reason = "No profile found referencing this credential." };
+            }
+
+            var targetConnection = await connectionStore.GetAsync(matchingProfile.ConnectionRef, CancellationToken.None).ConfigureAwait(false);
+
+            if (targetConnection is null || string.IsNullOrWhiteSpace(targetConnection.EnvironmentUrl))
+            {
+                return new { status = "skipped", reason = $"Profile '{matchingProfile.Id}' references connection '{matchingProfile.ConnectionRef}' which has no environment URL." };
+            }
+
+            if (!Uri.TryCreate(targetConnection.EnvironmentUrl, UriKind.Absolute, out var envUri))
+            {
+                return new { status = "skipped", reason = $"Connection '{targetConnection.Id}' has an invalid environment URL." };
+            }
+
+            var token = await tokenService.AcquireForResourceAsync(targetConnection, cred, envUri, CancellationToken.None).ConfigureAwait(false);
+
+            // Decode the JWT expiry claim for diagnostics (basic parsing —
+            // no signature validation needed for display purposes).
+            var expiry = TryParseJwtExpiry(token);
+
+            return new
+            {
+                status = "valid",
+                profile = matchingProfile.Id,
+                connection = targetConnection.Id,
+                environmentUrl = targetConnection.EnvironmentUrl,
+                expiresOn = expiry?.ToString("o"),
+                expiresInMinutes = expiry.HasValue ? Math.Round((expiry.Value - DateTimeOffset.UtcNow).TotalMinutes, 1) : (double?)null,
+            };
+        }
+        catch (Exception ex)
+        {
+            return new { status = "failed", error = ex.InnerException?.Message ?? ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Extracts the <c>exp</c> claim from a JWT access token without
+    /// pulling in a full JWT library.
+    /// </summary>
+    private static DateTimeOffset? TryParseJwtExpiry(string token)
+    {
+        try
+        {
+            var parts = token.Split('.');
+            if (parts.Length < 2) return null;
+
+            var payload = parts[1];
+            // Pad Base64URL to standard Base64.
+            payload = payload.Replace('-', '+').Replace('_', '/');
+            switch (payload.Length % 4)
+            {
+                case 2: payload += "=="; break;
+                case 3: payload += "="; break;
+            }
+
+            var json = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(payload));
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            if (doc.RootElement.TryGetProperty("exp", out var expElement) && expElement.TryGetInt64(out var exp))
+            {
+                return DateTimeOffset.FromUnixTimeSeconds(exp);
+            }
+        }
+        catch
+        {
+            // Best-effort diagnostics — JWT parsing failure is not critical.
+        }
+        return null;
     }
 }

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthShowCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthShowCliCommand.cs
@@ -27,7 +27,7 @@ public class AuthShowCliCommand : TxcLeafCommand
     [CliArgument(Description = "Credential alias (id).")]
     public required string Alias { get; set; }
 
-    [CliOption(Name = "--check-token", Description = "Attempt a silent token acquisition and report expiry/status.", Required = false)]
+    [CliOption(Name = "--check-token", Description = "Check token status and expiry; interactive re-authentication may occur for interactive credentials.", Required = false)]
     public bool CheckToken { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileCreateCliCommand.cs
@@ -222,12 +222,17 @@ public class ProfileCreateCliCommand : TxcLeafCommand
         var profileStore = TxcServices.Get<IProfileStore>();
         var globalConfig = TxcServices.Get<IGlobalConfigStore>();
 
+        var existingProfile = await profileStore.GetAsync(name, CancellationToken.None).ConfigureAwait(false);
+        var now = DateTimeOffset.UtcNow;
+
         var profile = new ProfileModel
         {
             Id = name,
             ConnectionRef = connectionId,
             CredentialRef = credentialId,
-            Description = Description,
+            Description = Description ?? (upn is not null ? $"{upn} → {connectionId}" : null),
+            CreatedAt = existingProfile?.CreatedAt ?? now,
+            UpdatedAt = now,
         };
 
         await profileStore.UpsertAsync(profile, CancellationToken.None).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileValidateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileValidateCliCommand.cs
@@ -6,6 +6,7 @@ using TALXIS.CLI.Core.DependencyInjection;
 using TALXIS.CLI.Core.Model;
 using TALXIS.CLI.Logging;
 
+
 namespace TALXIS.CLI.Features.Config.Profile;
 
 /// <summary>
@@ -37,6 +38,9 @@ public class ProfileValidateCliCommand : TxcLeafCommand
 
     [CliOption(Description = "Skip the live authenticated round-trip (WhoAmI); run structural checks only.")]
     public bool SkipLive { get; set; }
+
+    [CliOption(Name = "--refresh-env-type", Description = "Query the Power Platform catalog to refresh the environment type (Production/Sandbox/etc.) on the connection.")]
+    public bool RefreshEnvType { get; set; }
 
     protected override async Task<int> ExecuteAsync()
     {
@@ -81,15 +85,40 @@ public class ProfileValidateCliCommand : TxcLeafCommand
             return ExitError;
         }
 
+        EnvironmentType? refreshedEnvType = connection.EnvironmentType;
+        if (RefreshEnvType)
+        {
+            refreshedEnvType = await TryRefreshEnvironmentTypeAsync(connection, credential).ConfigureAwait(false);
+        }
+
         OutputFormatter.WriteData(new
         {
             profile = profile.Id,
             connection = connection.Id,
             credential = credential.Id,
             provider = connection.Provider.ToString().ToLowerInvariant(),
+            environmentType = refreshedEnvType?.ToString().ToLowerInvariant(),
             mode = mode.ToString().ToLowerInvariant(),
             status = "ok",
         });
         return ExitSuccess;
+    }
+
+    /// <summary>
+    /// Delegates to the registered <see cref="IEnvironmentTypeResolver"/> to
+    /// query the provider's control plane and update the connection metadata.
+    /// </summary>
+    private async Task<EnvironmentType?> TryRefreshEnvironmentTypeAsync(TALXIS.CLI.Core.Model.Connection connection, Credential credential)
+    {
+        try
+        {
+            var resolver = TxcServices.Get<IEnvironmentTypeResolver>();
+            return await resolver.RefreshAsync(connection, credential, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to refresh environment type. Current value unchanged.");
+            return connection.EnvironmentType;
+        }
     }
 }

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
@@ -87,11 +87,13 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
             request.Provider,
             request.EnvironmentUrl,
             cloud,
-            organizationId: null,
+            organizationId: names.OrganizationId?.ToString(),
             environmentId: names.EnvironmentId?.ToString(),
             tenantId: request.TenantId ?? acquired.TenantId,
             description: request.Description,
-            ct).ConfigureAwait(false);
+            ct,
+            displayName: names.DisplayName,
+            environmentType: names.EnvironmentType).ConfigureAwait(false);
 
         if (upsert.Error is not null)
             return new ProfileBootstrapResult(names.ProfileName, acquired.Credential, null, acquired.Upn, upsert.Error);
@@ -99,7 +101,13 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
         return new ProfileBootstrapResult(names.ProfileName, acquired.Credential, upsert.Connection, acquired.Upn, null);
     }
 
-    private sealed record BindingNames(string ProfileName, string ConnectionName, Guid? EnvironmentId = null);
+    private sealed record BindingNames(
+        string ProfileName,
+        string ConnectionName,
+        Guid? EnvironmentId = null,
+        string? DisplayName = null,
+        EnvironmentType? EnvironmentType = null,
+        Guid? OrganizationId = null);
 
     private async Task<BindingNames?> ResolveBindingNamesAsync(
         ProfileBootstrapRequest request,
@@ -122,6 +130,9 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
 
         string? preferredBase = null;
         Guid? resolvedEnvironmentId = null;
+        string? resolvedDisplayName = null;
+        EnvironmentType? resolvedEnvironmentType = null;
+        Guid? resolvedOrganizationId = null;
         var ephemeralConnection = new Connection
         {
             Id = "(ephemeral)",
@@ -138,8 +149,14 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 .ConfigureAwait(false);
             if (environment is not null)
             {
-                preferredBase = ProviderUrlResolver.DeriveDefaultName(environment.DisplayName, request.EnvironmentUrl);
+                // Include tenant domain in the slug so multi-customer users can
+                // distinguish environments across tenants at a glance.
+                var tenantDomain = CredentialAliasResolver.ExtractTenantShortName(acquired.Upn);
+                preferredBase = ProviderUrlResolver.DeriveDefaultName(environment.DisplayName, request.EnvironmentUrl, tenantDomain);
                 resolvedEnvironmentId = environment.EnvironmentId;
+                resolvedDisplayName = environment.DisplayName;
+                resolvedEnvironmentType = environment.EnvironmentType;
+                resolvedOrganizationId = environment.OrganizationId;
             }
         }
         catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
@@ -150,7 +167,11 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 request.EnvironmentUrl);
         }
 
-        preferredBase ??= ProviderUrlResolver.DeriveDefaultName(request.EnvironmentUrl);
+        if (string.IsNullOrEmpty(preferredBase))
+        {
+            var tenantDomain = CredentialAliasResolver.ExtractTenantShortName(acquired.Upn);
+            preferredBase = ProviderUrlResolver.DeriveDefaultName(null, request.EnvironmentUrl, tenantDomain);
+        }
         if (string.IsNullOrEmpty(preferredBase))
             return null;
 
@@ -162,7 +183,8 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                     await _profiles.GetAsync(candidate, existsCt).ConfigureAwait(false) is not null,
                 ct).ConfigureAwait(false);
 
-            return new BindingNames(profileName, existingConnection.Id, resolvedEnvironmentId);
+            return new BindingNames(profileName, existingConnection.Id, resolvedEnvironmentId,
+                resolvedDisplayName, resolvedEnvironmentType, resolvedOrganizationId);
         }
 
         // Keep profile + connection names aligned so the mental model is
@@ -174,7 +196,8 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 || await _connectionStore.GetAsync(candidate, existsCt).ConfigureAwait(false) is not null,
             ct).ConfigureAwait(false);
 
-        return new BindingNames(sharedName, sharedName, resolvedEnvironmentId);
+        return new BindingNames(sharedName, sharedName, resolvedEnvironmentId,
+            resolvedDisplayName, resolvedEnvironmentType, resolvedOrganizationId);
     }
 
     private async Task<Connection?> FindExistingConnectionAsync(

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
@@ -82,6 +82,20 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
                 $"Cannot derive a profile name from environment '{request.EnvironmentUrl}'. Pass --name explicitly.");
         }
 
+        // Now that the environment URL is confirmed, capture the audience
+        // and scopes on the credential so token acquisition can use them
+        // and diagnostics can report what the credential was consented for.
+        if (Uri.TryCreate(request.EnvironmentUrl, UriKind.Absolute, out var envUriForScopes))
+        {
+            var authority = envUriForScopes.GetLeftPart(UriPartial.Authority);
+            if (string.IsNullOrEmpty(acquired.Credential.Audience))
+            {
+                acquired.Credential.Audience = authority;
+                acquired.Credential.Scopes = new[] { authority + "//.default" };
+                await _credentials.UpsertAsync(acquired.Credential, ct).ConfigureAwait(false);
+            }
+        }
+
         var upsert = await _connectionUpserts.ValidateAndUpsertAsync(
             names.ConnectionName,
             request.Provider,

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/DataverseEnvironmentTypeResolver.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/DataverseEnvironmentTypeResolver.cs
@@ -58,7 +58,10 @@ public sealed class DataverseEnvironmentTypeResolver : IEnvironmentTypeResolver
                 newType?.ToString() ?? "(null)",
                 environment.DisplayName);
 
-            connection.EnvironmentType = newType;
+            // Only overwrite EnvironmentType when the API returned a value;
+            // a null SKU should not clear a previously-set type.
+            if (newType is not null)
+                connection.EnvironmentType = newType;
             connection.DisplayName = environment.DisplayName;
             if (environment.OrganizationId is { } orgId)
                 connection.OrganizationId = orgId.ToString();

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/DataverseEnvironmentTypeResolver.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/DataverseEnvironmentTypeResolver.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Platform.PowerPlatform.Control;
+
+namespace TALXIS.CLI.Platform.Dataverse.Runtime;
+
+/// <summary>
+/// Resolves and persists the Power Platform environment type by querying the
+/// admin API catalog. Called by <c>profile validate --refresh-env-type</c>.
+/// </summary>
+public sealed class DataverseEnvironmentTypeResolver : IEnvironmentTypeResolver
+{
+    private readonly IPowerPlatformEnvironmentCatalog _catalog;
+    private readonly IConnectionStore _connectionStore;
+    private readonly ILogger<DataverseEnvironmentTypeResolver> _logger;
+
+    public DataverseEnvironmentTypeResolver(
+        IPowerPlatformEnvironmentCatalog catalog,
+        IConnectionStore connectionStore,
+        ILogger<DataverseEnvironmentTypeResolver>? logger = null)
+    {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _connectionStore = connectionStore ?? throw new ArgumentNullException(nameof(connectionStore));
+        _logger = logger ?? NullLogger<DataverseEnvironmentTypeResolver>.Instance;
+    }
+
+    public async Task<EnvironmentType?> RefreshAsync(Connection connection, Credential credential, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(credential);
+
+        if (string.IsNullOrWhiteSpace(connection.EnvironmentUrl) ||
+            !Uri.TryCreate(connection.EnvironmentUrl, UriKind.Absolute, out var envUri))
+        {
+            _logger.LogWarning("Cannot refresh environment type — connection '{Id}' has no valid environment URL.", connection.Id);
+            return connection.EnvironmentType;
+        }
+
+        var environment = await _catalog.TryGetByEnvironmentUrlAsync(connection, credential, envUri, ct).ConfigureAwait(false);
+        if (environment is null)
+        {
+            _logger.LogWarning("Environment not found in Power Platform catalog for '{Url}'.", connection.EnvironmentUrl);
+            return connection.EnvironmentType;
+        }
+
+        var newType = environment.EnvironmentType;
+        var changed = newType != connection.EnvironmentType
+            || !string.Equals(environment.DisplayName, connection.DisplayName, StringComparison.Ordinal);
+
+        if (changed)
+        {
+            _logger.LogInformation(
+                "Refreshed connection '{ConnectionId}': type {OldType} → {NewType}, displayName='{DisplayName}'.",
+                connection.Id,
+                connection.EnvironmentType?.ToString() ?? "(null)",
+                newType?.ToString() ?? "(null)",
+                environment.DisplayName);
+
+            connection.EnvironmentType = newType;
+            connection.DisplayName = environment.DisplayName;
+            if (environment.OrganizationId is { } orgId)
+                connection.OrganizationId = orgId.ToString();
+            connection.EnvironmentId = environment.EnvironmentId;
+            connection.UpdatedAt = DateTimeOffset.UtcNow;
+            await _connectionStore.UpsertAsync(connection, ct).ConfigureAwait(false);
+        }
+
+        return newType ?? connection.EnvironmentType;
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
@@ -56,6 +56,7 @@ public static class DataverseProviderServiceCollectionExtensions
         services.AddSingleton<TALXIS.CLI.Core.Platforms.PowerPlatform.IEnvironmentSettingsService,
             EnvironmentSettingsService>();
         services.AddSingleton<IDataverseLiveChecker, DataverseLiveChecker>();
+        services.AddSingleton<IEnvironmentTypeResolver, DataverseEnvironmentTypeResolver>();
         services.AddSingleton<IInteractiveLoginService, DataverseInteractiveLoginService>();
         services.AddSingleton<TALXIS.CLI.Core.Bootstrapping.IConnectionProviderBootstrapper,
             TALXIS.CLI.Platform.Dataverse.Runtime.Bootstrapping.DataverseConnectionProviderBootstrapper>();

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
@@ -73,11 +73,10 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         if (!resourceUri.IsAbsoluteUri)
             throw new ArgumentException($"Resource URI '{resourceUri}' must be absolute.", nameof(resourceUri));
 
-        // Use credential-stored scopes when available; otherwise derive from
-        // the resource URI dynamically (backward-compatible default).
-        var scope = credential.Scopes is { Length: > 0 }
-            ? credential.Scopes[0]
-            : DataverseScope.BuildDefault(resourceUri);
+        // Always derive the scope from the actual resource URI. Credential.Scopes
+        // is for diagnostics only — using it here would break non-Dataverse
+        // resources (e.g. Power Platform admin API) and multi-environment credentials.
+        var scope = DataverseScope.BuildDefault(resourceUri);
         var cacheKey = InMemoryTokenCache.BuildKey(credential.Id, credential.TenantId, resourceUri.GetLeftPart(UriPartial.Authority));
 
         // Fast path: return a cached token that is still valid beyond the
@@ -174,6 +173,10 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
                         .ConfigureAwait(false);
                     _tokenCache.Set(cacheKey, interactiveResult);
                     return interactiveResult.AccessToken;
+                }
+                catch (OperationCanceledException)
+                {
+                    throw; // Propagate Ctrl+C / browser close cancellation.
                 }
                 catch (Exception reAuthEx)
                 {

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
@@ -16,25 +16,36 @@ namespace TALXIS.CLI.Platform.Dataverse.Runtime;
 /// all credential kinds go through one code path for authority selection,
 /// scope construction, and cache attachment.
 /// </summary>
+/// <remarks>
+/// An <see cref="InMemoryTokenCache"/> sits in front of MSAL to avoid
+/// repeated disk I/O and network calls. Tokens are returned from the
+/// in-memory cache when they are still valid beyond a 2-minute proactive
+/// renewal buffer (PAC CLI uses 1 minute). Per-key <see cref="SemaphoreSlim"/>
+/// prevents stampedes when multiple threads request the same token.
+/// </remarks>
 public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
 {
     private readonly MsalClientFactory _clientFactory;
     private readonly MsalTokenCacheBinder _cacheBinder;
     private readonly ICredentialVault _vault;
     private readonly IEnvironmentReader _env;
+    private readonly IHeadlessDetector _headless;
     private readonly ILogger<DataverseAccessTokenService> _logger;
+    private readonly InMemoryTokenCache _tokenCache = new();
 
     public DataverseAccessTokenService(
         MsalClientFactory clientFactory,
         MsalTokenCacheBinder cacheBinder,
         ICredentialVault vault,
         IEnvironmentReader env,
+        IHeadlessDetector headless,
         ILogger<DataverseAccessTokenService>? logger = null)
     {
         _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
         _cacheBinder = cacheBinder ?? throw new ArgumentNullException(nameof(cacheBinder));
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
         _env = env ?? throw new ArgumentNullException(nameof(env));
+        _headless = headless ?? throw new ArgumentNullException(nameof(headless));
         _logger = logger ?? NullLogger<DataverseAccessTokenService>.Instance;
     }
 
@@ -62,24 +73,52 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         if (!resourceUri.IsAbsoluteUri)
             throw new ArgumentException($"Resource URI '{resourceUri}' must be absolute.", nameof(resourceUri));
 
-        var scope = DataverseScope.BuildDefault(resourceUri);
+        // Use credential-stored scopes when available; otherwise derive from
+        // the resource URI dynamically (backward-compatible default).
+        var scope = credential.Scopes is { Length: > 0 }
+            ? credential.Scopes[0]
+            : DataverseScope.BuildDefault(resourceUri);
+        var cacheKey = InMemoryTokenCache.BuildKey(credential.Id, credential.TenantId, resourceUri.GetLeftPart(UriPartial.Authority));
 
-        return credential.Kind switch
+        // Fast path: return a cached token that is still valid beyond the
+        // proactive renewal buffer.
+        var cached = _tokenCache.TryGet(cacheKey);
+        if (cached is not null)
+            return cached;
+
+        // Slow path: serialize per-key to prevent multiple threads from hitting
+        // MSAL for the same token simultaneously.
+        var keyLock = _tokenCache.GetKeyLock(cacheKey);
+        await keyLock.WaitAsync(ct).ConfigureAwait(false);
+        try
         {
-            CredentialKind.InteractiveBrowser => await AcquirePublicClientSilentAsync(connection, credential, scope, ct).ConfigureAwait(false),
-            CredentialKind.ClientSecret => await AcquireClientSecretAsync(connection, credential, scope, ct).ConfigureAwait(false),
-            CredentialKind.ClientCertificate => await AcquireClientCertificateAsync(connection, credential, scope, ct).ConfigureAwait(false),
-            CredentialKind.WorkloadIdentityFederation => await AcquireFederatedAsync(connection, credential, scope, ct).ConfigureAwait(false),
-            CredentialKind.DeviceCode or CredentialKind.ManagedIdentity or CredentialKind.AzureCli or CredentialKind.Pat =>
-                throw new NotSupportedException(
-                    $"Credential kind {credential.Kind} is reserved but not yet wired for Dataverse token acquisition in this release. " +
-                    "Use InteractiveBrowser, ClientSecret, ClientCertificate, or WorkloadIdentityFederation."),
-            _ => throw new NotSupportedException($"Unknown credential kind: {credential.Kind}"),
-        };
+            // Double-check after acquiring the lock — another thread may have
+            // refreshed the token while we were waiting.
+            cached = _tokenCache.TryGet(cacheKey);
+            if (cached is not null)
+                return cached;
+
+            return credential.Kind switch
+            {
+                CredentialKind.InteractiveBrowser => await AcquirePublicClientSilentAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
+                CredentialKind.ClientSecret => await AcquireClientSecretAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
+                CredentialKind.ClientCertificate => await AcquireClientCertificateAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
+                CredentialKind.WorkloadIdentityFederation => await AcquireFederatedAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
+                CredentialKind.DeviceCode or CredentialKind.ManagedIdentity or CredentialKind.AzureCli or CredentialKind.Pat =>
+                    throw new NotSupportedException(
+                        $"Credential kind {credential.Kind} is reserved but not yet wired for Dataverse token acquisition in this release. " +
+                        "Use InteractiveBrowser, ClientSecret, ClientCertificate, or WorkloadIdentityFederation."),
+                _ => throw new NotSupportedException($"Unknown credential kind: {credential.Kind}"),
+            };
+        }
+        finally
+        {
+            keyLock.Release();
+        }
     }
 
     private async Task<string> AcquirePublicClientSilentAsync(
-        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, CancellationToken ct)
+        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, string cacheKey, CancellationToken ct)
     {
         var app = _clientFactory.BuildPublicClient(connection);
         _cacheBinder.Attach(app.UserTokenCache);
@@ -110,10 +149,38 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
                 .AcquireTokenSilent(new[] { scope }, account)
                 .ExecuteAsync(ct)
                 .ConfigureAwait(false);
+            _tokenCache.Set(cacheKey, result);
             return result.AccessToken;
         }
         catch (MsalUiRequiredException ex)
         {
+            // In interactive sessions, attempt automatic re-authentication
+            // using AcquireTokenInteractive with the actual Dataverse scope
+            // that failed — not just identity scopes. This ensures consent
+            // is obtained for the correct resource.
+            if (!_headless.IsHeadless)
+            {
+                _logger.LogWarning(
+                    "Token for credential '{CredentialId}' expired or requires consent — launching interactive re-authentication with Dataverse scope.",
+                    credential.Id);
+
+                try
+                {
+                    var interactiveResult = await app
+                        .AcquireTokenInteractive(new[] { scope })
+                        .WithAccount(account)
+                        .WithUseEmbeddedWebView(false)
+                        .ExecuteAsync(ct)
+                        .ConfigureAwait(false);
+                    _tokenCache.Set(cacheKey, interactiveResult);
+                    return interactiveResult.AccessToken;
+                }
+                catch (Exception reAuthEx)
+                {
+                    _logger.LogDebug(reAuthEx, "Automatic re-authentication failed; falling through to original error.");
+                }
+            }
+
             throw new InvalidOperationException(
                 $"Cached token for '{credential.Id}' expired or is missing consent. " +
                 "Run 'txc config auth login' and retry.", ex);
@@ -121,7 +188,7 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
     }
 
     private async Task<string> AcquireClientSecretAsync(
-        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, CancellationToken ct)
+        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, string cacheKey, CancellationToken ct)
     {
         if (credential.SecretRef is null)
             throw new InvalidOperationException($"Credential '{credential.Id}' (ClientSecret) has no SecretRef.");
@@ -134,15 +201,17 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
 
         var material = new ConfidentialClientMaterial { ClientSecret = secret };
         var app = _clientFactory.BuildConfidentialClient(connection, credential, material);
+        _cacheBinder.AttachAppCache(app.AppTokenCache);
         var result = await app
             .AcquireTokenForClient(new[] { scope })
             .ExecuteAsync(ct)
             .ConfigureAwait(false);
+        _tokenCache.Set(cacheKey, result);
         return result.AccessToken;
     }
 
     private async Task<string> AcquireClientCertificateAsync(
-        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, CancellationToken ct)
+        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, string cacheKey, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(credential.CertificatePath))
             throw new InvalidOperationException($"Credential '{credential.Id}' (ClientCertificate) has no CertificatePath.");
@@ -161,10 +230,12 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         {
             var material = new ConfidentialClientMaterial { Certificate = cert };
             var app = _clientFactory.BuildConfidentialClient(connection, credential, material);
+            _cacheBinder.AttachAppCache(app.AppTokenCache);
             var result = await app
                 .AcquireTokenForClient(new[] { scope })
                 .ExecuteAsync(ct)
                 .ConfigureAwait(false);
+            _tokenCache.Set(cacheKey, result);
             return result.AccessToken;
         }
         finally
@@ -174,15 +245,17 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
     }
 
     private async Task<string> AcquireFederatedAsync(
-        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, CancellationToken ct)
+        TALXIS.CLI.Core.Model.Connection connection, Credential credential, string scope, string cacheKey, CancellationToken ct)
     {
         var callback = FederatedAssertionCallbacks.AutoSelect(_env, logger: _logger);
         var material = new ConfidentialClientMaterial { AssertionCallback = callback };
         var app = _clientFactory.BuildConfidentialClient(connection, credential, material);
+        _cacheBinder.AttachAppCache(app.AppTokenCache);
         var result = await app
             .AcquireTokenForClient(new[] { scope })
             .ExecuteAsync(ct)
             .ConfigureAwait(false);
+        _tokenCache.Set(cacheKey, result);
         return result.AccessToken;
     }
 }

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/InMemoryTokenCache.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/InMemoryTokenCache.cs
@@ -1,0 +1,74 @@
+using System.Collections.Concurrent;
+using Microsoft.Identity.Client;
+
+namespace TALXIS.CLI.Platform.Dataverse.Runtime;
+
+/// <summary>
+/// Application-level in-memory token cache with a proactive renewal buffer.
+/// Sits in front of MSAL to avoid repeated disk I/O and network round-trips
+/// for the same (credential, tenant, resource) tuple within a single process.
+/// </summary>
+/// <remarks>
+/// PAC CLI uses an equivalent <c>ExchangeTokenSilentAsync</c> layer with a
+/// 1-minute buffer. We use 2 minutes to account for network latency during
+/// long-running operations (PackageDeployer, CMT imports).
+/// <para>
+/// Thread-safety: <see cref="ConcurrentDictionary{TKey, TValue}"/> for the
+/// cache entries, plus <see cref="SemaphoreSlim"/> per key to prevent
+/// stampedes when multiple threads request the same token simultaneously.
+/// </para>
+/// </remarks>
+internal sealed class InMemoryTokenCache
+{
+    /// <summary>
+    /// Tokens expiring within this window are considered stale and will be
+    /// refreshed proactively before they actually expire.
+    /// </summary>
+    private static readonly TimeSpan ProactiveRenewalBuffer = TimeSpan.FromMinutes(2);
+
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns a cached access token if still valid beyond the proactive
+    /// renewal buffer, or <c>null</c> if the caller should acquire a fresh
+    /// token from MSAL.
+    /// </summary>
+    public string? TryGet(string cacheKey)
+    {
+        if (_cache.TryGetValue(cacheKey, out var entry) &&
+            entry.ExpiresOn.UtcDateTime > DateTime.UtcNow.Add(ProactiveRenewalBuffer))
+        {
+            return entry.AccessToken;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Stores or updates a cached token.
+    /// </summary>
+    public void Set(string cacheKey, AuthenticationResult result)
+    {
+        _cache[cacheKey] = new CacheEntry(result.AccessToken, result.ExpiresOn);
+    }
+
+    /// <summary>
+    /// Gets or creates a per-key semaphore to prevent concurrent MSAL
+    /// requests for the same token. Callers must <c>await</c> the semaphore
+    /// and release it after acquiring and caching the token.
+    /// </summary>
+    public SemaphoreSlim GetKeyLock(string cacheKey)
+    {
+        return _locks.GetOrAdd(cacheKey, _ => new SemaphoreSlim(1, 1));
+    }
+
+    /// <summary>
+    /// Builds a deterministic cache key from the credential and resource.
+    /// </summary>
+    public static string BuildKey(string credentialId, string? tenantId, string resourceAuthority)
+    {
+        return $"{credentialId}|{tenantId ?? "default"}|{resourceAuthority}";
+    }
+
+    private readonly record struct CacheEntry(string AccessToken, DateTimeOffset ExpiresOn);
+}

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/PowerPlatformEnvironmentCatalog.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/PowerPlatformEnvironmentCatalog.cs
@@ -16,7 +16,8 @@ public sealed record PowerPlatformEnvironmentSummary(
     Uri EnvironmentUrl,
     string? UniqueName,
     string? DomainName,
-    Guid? OrganizationId);
+    Guid? OrganizationId,
+    TALXIS.CLI.Core.Model.EnvironmentType? EnvironmentType = null);
 
 public interface IPowerPlatformEnvironmentCatalog
 {
@@ -135,7 +136,8 @@ public sealed class PowerPlatformEnvironmentCatalog : IPowerPlatformEnvironmentC
             EnvironmentUrl: NormalizeEnvironmentUrl(environmentUrl),
             UniqueName: TryReadOptionalString(linked, "uniqueName"),
             DomainName: TryReadOptionalString(linked, "domainName"),
-            OrganizationId: TryReadOptionalGuid(linked, "resourceId"));
+            OrganizationId: TryReadOptionalGuid(linked, "resourceId"),
+            EnvironmentType: TryParseEnvironmentSku(properties));
         return true;
     }
 
@@ -175,6 +177,22 @@ public sealed class PowerPlatformEnvironmentCatalog : IPowerPlatformEnvironmentC
            && Guid.TryParse(propertyElement.GetString(), out var parsed)
             ? parsed
             : null;
+
+    private static TALXIS.CLI.Core.Model.EnvironmentType? TryParseEnvironmentSku(JsonElement properties)
+    {
+        if (!TryReadString(properties, "environmentSku", out var sku))
+            return null;
+
+        return sku.ToLowerInvariant() switch
+        {
+            "production" => TALXIS.CLI.Core.Model.EnvironmentType.Production,
+            "sandbox" => TALXIS.CLI.Core.Model.EnvironmentType.Sandbox,
+            "trial" => TALXIS.CLI.Core.Model.EnvironmentType.Trial,
+            "developer" => TALXIS.CLI.Core.Model.EnvironmentType.Developer,
+            "default" => TALXIS.CLI.Core.Model.EnvironmentType.Default,
+            _ => null,
+        };
+    }
 
     private static bool UrlEquals(Uri left, Uri right)
         => NormalizeEnvironmentUrl(left).AbsoluteUri.Equals(

--- a/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProfileCreateOneLinerTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProfileCreateOneLinerTests.cs
@@ -123,8 +123,10 @@ public sealed class ProfileCreateOneLinerTests
 
         var profiles = (IProfileStore)host.Provider.GetService(typeof(IProfileStore))!;
         var connections = (IConnectionStore)host.Provider.GetService(typeof(IConnectionStore))!;
-        Assert.NotNull(await profiles.GetAsync("contoso-dev-org0fadb1dd", default));
-        Assert.NotNull(await connections.GetAsync("contoso-dev-org0fadb1dd", default));
+        // "Contoso Dev" display name with UPN tomas@contoso.com → "contoso-dev"
+        // (tenant domain "contoso" already present in the slug, so not appended)
+        Assert.NotNull(await profiles.GetAsync("contoso-dev", default));
+        Assert.NotNull(await connections.GetAsync("contoso-dev", default));
     }
 
     [Fact]
@@ -141,7 +143,7 @@ public sealed class ProfileCreateOneLinerTests
 
         using var host = new CommandTestHost(environmentCatalog: catalog);
         var connections = (IConnectionStore)host.Provider.GetService(typeof(IConnectionStore))!;
-        await connections.UpsertAsync(new Connection { Id = "contoso-dev-org0fadb1dd", Provider = ProviderKind.Dataverse, EnvironmentUrl = "https://existing" }, default);
+        await connections.UpsertAsync(new Connection { Id = "contoso-dev", Provider = ProviderKind.Dataverse, EnvironmentUrl = "https://existing" }, default);
 
         using (OutputWriter.RedirectTo(new StringWriter()))
         {
@@ -153,7 +155,7 @@ public sealed class ProfileCreateOneLinerTests
         }
 
         var profiles = (IProfileStore)host.Provider.GetService(typeof(IProfileStore))!;
-        Assert.NotNull(await profiles.GetAsync("contoso-dev-org0fadb1dd-2", default));
+        Assert.NotNull(await profiles.GetAsync("contoso-dev-2", default));
     }
 
     [Fact]
@@ -175,7 +177,8 @@ public sealed class ProfileCreateOneLinerTests
         }
 
         var profiles = (IProfileStore)host.Provider.GetService(typeof(IProfileStore))!;
-        Assert.NotNull(await profiles.GetAsync("fallback", default));
+        // Host slug "fallback" + tenant domain "contoso" → "fallback-contoso"
+        Assert.NotNull(await profiles.GetAsync("fallback-contoso", default));
     }
 
     [Fact]
@@ -318,8 +321,10 @@ public sealed class ProfileCreateOneLinerTests
         var profiles = (IProfileStore)host.Provider.GetService(typeof(IProfileStore))!;
         var creds = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
 
+        // "contoso" host + "contoso" tenant → "contoso" (tenant already in slug)
+        // "fabrikam" host + "contoso" tenant → "fabrikam-contoso"
         var contoso = await profiles.GetAsync("contoso", default);
-        var fabrikam = await profiles.GetAsync("fabrikam", default);
+        var fabrikam = await profiles.GetAsync("fabrikam-contoso", default);
         Assert.NotNull(contoso);
         Assert.NotNull(fabrikam);
 

--- a/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProviderUrlResolverTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProviderUrlResolverTests.cs
@@ -62,11 +62,13 @@ public class ProviderUrlResolverTests
     }
 
     [Theory]
-    [InlineData("Contoso Dev", "https://org0fadb1dd.crm.dynamics.com/", "contoso-dev-org0fadb1dd")]
-    [InlineData("Org0fadb1dd", "https://org0fadb1dd.crm.dynamics.com/", "org0fadb1dd")]
-    [InlineData("Very Long Environment Name That Should Still Keep The Host Visible", "https://org0fadb1dd.crm.dynamics.com/", "very-long-environment-name-that-should-still-keep-th-org0fadb1dd")]
-    public void DeriveDefaultName_UsesDisplayNameAndKeepsHostSuffix(string displayName, string url, string expected)
+    [InlineData("Contoso Dev", "https://org0fadb1dd.crm.dynamics.com/", null, "contoso-dev")]
+    [InlineData("Contoso Dev", "https://org0fadb1dd.crm.dynamics.com/", "contoso", "contoso-dev")]
+    [InlineData("TALXIS Dev", "https://org0fadb1dd.crm.dynamics.com/", "thenetw", "talxis-dev-thenetw")]
+    [InlineData("Org0fadb1dd", "https://org0fadb1dd.crm.dynamics.com/", null, "org0fadb1dd")]
+    [InlineData(null, "https://org0fadb1dd.crm.dynamics.com/", "contoso", "org0fadb1dd-contoso")]
+    public void DeriveDefaultName_UsesDisplayNameWithTenantDomain(string? displayName, string url, string? tenantDomain, string expected)
     {
-        Assert.Equal(expected, ProviderUrlResolver.DeriveDefaultName(displayName, url));
+        Assert.Equal(expected, ProviderUrlResolver.DeriveDefaultName(displayName, url, tenantDomain));
     }
 }


### PR DESCRIPTION
## Summary

Addresses frequent token expiration during CLI operations, improves config model for multi-customer workflows, and adds production environment safety guards.

### Token Expiration Mitigation
- **In-memory token cache** with 2-minute proactive renewal buffer and per-key stampede protection (`InMemoryTokenCache`)
- **SPN token cache persistence** via separate `txc.msal.spn-tokens.v1.dat` file — confidential client tokens now survive across CLI invocations
- **Auto re-authentication** on `MsalUiRequiredException` — uses `AcquireTokenInteractive` with the actual Dataverse scope (not just identity scopes)
- **Token diagnostics** via `txc config auth show <alias> --check-token` — reports expiry time, remaining minutes, connection context

### Config Model Improvements
- **Connection**: `DisplayName`, `EnvironmentType`, `CreatedAt`/`UpdatedAt` timestamps
- **Credential**: `Audience`, `Scopes` (populated at bootstrap), `CreatedAt`/`UpdatedAt`
- **Profile**: `CreatedAt`/`UpdatedAt`, `ExtraFields` (forward-compat)
- **Better naming**: connection/profile slugs include tenant domain — e.g. `talxis-dev-thenetw` instead of `org2928f636`
- **Auto-populated metadata**: `OrganizationId`, `DisplayName`, `Description` from Power Platform catalog during bootstrap
- **Timestamps**: all three store `UpsertAsync` methods set `CreatedAt`/`UpdatedAt` as a safety net

### Production Environment Protection
- **`EnvironmentType` enum** (`Production`/`Sandbox`/`Trial`/`Developer`/`Default`) parsed from Power Platform admin API `environmentSku` field
- **Production safety guard** in `ProfiledCliCommand.PreExecuteAsync()` — blocks `[CliDestructive]` commands against production-like environments unless `--allow-production` is passed
- **Name-based heuristic**: also checks `DisplayName` and URL hostname for keywords `prod`/`production`/`prd`/`live` (case-insensitive, word-boundary)
- **`--allow-production` flag** — additional gate on top of the existing `--yes` confirmation (two-factor for production)
- **`IEnvironmentTypeResolver`** abstraction + `DataverseEnvironmentTypeResolver` implementation
- **`--refresh-env-type`** flag on `txc config profile validate` to sync environment type from Power Platform catalog

### Tested
- ✅ Live-tested against `https://org2928f636.crm.dynamics.com` and `https://orgccafd4f5.crm4.dynamics.com`
- ✅ Cross-org scope validation confirmed (same credential works across environments)
- ✅ Build: 0 errors
- ✅ Tests: 14+1 pre-existing failures from PR #22 (`IConfirmationPrompter` not registered in test host)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>