### PR TITLE
fix: correct exit codes for validation errors in config commands

### DIFF
--- a/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
@@ -89,7 +89,7 @@ public abstract class TxcLeafCommand
         catch (Exception ex) when (ex is Abstractions.ConfigurationResolutionException)
         {
             Logger.LogError("{Error}", ex.Message);
-            return ExitError;
+            return ExitValidationError;
         }
         catch (OperationCanceledException)
         {

--- a/src/TALXIS.CLI.Features.Config/Setting/SettingSetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Setting/SettingSetCliCommand.cs
@@ -46,7 +46,16 @@ public class SettingSetCliCommand : TxcLeafCommand
             return ExitValidationError;
         }
 
-        var normalized = SettingRegistry.NormalizeValue(descriptor, Value);
+        string normalized;
+        try
+        {
+            normalized = SettingRegistry.NormalizeValue(descriptor, Value);
+        }
+        catch (ArgumentException ex)
+        {
+            Logger.LogError("{Error}", ex.Message);
+            return ExitValidationError;
+        }
 
         var store = TxcServices.Get<IGlobalConfigStore>();
         var config = await store.LoadAsync(CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
## Problem
Six tests were failing because validation scenarios returned exit code 1 (runtime error) instead of exit code 2 (validation error).

## Root Cause
Two issues:

1. **`TxcLeafCommand.RunAsync()`** — the `catch` block for `ConfigurationResolutionException` returned `ExitError` (1). This exception represents missing profiles/connections (validation errors), so it should return `ExitValidationError` (2).

2. **`SettingSetCliCommand.ExecuteAsync()`** — `SettingRegistry.NormalizeValue()` throws `ArgumentException` for invalid enum/bool values, which fell through to the generic `catch (Exception)` returning `ExitError` (1). Added explicit `ArgumentException` handling to return `ExitValidationError` (2).

## Changes
- `src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs`: Changed `ConfigurationResolutionException` catch to return `ExitValidationError`
- `src/TALXIS.CLI.Features.Config/Setting/SettingSetCliCommand.cs`: Added `ArgumentException` catch around `NormalizeValue` call

## Testing
All 392 unit tests pass. All 6 previously failing tests now pass.