### PR TITLE
fix: improve error reporting UX for queries, connections, and GUID arguments

### DIFF
--- a/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core.Abstractions;
 using TALXIS.CLI.Core.Model;
 using TALXIS.CLI.Core.Storage;
@@ -21,10 +23,12 @@ public sealed record ConnectionUpsertResult(Connection? Connection, string? Erro
 public sealed class ConnectionUpsertService
 {
     private readonly IConnectionStore _store;
+    private readonly ILogger<ConnectionUpsertService>? _logger;
 
-    public ConnectionUpsertService(IConnectionStore store)
+    public ConnectionUpsertService(IConnectionStore store, ILogger<ConnectionUpsertService>? logger = null)
     {
         _store = store ?? throw new ArgumentNullException(nameof(store));
+        _logger = logger;
     }
 
     /// <summary>
@@ -77,6 +81,16 @@ public sealed class ConnectionUpsertService
                 return new ConnectionUpsertResult(null,
                     $"--environment-id must be a GUID: '{environmentId}'.");
             parsedEnvironmentId = eid;
+        }
+
+        // Non-blocking DNS reachability check — warn if the hostname cannot be resolved.
+        try
+        {
+            await Dns.GetHostAddressesAsync(envUri.Host, ct).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            _logger?.LogWarning("Hostname '{Host}' could not be resolved. The connection will be saved but may not work at runtime.", envUri.Host);
         }
 
         // Check if a connection already exists to preserve CreatedAt.

--- a/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs
@@ -84,11 +84,12 @@ public sealed class ConnectionUpsertService
         }
 
         // Non-blocking DNS reachability check — warn if the hostname cannot be resolved.
+        // Let cancellation propagate so user Ctrl+C is not swallowed.
         try
         {
             await Dns.GetHostAddressesAsync(envUri.Host, ct).ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (Exception) when (!ct.IsCancellationRequested)
         {
             _logger?.LogWarning("Hostname '{Host}' could not be resolved. The connection will be saved but may not work at runtime.", envUri.Host);
         }

--- a/src/TALXIS.CLI.Core/Shared/CliValidation.cs
+++ b/src/TALXIS.CLI.Core/Shared/CliValidation.cs
@@ -1,0 +1,26 @@
+namespace TALXIS.CLI.Core;
+
+/// <summary>
+/// Shared validation constants for CLI argument and option attributes.
+/// Values are <see langword="const"/> so they can be used in
+/// <c>[CliArgument]</c> / <c>[CliOption]</c> attribute declarations.
+/// </summary>
+public static class CliValidation
+{
+    /// <summary>
+    /// Regex pattern that accepts all common GUID text representations:
+    /// hyphenated (<c>00000000-0000-0000-0000-000000000000</c>),
+    /// braces (<c>{00000000-0000-0000-0000-000000000000}</c>), and
+    /// bare 32-character hex (<c>00000000000000000000000000000000</c>).
+    /// Matches the formats accepted by <see cref="System.Guid.TryParse"/>.
+    /// </summary>
+    public const string GuidPattern =
+        @"^(\{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\}?|[0-9a-fA-F]{32})$";
+
+    /// <summary>
+    /// User-facing validation error message displayed when a GUID argument
+    /// does not match <see cref="GuidPattern"/>.
+    /// </summary>
+    public const string GuidValidationMessage =
+        "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).";
+}

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
@@ -22,14 +22,15 @@ public class EnvDataRecordAssociateCliCommand : StagedCliCommand
 
     [CliArgument(
         Description = "The GUID of the source record.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliOption(Name = "--target", Description = "The GUID of the target record to associate.", Required = true)]
+    [CliOption(Name = "--target", Description = "The GUID of the target record to associate.", Required = true,
+        ValidationPattern = CliValidation.GuidPattern, ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid Target { get; set; }
 
     [CliOption(Name = "--target-entity", Description = "Entity logical name of the target record.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
@@ -20,7 +20,10 @@ public class EnvDataRecordAssociateCliCommand : StagedCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordAssociateCliCommand));
 
-    [CliArgument(Description = "The GUID of the source record.")]
+    [CliArgument(
+        Description = "The GUID of the source record.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
@@ -26,7 +26,10 @@ public class EnvDataRecordDeleteCliCommand : StagedCliCommand, IDestructiveComma
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(Description = "The GUID of the record to delete.")]
+    [CliArgument(
+        Description = "The GUID of the record to delete.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
@@ -28,8 +28,8 @@ public class EnvDataRecordDeleteCliCommand : StagedCliCommand, IDestructiveComma
 
     [CliArgument(
         Description = "The GUID of the record to delete.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
@@ -26,14 +26,15 @@ public class EnvDataRecordDisassociateCliCommand : StagedCliCommand, IDestructiv
 
     [CliArgument(
         Description = "The GUID of the source record.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliOption(Name = "--target", Description = "The GUID of the target record to disassociate.", Required = true)]
+    [CliOption(Name = "--target", Description = "The GUID of the target record to disassociate.", Required = true,
+        ValidationPattern = CliValidation.GuidPattern, ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid Target { get; set; }
 
     [CliOption(Name = "--target-entity", Description = "Entity logical name of the target record.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
@@ -24,7 +24,10 @@ public class EnvDataRecordDisassociateCliCommand : StagedCliCommand, IDestructiv
     [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
-    [CliArgument(Description = "The GUID of the source record.")]
+    [CliArgument(
+        Description = "The GUID of the source record.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
@@ -25,8 +25,8 @@ public class EnvDataRecordDownloadFileCliCommand : ProfiledCliCommand
 
     [CliArgument(
         Description = "The GUID of the record containing the file.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
@@ -23,7 +23,10 @@ public class EnvDataRecordDownloadFileCliCommand : ProfiledCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. fin_mytable).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(Description = "The GUID of the record containing the file.")]
+    [CliArgument(
+        Description = "The GUID of the record containing the file.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
@@ -23,7 +23,10 @@ public class EnvDataRecordGetCliCommand : ProfiledCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(Description = "The GUID of the record to retrieve.")]
+    [CliArgument(
+        Description = "The GUID of the record to retrieve.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--columns", Description = "Comma-separated column names to retrieve.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
@@ -25,8 +25,8 @@ public class EnvDataRecordGetCliCommand : ProfiledCliCommand
 
     [CliArgument(
         Description = "The GUID of the record to retrieve.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--columns", Description = "Comma-separated column names to retrieve.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -26,8 +26,8 @@ public class EnvDataRecordUpdateCliCommand : StagedCliCommand
 
     [CliArgument(
         Description = "The GUID of the record to update.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -24,7 +24,10 @@ public class EnvDataRecordUpdateCliCommand : StagedCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(Description = "The GUID of the record to update.")]
+    [CliArgument(
+        Description = "The GUID of the record to update.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
@@ -25,8 +25,8 @@ public class EnvDataRecordUploadFileCliCommand : StagedCliCommand
 
     [CliArgument(
         Description = "The GUID of the record to upload the file to.",
-        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
+        ValidationPattern = CliValidation.GuidPattern,
+        ValidationMessage = CliValidation.GuidValidationMessage)]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
@@ -23,7 +23,10 @@ public class EnvDataRecordUploadFileCliCommand : StagedCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. fin_mytable).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(Description = "The GUID of the record to upload the file to.")]
+    [CliArgument(
+        Description = "The GUID of the record to upload the file to.",
+        ValidationPattern = @"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        ValidationMessage = "Value must be a valid GUID (e.g. 00000000-0000-0000-0000-000000000000).")]
     public Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
@@ -52,10 +52,28 @@ internal sealed class DataverseQueryService : IDataverseQueryService
 
         var headers = BuildHeaders(includeAnnotations);
         var queryPath = $"{entitySetName}?sql={Uri.EscapeDataString(sql)}";
-        var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"SQL query against '{entitySetName}' failed: {ex.Message}", ex);
+        }
 
         var records = new List<JsonElement>();
-        await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+        try
+        {
+            await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException(
+                $"SQL query against '{entitySetName}' failed: {ex.Message}", ex);
+        }
 
         // Follow @odata.nextLink pages until exhausted or top limit reached.
         await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
@@ -133,10 +151,28 @@ internal sealed class DataverseQueryService : IDataverseQueryService
 
         var queryPath = BuildODataQueryPath(entitySetOrPath, select, filter, orderBy, top);
         var headers = BuildHeaders(includeAnnotations);
-        var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"OData query against '{entitySetOrPath}' failed: {ex.Message}", ex);
+        }
 
         var records = new List<JsonElement>();
-        await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+        try
+        {
+            await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException(
+                $"OData query against '{entitySetOrPath}' failed: {ex.Message}", ex);
+        }
 
         // Dataverse can still return @odata.nextLink when $top is specified
         // (for example when the requested top exceeds the server page size).
@@ -175,7 +211,7 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         // Simple regex to grab the first table name after FROM.
         var match = Regex.Match(sql, @"\bFROM\s+(\w+)", RegexOptions.IgnoreCase);
         if (!match.Success)
-            throw new InvalidOperationException("Could not parse a table name from the SQL FROM clause.");
+            throw new InvalidOperationException($"Could not parse a table name from the SQL FROM clause in: '{sql}'.");
 
         var tableName = match.Groups[1].Value.ToLowerInvariant();
 
@@ -225,6 +261,8 @@ internal sealed class DataverseQueryService : IDataverseQueryService
 
     /// <summary>
     /// Parses the <c>value</c> array from a Web API JSON response.
+    /// Throws <see cref="InvalidOperationException"/> with the server error
+    /// message when the response indicates a non-success HTTP status code.
     /// </summary>
     private static async Task ParseValueArrayAsync(
         HttpResponseMessage response,
@@ -232,6 +270,16 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         CancellationToken ct)
     {
         var content = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var serverMessage = TryExtractODataErrorMessage(content);
+            throw new InvalidOperationException(
+                string.IsNullOrEmpty(serverMessage)
+                    ? $"Dataverse returned HTTP {(int)response.StatusCode} ({response.StatusCode})."
+                    : $"Dataverse returned HTTP {(int)response.StatusCode} ({response.StatusCode}): {serverMessage}");
+        }
+
         using var doc = JsonDocument.Parse(content);
 
         if (doc.RootElement.TryGetProperty("value", out var valueArray) &&
@@ -240,6 +288,29 @@ internal sealed class DataverseQueryService : IDataverseQueryService
             foreach (var item in valueArray.EnumerateArray())
                 target.Add(item.Clone());
         }
+    }
+
+    /// <summary>
+    /// Attempts to extract the <c>error.message</c> field from an OData
+    /// error response body. Returns <c>null</c> when the body is not valid
+    /// OData error JSON.
+    /// </summary>
+    private static string? TryExtractODataErrorMessage(string responseBody)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
+                errorElement.TryGetProperty("message", out var messageElement))
+            {
+                return messageElement.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Response is not valid JSON — fall through.
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs
@@ -53,30 +53,20 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         var headers = BuildHeaders(includeAnnotations);
         var queryPath = $"{entitySetName}?sql={Uri.EscapeDataString(sql)}";
 
-        HttpResponseMessage response;
-        try
-        {
-            response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"SQL query against '{entitySetName}' failed: {ex.Message}", ex);
-        }
-
         var records = new List<JsonElement>();
         try
         {
+            using var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
             await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+
+            // Follow @odata.nextLink pages until exhausted or top limit reached.
+            await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new InvalidOperationException(
                 $"SQL query against '{entitySetName}' failed: {ex.Message}", ex);
         }
-
-        // Follow @odata.nextLink pages until exhausted or top limit reached.
-        await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
 
         if (!includeAnnotations)
             StripAnnotations(records);
@@ -152,33 +142,23 @@ internal sealed class DataverseQueryService : IDataverseQueryService
         var queryPath = BuildODataQueryPath(entitySetOrPath, select, filter, orderBy, top);
         var headers = BuildHeaders(includeAnnotations);
 
-        HttpResponseMessage response;
-        try
-        {
-            response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException(
-                $"OData query against '{entitySetOrPath}' failed: {ex.Message}", ex);
-        }
-
         var records = new List<JsonElement>();
         try
         {
+            using var response = conn.Client.ExecuteWebRequest(HttpMethod.Get, queryPath, string.Empty, headers);
             await ParseValueArrayAsync(response, records, ct).ConfigureAwait(false);
+
+            // Dataverse can still return @odata.nextLink when $top is specified
+            // (for example when the requested top exceeds the server page size).
+            // Always follow pagination links and let the helper stop once the
+            // requested number of records has been accumulated.
+            await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             throw new InvalidOperationException(
                 $"OData query against '{entitySetOrPath}' failed: {ex.Message}", ex);
         }
-
-        // Dataverse can still return @odata.nextLink when $top is specified
-        // (for example when the requested top exceeds the server page size).
-        // Always follow pagination links and let the helper stop once the
-        // requested number of records has been accumulated.
-        await FollowNextLinksAsync(conn, response, records, top, headers, ct).ConfigureAwait(false);
 
         if (!includeAnnotations)
             StripAnnotations(records);
@@ -303,7 +283,19 @@ internal sealed class DataverseQueryService : IDataverseQueryService
             if (doc.RootElement.TryGetProperty("error", out var errorElement) &&
                 errorElement.TryGetProperty("message", out var messageElement))
             {
-                return messageElement.GetString();
+                if (messageElement.ValueKind == JsonValueKind.String)
+                {
+                    return messageElement.GetString();
+                }
+
+                // OData error payloads may represent "message" as an object
+                // such as { "lang": "en-US", "value": "..." }.
+                if (messageElement.ValueKind == JsonValueKind.Object &&
+                    messageElement.TryGetProperty("value", out var valueElement) &&
+                    valueElement.ValueKind == JsonValueKind.String)
+                {
+                    return valueElement.GetString();
+                }
             }
         }
         catch (JsonException)
@@ -345,12 +337,27 @@ internal sealed class DataverseQueryService : IDataverseQueryService
             // Extract relative path from the absolute nextLink URL.
             var relativePath = ExtractRelativePath(nextLinkUrl, conn);
 
-            currentResponse = conn.Client.ExecuteWebRequest(HttpMethod.Get, relativePath, string.Empty, headers);
-            await ParseValueArrayAsync(currentResponse, records, ct).ConfigureAwait(false);
+            // Dispose paginated responses to avoid socket/handler leaks.
+            var nextResponse = conn.Client.ExecuteWebRequest(HttpMethod.Get, relativePath, string.Empty, headers);
+            try
+            {
+                await ParseValueArrayAsync(nextResponse, records, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                // Keep the reference for the next iteration's content read.
+                if (currentResponse != lastResponse)
+                    currentResponse.Dispose();
+                currentResponse = nextResponse;
+            }
 
             if (top.HasValue && records.Count >= top.Value)
                 break;
         }
+
+        // Dispose the last paginated response (but not the caller's initial response).
+        if (currentResponse != lastResponse)
+            currentResponse.Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Smoke testing `txc` v1.7.0 revealed several error-reporting gaps. This PR improves user-facing messages across OData queries, SQL parsing, connection creation, and record commands.

## Changes

| Area | Improvement |
|------|-------------|
| **OData response handling** | Check HTTP status before parsing response body; surface Dataverse `error.message` instead of generic SDK exceptions (e.g. `"Operation returned an invalid status code 'NotFound'"`) |
| **Query error context** | Enrich OData and SQL query errors with the entity set name/path (e.g. `"OData query against 'fakeentityset' failed: ..."`) |
| **SQL parse errors** | Include the input SQL text in FROM-clause parse errors so users can see what failed |
| **Connection URL warning** | Non-blocking DNS reachability check when creating connections; warns if hostname is unresolvable (connection still saved) |
| **GUID validation** | Use DotMake `ValidationPattern` + `ValidationMessage` on all 7 record command GUID arguments for clear validation messages instead of raw `System.Guid` parse errors |

## Error messages are MCP-safe
All messages are purely descriptive — no `"run txc ..."` suggestions, since errors are also surfaced via MCP where terminal command suggestions are inappropriate.

## Files changed (9)
- `src/TALXIS.CLI.Platform.Dataverse.Data/DataverseQueryService.cs`
- `src/TALXIS.CLI.Core/Bootstrapping/ConnectionUpsertService.cs`
- 7× `src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecord*CliCommand.cs`

## Testing
- Build passes with 0 errors
- Smoke tested error scenarios against `https://org2928f636.crm.dynamics.com`