### PR TITLE
chore: improve CLI naming consistency and developer UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ txc env setting list --filter powerApps
 
 **Enable Power Apps Code Apps:**
 ```sh
-txc env setting update --name powerApps_AllowCodeApps --value true
+txc env setting update powerApps_AllowCodeApps true
 ```
 
 ### Application Plane
@@ -207,15 +207,15 @@ txc env entity create --name tom_project \
   --display-name "Project" --plural-name "Projects" \
   --ownership user --apply
 
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_budget --type money --display-name "Budget" --apply
 
 # Or stage everything and apply in one optimised batch
 txc env entity create --name tom_invoice \
   --display-name "Invoice" --plural-name "Invoices" --stage
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_amount --type money --display-name "Amount" --stage
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_duedate --type datetime --display-name "Due Date" --stage
 
 txc env changeset status          # review what's queued

--- a/docs/changeset-staging.md
+++ b/docs/changeset-staging.md
@@ -32,10 +32,10 @@ txc env entity create --name tom_project \
   --ownership user --stage
 
 # Stage attributes on the new entity
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_name --type string --display-name "Name" --stage
 
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_budget --type money --display-name "Budget" --stage
 ```
 
@@ -137,17 +137,17 @@ txc env entity create --name tom_invoice \
   --ownership user --has-notes --stage
 
 # 2. Stage attributes
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_number --type string --display-name "Invoice Number" --stage
 
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_amount --type money --display-name "Amount" --stage
 
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_issuedate --type datetime --display-name "Issue Date" \
   --datetime-format dateonly --stage
 
-txc env entity attribute create --entity tom_invoice \
+txc env entity attribute create tom_invoice \
   --name tom_status --type choice --display-name "Status" \
   --options "Draft,Sent,Paid,Cancelled" --stage
 

--- a/docs/environment-settings.md
+++ b/docs/environment-settings.md
@@ -4,7 +4,7 @@
 
 ```sh
 txc env setting list [--filter <substring>] [--format json|text]
-txc env setting update --name <setting> --value <value>
+txc env setting update <setting> <value>
 ```
 
 All commands respect `--profile` for targeting a specific environment. See [profiles-and-authentication.md](profiles-and-authentication.md).
@@ -17,7 +17,7 @@ Copilot and AI features are enabled by default in new environments. You can turn
 
 **Disable Copilot control in model-driven apps:**
 ```sh
-txc env setting update --name appcopilotenabled --value 0
+txc env setting update appcopilotenabled 0
 ```
 
 **Disable AI form fill assistance (automatic predictions on edit forms):**
@@ -40,17 +40,17 @@ txc env setting list --filter EnableFormInsights
 
 **Disable AI Builder preview scenarios:**
 ```sh
-txc env setting update --name paipreviewscenarioenabled --value false
+txc env setting update paipreviewscenarioenabled false
 ```
 
 **Disable AI Prompts:**
 ```sh
-txc env setting update --name aipromptsenabled --value false
+txc env setting update aipromptsenabled false
 ```
 
 **Disable the maker Copilot bot:**
 ```sh
-txc env setting update --name powerappsmakerbotenabled --value false
+txc env setting update powerappsmakerbotenabled false
 ```
 
 You can verify the changes by listing the relevant settings:
@@ -64,7 +64,7 @@ txc env setting list --filter ai
 Power Apps code-first (custom pages, code components beyond PCF) requires an explicit opt-in at the environment level via the control plane:
 
 ```sh
-txc env setting update --name PowerApps_AllowCodeApps --value true
+txc env setting update PowerApps_AllowCodeApps true
 ```
 
 Verify:
@@ -77,7 +77,7 @@ txc env setting list --filter AllowCodeApps
 Enable or disable Dataverse auditing:
 
 ```sh
-txc env setting update --name isauditenabled --value true
+txc env setting update isauditenabled true
 ```
 
 ### File upload limits
@@ -85,7 +85,7 @@ txc env setting update --name isauditenabled --value true
 Increase the maximum file upload size (in KB):
 
 ```sh
-txc env setting update --name maxuploadfilesize --value 131072
+txc env setting update maxuploadfilesize 131072
 ```
 
 ### Blocked file extensions
@@ -93,7 +93,7 @@ txc env setting update --name maxuploadfilesize --value 131072
 Update the list of blocked attachment file extensions:
 
 ```sh
-txc env setting update --name blockedattachments --value "exe;bat;com;cmd"
+txc env setting update blockedattachments "exe;bat;com;cmd"
 ```
 
 ## Discovering settings

--- a/docs/schema-management.md
+++ b/docs/schema-management.md
@@ -120,9 +120,9 @@ Creates a new attribute (column) on an entity. The `--type` flag determines whic
 
 **Common options (all types):**
 
-| Option | Required | Default | Description |
-|--------|----------|---------|-------------|
-| `--entity` | Yes | — | Target entity logical name |
+| Argument/Option | Required | Default | Description |
+|-----------------|----------|---------|-------------|
+| `<entity>` (positional) | Yes | — | Target entity logical name |
 | `--name` | Yes | — | Attribute logical name |
 | `--type` | Yes | — | Attribute type (see [types](#attribute-types)) |
 | `--display-name` | No | — | Display name |
@@ -233,22 +233,22 @@ Creates a new attribute (column) on an entity. The `--type` flag determines whic
 
 ```sh
 # String attribute
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_code --type string --display-name "Code" \
   --max-length 20 --required required --apply
 
 # Money attribute
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_budget --type money --display-name "Budget" \
   --precision 2 --apply
 
 # Lookup attribute
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_accountid --type lookup --display-name "Account" \
   --target-entity account --apply
 
 # Choice attribute
-txc env entity attribute create --entity tom_project \
+txc env entity attribute create tom_project \
   --name tom_priority --type choice --display-name "Priority" \
   --options "Low,Medium,High,Critical" --apply
 ```
@@ -257,22 +257,22 @@ txc env entity attribute create --entity tom_project \
 
 Retrieves detailed metadata for a single attribute.
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `--entity` | Yes | Entity logical name |
+| Argument/Option | Required | Description |
+|-----------------|----------|-------------|
+| `<entity>` (positional) | Yes | Entity logical name |
 | `--name` | Yes | Attribute logical name |
 
 ```sh
-txc env entity attribute get --entity account --name name
+txc env entity attribute get account --name name
 ```
 
 ### `txc env entity attribute update`
 
 Updates an existing attribute's display metadata.
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `--entity` | Yes | Entity logical name |
+| Argument/Option | Required | Description |
+|-----------------|----------|-------------|
+| `<entity>` (positional) | Yes | Entity logical name |
 | `--name` | Yes | Attribute logical name |
 | `--display-name` | No | New display name |
 | `--description` | No | New description |
@@ -281,7 +281,7 @@ Updates an existing attribute's display metadata.
 > **Note:** Updating `RequiredLevel` uses a Web API `PUT` (full replacement) internally, because the SDK's `UpdateAttributeRequest` silently ignores `RequiredLevel` changes. See [dataverse-metadata-performance.md](dataverse-metadata-performance.md) for details.
 
 ```sh
-txc env entity attribute update --entity account --name name \
+txc env entity attribute update account --name name \
   --required required --apply
 ```
 
@@ -289,14 +289,14 @@ txc env entity attribute update --entity account --name name \
 
 Deletes an attribute. Destructive — requires `--yes`.
 
-| Option | Required | Description |
-|--------|----------|-------------|
-| `--entity` | Yes | Entity logical name |
+| Argument/Option | Required | Description |
+|-----------------|----------|-------------|
+| `<entity>` (positional) | Yes | Entity logical name |
 | `--name` | Yes | Attribute logical name |
 | `--yes` | No | Skip confirmation prompt |
 
 ```sh
-txc env entity attribute delete --entity tom_project --name tom_code --yes --apply
+txc env entity attribute delete tom_project --name tom_code --yes --apply
 ```
 
 ---
@@ -379,7 +379,7 @@ txc env entity relationship delete --name tom_project_account --yes --apply
 
 Manage global option sets and individual options on both local and global option sets.
 
-### `txc env entity optionset create-global`
+### `txc env entity optionset global create`
 
 Creates a new global option set.
 
@@ -392,12 +392,12 @@ Creates a new global option set.
 | `--solution` | No | Solution unique name |
 
 ```sh
-txc env entity optionset create-global \
+txc env entity optionset global create \
   --name tom_priority --display-name "Priority" \
   --options "Low,Medium,High,Critical" --apply
 ```
 
-### `txc env entity optionset delete-global`
+### `txc env entity optionset global delete`
 
 Deletes a global option set. Destructive — requires `--yes`.
 
@@ -406,7 +406,15 @@ Deletes a global option set. Destructive — requires `--yes`.
 | `--name` | Yes | Global option set name |
 | `--yes` | No | Skip confirmation prompt |
 
-### `txc env entity optionset add-option`
+### `txc env entity optionset global list`
+
+Lists all global option sets in the environment.
+
+```sh
+txc env entity optionset global list
+```
+
+### `txc env entity optionset option add`
 
 Adds an option to a local or global option set. Target the option set by providing either `--entity` + `--attribute` (local) or `--global-optionset` (global).
 
@@ -421,11 +429,11 @@ Adds an option to a local or global option set. Target the option set by providi
 \* Provide either `--entity` + `--attribute` or `--global-optionset`.
 
 ```sh
-txc env entity optionset add-option \
+txc env entity optionset option add \
   --global-optionset tom_priority --label "Urgent" --apply
 ```
 
-### `txc env entity optionset delete-option`
+### `txc env entity optionset option delete`
 
 Removes an option from a local or global option set. Destructive — requires `--yes`.
 
@@ -436,11 +444,3 @@ Removes an option from a local or global option set. Destructive — requires `-
 | `--global-optionset` | No* | Global option set name |
 | `--value` | Yes | Integer value of the option to remove |
 | `--yes` | No | Skip confirmation prompt |
-
-### `txc env entity optionset list-global`
-
-Lists all global option sets in the environment.
-
-```sh
-txc env entity optionset list-global
-```

--- a/src/TALXIS.CLI.Core/Shared/ProfiledCliCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/ProfiledCliCommand.cs
@@ -50,7 +50,7 @@ public abstract class ProfiledCliCommand : TxcLeafCommand
 
     [CliOption(
         Name = "--profile",
-        Aliases = new[] { "-p" },
+        Aliases = ["-p"],
         Description = "Profile name to resolve (falls back to TXC_PROFILE, workspace pin, or global active).",
         Required = false)]
     public string? Profile { get; set; }

--- a/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
@@ -37,7 +37,7 @@ public abstract class TxcLeafCommand
 
     [CliOption(
         Name = "--format",
-        Aliases = new[] { "-f" },
+        Aliases = ["-f"],
         Description = "Output format: json (default when piped) or text (default in terminal).",
         Required = false)]
     public string? Format { get; set; }

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthAddServicePrincipalCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthAddServicePrincipalCliCommand.cs
@@ -21,7 +21,7 @@ namespace TALXIS.CLI.Features.Config.Auth;
 [CliIdempotent]
 [CliCommand(
     Name = "add-service-principal",
-    Aliases = new[] { "add-sp" },
+    Aliases = ["add-sp"],
     Description = "Register a client-secret service principal credential."
 )]
 public class AuthAddServicePrincipalCliCommand : TxcLeafCommand
@@ -34,7 +34,7 @@ public class AuthAddServicePrincipalCliCommand : TxcLeafCommand
     [CliOption(Name = "--tenant", Description = "Entra tenant id or domain.", Required = true)]
     public string Tenant { get; set; } = string.Empty;
 
-    [CliOption(Name = "--application-id", Aliases = new[] { "--app-id", "--client-id" }, Description = "Entra application (client) id.", Required = true)]
+    [CliOption(Name = "--application-id", Aliases = ["--app-id", "--client-id"], Description = "Entra application (client) id.", Required = true)]
     public string ApplicationId { get; set; } = string.Empty;
 
     [CliOption(Name = "--cloud", Description = "Sovereign cloud. Default: public.", Required = false)]

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthCliCommand.cs
@@ -19,7 +19,8 @@ namespace TALXIS.CLI.Features.Config.Auth;
         typeof(AuthListCliCommand),
         typeof(AuthShowCliCommand),
         typeof(AuthDeleteCliCommand),
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class AuthCliCommand
 {

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthDeleteCliCommand.cs
@@ -27,7 +27,7 @@ public class AuthDeleteCliCommand : TxcLeafCommand, IDestructiveCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(AuthDeleteCliCommand));
 
-    [CliOption(Name = "--yes", Description = "Skip confirmation for this destructive operation.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     [CliArgument(Description = "Credential alias (id) to delete.")]

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
@@ -20,6 +20,7 @@ namespace TALXIS.CLI.Features.Config.Auth;
 /// Fails fast with exit 1 in headless contexts — interactive browser is
 /// never a permitted headless kind. See <see cref="HeadlessAuthRequiredException"/>.
 /// </remarks>
+[CliIdempotent]
 [McpIgnore]
 [CliCommand(
     Name = "login",

--- a/src/TALXIS.CLI.Features.Config/ConfigClearCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/ConfigClearCliCommand.cs
@@ -14,14 +14,19 @@ namespace TALXIS.CLI.Features.Config;
 /// profiles, connections, credentials, settings, secret vault, MSAL token
 /// cache, and the workspace pin discoverable from the current directory.
 /// </summary>
+[CliDestructive("Permanently removes all persisted txc configuration, credentials, and auth state from this device.")]
 [McpIgnore]
 [CliCommand(
     Name = "clear",
     Description = "Remove all persisted txc configuration and auth state from this device."
 )]
-public sealed class ConfigClearCliCommand : TxcLeafCommand
+public sealed class ConfigClearCliCommand : TxcLeafCommand, IDestructiveCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ConfigClearCliCommand));
+
+    /// <inheritdoc />
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
+    public bool Yes { get; set; }
 
     protected override async Task<int> ExecuteAsync()
     {

--- a/src/TALXIS.CLI.Features.Config/ConfigCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/ConfigCliCommand.cs
@@ -5,12 +5,10 @@ namespace TALXIS.CLI.Features.Config;
 /// <summary>
 /// Root <c>config</c> command group — wired into
 /// <c>TxcCliCommand.Children</c> so <c>txc config …</c> is invocable and
-/// MCP discovers <c>config_*</c> tools. Alias <c>c</c> keeps day-to-day
-/// typing short (e.g. <c>txc c p select customer-a-dev</c>).
+/// MCP discovers <c>config_*</c> tools.
 /// </summary>
 [CliCommand(
     Name = "config",
-    Aliases = new[] { "c" },
     Description = "Manage txc profiles, connections, credentials, and settings.",
     Children = new[]
     {
@@ -19,7 +17,8 @@ namespace TALXIS.CLI.Features.Config;
         typeof(Connection.ConnectionCliCommand),
         typeof(Profile.ProfileCliCommand),
         typeof(Setting.SettingCliCommand),
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class ConfigCliCommand
 {

--- a/src/TALXIS.CLI.Features.Config/Connection/ConnectionCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Connection/ConnectionCliCommand.cs
@@ -19,7 +19,8 @@ namespace TALXIS.CLI.Features.Config.Connection;
         typeof(ConnectionListCliCommand),
         typeof(ConnectionShowCliCommand),
         typeof(ConnectionDeleteCliCommand),
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class ConnectionCliCommand
 {

--- a/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Connection/ConnectionCreateCliCommand.cs
@@ -31,16 +31,16 @@ public class ConnectionCreateCliCommand : TxcLeafCommand
     [CliOption(Name = "--provider", Description = "Connection provider. Only 'dataverse' is supported in v1.", Required = true)]
     public ProviderKind Provider { get; set; }
 
-    [CliOption(Name = "--environment", Aliases = new[] { "--url" }, Description = "Dataverse environment URL (required for --provider dataverse).", Required = false)]
+    [CliOption(Name = "--environment", Aliases = ["--url"], Description = "Dataverse environment URL (required for --provider dataverse).", Required = false)]
     public string? EnvironmentUrl { get; set; }
 
     [CliOption(Name = "--cloud", Description = "Sovereign cloud for Dataverse. Default: public.", Required = false)]
     public CloudInstance? Cloud { get; set; }
 
-    [CliOption(Name = "--organization-id", Aliases = new[] { "--org-id" }, Description = "Dataverse organization id (GUID). Optional.", Required = false)]
+    [CliOption(Name = "--organization-id", Aliases = ["--org-id"], Description = "Dataverse organization id (GUID). Optional.", Required = false)]
     public string? OrganizationId { get; set; }
 
-    [CliOption(Name = "--environment-id", Aliases = new[] { "--env-id" }, Description = "Power Platform environment id (GUID) used by the control plane API. Optional — if omitted, it may be resolved later during `txc config profile create --url ...` bootstrap or at runtime when calling control-plane commands.", Required = false)]
+    [CliOption(Name = "--environment-id", Aliases = ["--env-id"], Description = "Power Platform environment id (GUID) used by the control plane API. Optional — if omitted, it may be resolved later during `txc config profile create --url ...` bootstrap or at runtime when calling control-plane commands.", Required = false)]
     public string? EnvironmentId { get; set; }
 
     [CliOption(Name = "--tenant", Description = "Entra tenant id or domain. Optional — defaults to the credential's tenant at resolve time.", Required = false)]

--- a/src/TALXIS.CLI.Features.Config/Connection/ConnectionDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Connection/ConnectionDeleteCliCommand.cs
@@ -25,7 +25,7 @@ public class ConnectionDeleteCliCommand : TxcLeafCommand, IDestructiveCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ConnectionDeleteCliCommand));
 
-    [CliOption(Name = "--yes", Description = "Skip confirmation for this destructive operation.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     [CliArgument(Description = "Connection name.")]

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileCliCommand.cs
@@ -10,7 +10,6 @@ namespace TALXIS.CLI.Features.Config.Profile;
 /// </summary>
 [CliCommand(
     Name = "profile",
-    Aliases = new[] { "p" },
     Description = "Manage profiles (bind one auth to one connection).",
     Children = new[]
     {
@@ -23,7 +22,8 @@ namespace TALXIS.CLI.Features.Config.Profile;
         typeof(ProfileUnpinCliCommand),
         typeof(ProfileValidateCliCommand),
         typeof(ProfileDeleteCliCommand),
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class ProfileCliCommand
 {

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileCreateCliCommand.cs
@@ -41,7 +41,7 @@ public class ProfileCreateCliCommand : TxcLeafCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ProfileCreateCliCommand));
 
-    [CliOption(Name = "--name", Aliases = new[] { "-n" }, Description = "Profile name (slug). Optional — derived from the Power Platform environment name and URL host, or from --connection when omitted.", Required = false)]
+    [CliOption(Name = "--name", Aliases = ["-n"], Description = "Profile name (slug). Optional — derived from the Power Platform environment name and URL host, or from --connection when omitted.", Required = false)]
     public string? Name { get; set; }
 
     [CliOption(Name = "--url", Description = "Service URL to bootstrap from. Triggers interactive sign-in, credential upsert, and connection creation in one step.", Required = false)]

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileDeleteCliCommand.cs
@@ -29,7 +29,7 @@ public class ProfileDeleteCliCommand : TxcLeafCommand, IDestructiveCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ProfileDeleteCliCommand));
 
-    [CliOption(Name = "--yes", Description = "Skip confirmation for this destructive operation.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     [CliArgument(Description = "Profile name.")]

--- a/src/TALXIS.CLI.Features.Config/Profile/ProfileUnpinCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Profile/ProfileUnpinCliCommand.cs
@@ -25,7 +25,7 @@ public class ProfileUnpinCliCommand : TxcLeafCommand, IDestructiveCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ProfileUnpinCliCommand));
 
-    [CliOption(Name = "--yes", Description = "Skip confirmation for this destructive operation.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     protected override Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Config/Setting/SettingCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Setting/SettingCliCommand.cs
@@ -16,7 +16,8 @@ namespace TALXIS.CLI.Features.Config.Setting;
         typeof(SettingSetCliCommand),
         typeof(SettingGetCliCommand),
         typeof(SettingListCliCommand),
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class SettingCliCommand
 {

--- a/src/TALXIS.CLI.Features.Data/DataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataCliCommand.cs
@@ -4,7 +4,8 @@ namespace TALXIS.CLI.Features.Data;
 
 [CliCommand(
     Description = "Offline data utilities for modeling, demonstration, migration and integration",
-    Children = new[] { typeof(TransformCliCommand), typeof(DataPackageCliCommand), typeof(DataModelCliCommand) }
+    Children = new[] { typeof(TransformCliCommand), typeof(DataPackageCliCommand), typeof(DataModelCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class DataCliCommand
 {

--- a/src/TALXIS.CLI.Features.Data/DataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataCliCommand.cs
@@ -3,7 +3,7 @@ using DotMake.CommandLine;
 namespace TALXIS.CLI.Features.Data;
 
 [CliCommand(
-    Description = "Data utilities for modeling, demostration, migration and integration",
+    Description = "Offline data utilities for modeling, demonstration, migration and integration",
     Children = new[] { typeof(TransformCliCommand), typeof(DataPackageCliCommand), typeof(DataModelCliCommand) }
 )]
 public class DataCliCommand

--- a/src/TALXIS.CLI.Features.Data/DataModelCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataModelCliCommand.cs
@@ -5,7 +5,8 @@ namespace TALXIS.CLI.Features.Data;
 [CliCommand(
     Name = "model",
     Description = "Data modeling utilities",
-    Children = new[] { typeof(DataModelConvertCliCommand) }
+    Children = new[] { typeof(DataModelConvertCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class DataModelCliCommand
 {

--- a/src/TALXIS.CLI.Features.Data/DataModelConvertCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataModelConvertCliCommand.cs
@@ -18,6 +18,7 @@ public class DataModelConvertCliCommand : TxcLeafCommand
 
     [CliOption(
         Name = "--input",
+        Aliases = ["-i"],
         Description = "Path to the input: a solution project folder (.cdsproj/.csproj with SolutionRootPath), a declarations folder, or a .zip solution file. Defaults to the current directory.",
         Required = false
     )]
@@ -33,7 +34,8 @@ public class DataModelConvertCliCommand : TxcLeafCommand
 
     [CliOption(
         Name = "--output",
-        Description = $"Directory to write the output file into. Defaults to the '{ExportsFolderName}/' folder in the current directory (auto-created and gitignored).",
+        Aliases = ["-o"],
+        Description = $"Directory path to write the output file into. Defaults to the '{ExportsFolderName}/' folder in the current directory (auto-created and gitignored).",
         Required = false
     )]
     public string? OutputDirectory { get; set; }

--- a/src/TALXIS.CLI.Features.Data/DataPackageCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageCliCommand.cs
@@ -6,7 +6,8 @@ namespace TALXIS.CLI.Features.Data;
     Name = "package",
     Alias = "pkg",
     Description = "Configuration migration tool (CMT) for moving data between different environments",
-    Children = new[] { typeof(DataPackageConvertCliCommand), typeof(DataPackageImportCliCommand), typeof(DataPackageExportCliCommand) }
+    Children = new[] { typeof(DataPackageConvertCliCommand), typeof(DataPackageImportCliCommand), typeof(DataPackageExportCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class DataPackageCliCommand
 {

--- a/src/TALXIS.CLI.Features.Data/DataPackageConvertCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageConvertCliCommand.cs
@@ -15,6 +15,7 @@ public class DataPackageConvertCliCommand : TxcLeafCommand
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(DataPackageConvertCliCommand));
     [CliOption(
         Name = "--input",
+        Aliases = ["-i"],
         Description = "Path to the input XLSX file",
         Required = true
     )]
@@ -22,7 +23,8 @@ public class DataPackageConvertCliCommand : TxcLeafCommand
 
     [CliOption(
         Name = "--output",
-        Description = "Path to the output XML file",
+        Aliases = ["-o"],
+        Description = "File path for the output XML file",
         Required = true
     )]
     public string? OutputPath { get; set; }

--- a/src/TALXIS.CLI.Features.Data/DataPackageExportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageExportCliCommand.cs
@@ -21,7 +21,7 @@ public class DataPackageExportCliCommand : ProfiledCliCommand
     [CliOption(Name = "--schema", Alias = "-s", Description = "Path to the schema file (data_schema.xml) that defines which entities, fields and relationships to export. You can create this file using the Configuration Migration Tool GUI or write it by hand.", Required = true)]
     public required string Schema { get; set; }
 
-    [CliOption(Name = "--output", Alias = "-o", Description = "Output folder for the extracted data package (default), or path to a .zip file when --zip is used.", Required = true)]
+    [CliOption(Name = "--output", Alias = "-o", Description = "Directory path for the extracted data package (default), or file path to a .zip archive when --zip is used.", Required = true)]
     public required string Output { get; set; }
 
     [CliOption(Name = "--export-files", Description = "Also download binary file and image columns (e.g. profile pictures, attachments). These are saved inside the zip in a 'files' folder. Off by default because it can be slow for large files.", Required = false)]

--- a/src/TALXIS.CLI.Features.Data/DataPackageExportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageExportCliCommand.cs
@@ -19,10 +19,10 @@ public class DataPackageExportCliCommand : ProfiledCliCommand
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(DataPackageExportCliCommand));
 
     [CliOption(Name = "--schema", Alias = "-s", Description = "Path to the schema file (data_schema.xml) that defines which entities, fields and relationships to export. You can create this file using the Configuration Migration Tool GUI or write it by hand.", Required = true)]
-    public required string Schema { get; set; }
+    public string Schema { get; set; } = null!;
 
     [CliOption(Name = "--output", Alias = "-o", Description = "Directory path for the extracted data package (default), or file path to a .zip archive when --zip is used.", Required = true)]
-    public required string Output { get; set; }
+    public string Output { get; set; } = null!;
 
     [CliOption(Name = "--export-files", Description = "Also download binary file and image columns (e.g. profile pictures, attachments). These are saved inside the zip in a 'files' folder. Off by default because it can be slow for large files.", Required = false)]
     [DefaultValue(false)]

--- a/src/TALXIS.CLI.Features.Data/TransformCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/TransformCliCommand.cs
@@ -3,7 +3,8 @@ using DotMake.CommandLine;
 namespace TALXIS.CLI.Features.Data;
 
 [CliCommand(
-    Description = "Data-related utilities for ETL, Power Query and migration scenarios"
+    Description = "Data-related utilities for ETL, Power Query and migration scenarios",
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class TransformCliCommand
 {
@@ -14,7 +15,8 @@ public class TransformCliCommand
     [CliCommand(
         Description = "HTTP server for ETL and data transformation tasks",
         Children = new[] { typeof(TransformServerStartCliCommand) },
-        Name = "server")]
+        Name = "server",
+        ShortFormAutoGenerate = CliNameAutoGenerate.None)]
     public class TransformServerCliCommand
     {
         public void Run(CliContext context)

--- a/src/TALXIS.CLI.Features.Environment/Changeset/ChangesetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Changeset/ChangesetCliCommand.cs
@@ -8,7 +8,8 @@ namespace TALXIS.CLI.Features.Environment.Changeset;
 [CliCommand(
     Name = "changeset",
     Description = "Manage staged operations for batch apply to the environment.",
-    Children = new[] { typeof(ChangesetStatusCliCommand), typeof(ChangesetDiscardCliCommand), typeof(ChangesetApplyCliCommand) }
+    Children = new[] { typeof(ChangesetStatusCliCommand), typeof(ChangesetDiscardCliCommand), typeof(ChangesetApplyCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class ChangesetCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Changeset/ChangesetDiscardCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Changeset/ChangesetDiscardCliCommand.cs
@@ -22,7 +22,7 @@ public class ChangesetDiscardCliCommand : TxcLeafCommand, IDestructiveCommand
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ChangesetDiscardCliCommand));
 
     /// <inheritdoc />
-    [CliOption(Name = "--yes", Description = "Skip confirmation prompt.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     protected override Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Data.Bulk;
 [CliCommand(
     Name = "bulk",
     Description = "Bulk operations (CreateMultiple, UpdateMultiple, UpsertMultiple) against the environment.",
-    Children = new[] { typeof(EnvDataBulkCreateCliCommand), typeof(EnvDataBulkUpdateCliCommand), typeof(EnvDataBulkUpsertCliCommand) }
+    Children = new[] { typeof(EnvDataBulkCreateCliCommand), typeof(EnvDataBulkUpdateCliCommand), typeof(EnvDataBulkUpsertCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EnvDataBulkCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
@@ -8,7 +8,7 @@ namespace TALXIS.CLI.Features.Environment.Data;
 /// </summary>
 [CliCommand(
     Name = "data",
-    Description = "Data operations against the live environment (query, record CRUD, bulk operations).",
+    Description = "Data operations against a live Dataverse environment (query, record CRUD, bulk operations)",
     Children = new[] { typeof(Query.EnvDataQueryCliCommand), typeof(Record.EnvDataRecordCliCommand), typeof(Bulk.EnvDataBulkCliCommand) }
 )]
 public class EnvDataCliCommand

--- a/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/EnvDataCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Data;
 [CliCommand(
     Name = "data",
     Description = "Data operations against a live Dataverse environment (query, record CRUD, bulk operations)",
-    Children = new[] { typeof(Query.EnvDataQueryCliCommand), typeof(Record.EnvDataRecordCliCommand), typeof(Bulk.EnvDataBulkCliCommand) }
+    Children = new[] { typeof(Query.EnvDataQueryCliCommand), typeof(Record.EnvDataRecordCliCommand), typeof(Bulk.EnvDataBulkCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EnvDataCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Query/EnvDataQueryCliCommand.cs
@@ -8,7 +8,8 @@ namespace TALXIS.CLI.Features.Environment.Data.Query;
 [CliCommand(
     Name = "query",
     Description = "Execute data queries against the environment.",
-    Children = new[] { typeof(EnvDataQuerySqlCliCommand), typeof(EnvDataQueryFetchXmlCliCommand), typeof(EnvDataQueryODataCliCommand) }
+    Children = new[] { typeof(EnvDataQuerySqlCliCommand), typeof(EnvDataQueryFetchXmlCliCommand), typeof(EnvDataQueryODataCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EnvDataQueryCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordAssociateCliCommand.cs
@@ -24,7 +24,7 @@ public class EnvDataRecordAssociateCliCommand : StagedCliCommand
         Description = "The GUID of the source record.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]
     public string Entity { get; set; } = null!;

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Data.Record;
 [CliCommand(
     Name = "record",
     Description = "Single-record CRUD operations against the environment.",
-    Children = new[] { typeof(EnvDataRecordGetCliCommand), typeof(EnvDataRecordCreateCliCommand), typeof(EnvDataRecordUpdateCliCommand), typeof(EnvDataRecordDeleteCliCommand), typeof(EnvDataRecordDownloadFileCliCommand), typeof(EnvDataRecordUploadFileCliCommand), typeof(EnvDataRecordAssociateCliCommand), typeof(EnvDataRecordDisassociateCliCommand) }
+    Children = new[] { typeof(EnvDataRecordGetCliCommand), typeof(EnvDataRecordCreateCliCommand), typeof(EnvDataRecordUpdateCliCommand), typeof(EnvDataRecordDeleteCliCommand), typeof(EnvDataRecordDownloadFileCliCommand), typeof(EnvDataRecordUploadFileCliCommand), typeof(EnvDataRecordAssociateCliCommand), typeof(EnvDataRecordDisassociateCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EnvDataRecordCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDeleteCliCommand.cs
@@ -18,7 +18,7 @@ namespace TALXIS.CLI.Features.Environment.Data.Record;
 )]
 public class EnvDataRecordDeleteCliCommand : StagedCliCommand, IDestructiveCommand
 {
-    [CliOption(Name = "--yes", Description = "Skip confirmation for this destructive operation.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EnvDataRecordDeleteCliCommand));
@@ -30,7 +30,7 @@ public class EnvDataRecordDeleteCliCommand : StagedCliCommand, IDestructiveComma
         Description = "The GUID of the record to delete.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     protected override async Task<int> ExecuteAsync()
     {

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDisassociateCliCommand.cs
@@ -28,7 +28,7 @@ public class EnvDataRecordDisassociateCliCommand : StagedCliCommand, IDestructiv
         Description = "The GUID of the source record.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--entity", Description = "Entity logical name of the source record.", Required = true)]
     public string Entity { get; set; } = null!;

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
@@ -27,7 +27,7 @@ public class EnvDataRecordDownloadFileCliCommand : ProfiledCliCommand
         Description = "The GUID of the record containing the file.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]
     public string Column { get; set; } = null!;

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
@@ -32,7 +32,7 @@ public class EnvDataRecordDownloadFileCliCommand : ProfiledCliCommand
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]
     public string Column { get; set; } = null!;
 
-    [CliOption(Name = "--output", Description = "Local path where the file will be saved.", Required = true)]
+    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Local file path where the downloaded file will be saved.", Required = true)]
     public string Output { get; set; } = null!;
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordGetCliCommand.cs
@@ -27,7 +27,7 @@ public class EnvDataRecordGetCliCommand : ProfiledCliCommand
         Description = "The GUID of the record to retrieve.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--columns", Description = "Comma-separated column names to retrieve.", Required = false)]
     public string? Columns { get; set; }

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -28,7 +28,7 @@ public class EnvDataRecordUpdateCliCommand : StagedCliCommand
         Description = "The GUID of the record to update.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update.", Required = false)]
     public string? Data { get; set; }

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
@@ -27,7 +27,7 @@ public class EnvDataRecordUploadFileCliCommand : StagedCliCommand
         Description = "The GUID of the record to upload the file to.",
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
-    public Guid RecordId { get; set; }
+    public required Guid RecordId { get; set; }
 
     [CliOption(Name = "--column", Description = "Logical name of the file/image column.", Required = true)]
     public string Column { get; set; } = null!;

--- a/src/TALXIS.CLI.Features.Environment/Deployment/DeploymentCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Deployment/DeploymentCliCommand.cs
@@ -6,7 +6,8 @@ namespace TALXIS.CLI.Features.Environment.Deployment;
     Name = "deployment",
     Alias = "deploy",
     Description = "Inspect past package and solution deployment runs in the target environment.",
-    Children = new[] { typeof(DeploymentListCliCommand), typeof(DeploymentShowCliCommand) }
+    Children = new[] { typeof(DeploymentListCliCommand), typeof(DeploymentShowCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class DeploymentCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 [CliCommand(
     Name = "attribute",
     Description = "Create and manage entity attributes (columns).",
-    Children = new[] { typeof(EntityAttributeGetCliCommand), typeof(EntityAttributeCreateCliCommand), typeof(EntityAttributeUpdateCliCommand), typeof(EntityAttributeDeleteCliCommand), typeof(EntityAttributeTypeCliCommand) }
+    Children = new[] { typeof(EntityAttributeGetCliCommand), typeof(EntityAttributeCreateCliCommand), typeof(EntityAttributeUpdateCliCommand), typeof(EntityAttributeDeleteCliCommand), typeof(EntityAttributeTypeCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EntityAttributeCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
@@ -11,13 +11,13 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Creates an attribute (column) on a Dataverse entity.
-/// Usage: <c>txc environment entity attribute create --entity &lt;name&gt; --name &lt;schema-name&gt; --type &lt;type&gt; [options]</c>
-/// Use <c>txc environment entity attribute type describe &lt;type&gt;</c> to see type-specific parameters.
+/// Usage: <c>txc environment entity attribute create &lt;entity&gt; --name &lt;schema-name&gt; --type &lt;type&gt; [options]</c>
+/// Use <c>txc environment entity attribute type show &lt;type&gt;</c> to see type-specific parameters.
 /// </summary>
 [CliIdempotent]
 [CliCommand(
     Name = "create",
-    Description = "Create a column (attribute) on an entity. Use 'txc environment entity attribute type describe <type>' to see type-specific parameters."
+    Description = "Create a column (attribute) on an entity. Use 'txc environment entity attribute type show <type>' to see type-specific parameters."
 )]
 #pragma warning disable TXC003
 public class EntityAttributeCreateCliCommand : StagedCliCommand
@@ -26,7 +26,7 @@ public class EntityAttributeCreateCliCommand : StagedCliCommand
 
     // === Required for all types ===
 
-    [CliOption(Name = "--entity", Description = "Entity logical name.", Required = true)]
+    [CliArgument(Description = "Entity logical name.")]
     public string Entity { get; set; } = null!;
 
     [CliOption(Name = "--name", Description = "Schema name for the new column.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
@@ -12,12 +12,12 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 /// <summary>
 /// Creates an attribute (column) on a Dataverse entity.
 /// Usage: <c>txc environment entity attribute create &lt;entity&gt; --name &lt;schema-name&gt; --type &lt;type&gt; [options]</c>
-/// Use <c>txc environment entity attribute type show &lt;type&gt;</c> to see type-specific parameters.
+/// Use <c>txc environment entity attribute type describe &lt;type&gt;</c> to see type-specific parameters.
 /// </summary>
 [CliIdempotent]
 [CliCommand(
     Name = "create",
-    Description = "Create a column (attribute) on an entity. Use 'txc environment entity attribute type show <type>' to see type-specific parameters."
+    Description = "Create a column (attribute) on an entity. Use 'txc environment entity attribute type describe <type>' to see type-specific parameters."
 )]
 #pragma warning disable TXC003
 public class EntityAttributeCreateCliCommand : StagedCliCommand

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeDeleteCliCommand.cs
@@ -10,7 +10,7 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Deletes an attribute (column) from a Dataverse entity.
-/// Usage: <c>txc environment entity attribute delete --entity &lt;name&gt; --name &lt;name&gt;</c>
+/// Usage: <c>txc environment entity attribute delete &lt;entity&gt; --name &lt;name&gt;</c>
 /// </summary>
 [CliDestructive("Permanently deletes the attribute from the remote environment.")]
 [CliCommand(
@@ -25,7 +25,7 @@ public class EntityAttributeDeleteCliCommand : StagedCliCommand, IDestructiveCom
     [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
-    [CliOption(Name = "--entity", Description = "The logical name of the entity.", Required = true)]
+    [CliArgument(Description = "The logical name of the entity.")]
     public string Entity { get; set; } = null!;
 
     [CliOption(Name = "--name", Description = "The logical name of the attribute to delete.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeGetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeGetCliCommand.cs
@@ -10,7 +10,7 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Retrieves detailed metadata for a single attribute (column) on a Dataverse entity.
-/// Usage: <c>txc environment entity attribute get --entity &lt;name&gt; --name &lt;name&gt; [-p profile] [--format json]</c>
+/// Usage: <c>txc environment entity attribute get &lt;entity&gt; --name &lt;name&gt; [-p profile] [--format json]</c>
 /// </summary>
 [CliReadOnly]
 [CliCommand(
@@ -22,8 +22,8 @@ public class EntityAttributeGetCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EntityAttributeGetCliCommand));
 
-    [CliOption(Name = "--entity", Description = "Entity logical name.", Required = true)]
-    public string Entity { get; set; } = null!;
+    [CliArgument(Description = "Entity logical name.")]
+    public required string Entity { get; set; }
 
     [CliOption(Name = "--name", Description = "Attribute logical name.", Required = true)]
     public string Name { get; set; } = null!;

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeTypeCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeTypeCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 [CliCommand(
     Name = "type",
     Description = "Discover available attribute types and their parameters.",
-    Children = new[] { typeof(EntityAttributeTypeListCliCommand), typeof(EntityAttributeTypeDescribeCliCommand) }
+    Children = new[] { typeof(EntityAttributeTypeListCliCommand), typeof(EntityAttributeTypeDescribeCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EntityAttributeTypeCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeUpdateCliCommand.cs
@@ -10,7 +10,7 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Updates an existing attribute (column) on a Dataverse entity.
-/// Usage: <c>txc environment entity attribute update --entity &lt;name&gt; --name &lt;name&gt; [--display-name &lt;label&gt;] [--description &lt;text&gt;] [--required &lt;none|recommended|required&gt;]</c>
+/// Usage: <c>txc environment entity attribute update &lt;entity&gt; --name &lt;name&gt; [--display-name &lt;label&gt;] [--description &lt;text&gt;] [--required &lt;none|recommended|required&gt;]</c>
 /// </summary>
 [CliIdempotent]
 [CliCommand(
@@ -22,7 +22,7 @@ public class EntityAttributeUpdateCliCommand : StagedCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EntityAttributeUpdateCliCommand));
 
-    [CliOption(Name = "--entity", Description = "The logical name of the entity.", Required = true)]
+    [CliArgument(Description = "The logical name of the entity.")]
     public string Entity { get; set; } = null!;
 
     [CliOption(Name = "--name", Description = "The logical name of the attribute to update.", Required = true)]

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetAddOptionCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetAddOptionCliCommand.cs
@@ -10,11 +10,11 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Adds an option value to a local or global option set.
-/// Usage: <c>txc environment entity optionset add-option --label &lt;text&gt; (--global-optionset &lt;name&gt; | --entity &lt;name&gt; --attribute &lt;name&gt;) [--value &lt;int&gt;]</c>
+/// Usage: <c>txc environment entity optionset option add --label &lt;text&gt; (--global-optionset &lt;name&gt; | --entity &lt;name&gt; --attribute &lt;name&gt;) [--value &lt;int&gt;]</c>
 /// </summary>
 [CliIdempotent]
 [CliCommand(
-    Name = "add-option",
+    Name = "add",
     Description = "Add an option value to a local or global option set."
 )]
 #pragma warning disable TXC003

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetCliCommand.cs
@@ -4,21 +4,64 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Parent command for option set operations.
-/// Usage: <c>txc environment entity optionset [create-global|add-option|delete-option|list-global]</c>
+/// Usage: <c>txc environment entity optionset [global|option]</c>
 /// </summary>
 [CliCommand(
     Name = "optionset",
     Description = "Create and manage option sets (choices).",
     Children = new[]
     {
-        typeof(EntityOptionSetCreateGlobalCliCommand),
-        typeof(EntityOptionSetDeleteGlobalCliCommand),
-        typeof(EntityOptionSetAddOptionCliCommand),
-        typeof(EntityOptionSetDeleteOptionCliCommand),
-        typeof(EntityOptionSetListGlobalCliCommand)
-    }
+        typeof(EntityOptionSetGlobalCliCommand),
+        typeof(EntityOptionSetOptionCliCommand)
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EntityOptionSetCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}
+
+/// <summary>
+/// Group command for global option set operations.
+/// Usage: <c>txc environment entity optionset global [create|delete|list]</c>
+/// </summary>
+[CliCommand(
+    Name = "global",
+    Description = "Manage global option sets.",
+    Children = new[]
+    {
+        typeof(EntityOptionSetCreateGlobalCliCommand),
+        typeof(EntityOptionSetDeleteGlobalCliCommand),
+        typeof(EntityOptionSetListGlobalCliCommand)
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
+)]
+public class EntityOptionSetGlobalCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}
+
+/// <summary>
+/// Group command for individual option (value) operations.
+/// Usage: <c>txc environment entity optionset option [add|delete]</c>
+/// </summary>
+[CliCommand(
+    Name = "option",
+    Description = "Add or remove individual options (values) in an option set.",
+    Children = new[]
+    {
+        typeof(EntityOptionSetAddOptionCliCommand),
+        typeof(EntityOptionSetDeleteOptionCliCommand)
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
+)]
+public class EntityOptionSetOptionCliCommand
 {
     public void Run(CliContext context)
     {

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetCreateGlobalCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetCreateGlobalCliCommand.cs
@@ -10,11 +10,11 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Creates a new global option set (choice) in Dataverse.
-/// Usage: <c>txc environment entity optionset create-global --name &lt;schema-name&gt; --display-name &lt;label&gt; --options &lt;csv&gt; [--description &lt;text&gt;] [--solution &lt;name&gt;]</c>
+/// Usage: <c>txc environment entity optionset global create --name &lt;schema-name&gt; --display-name &lt;label&gt; --options &lt;csv&gt; [--description &lt;text&gt;] [--solution &lt;name&gt;]</c>
 /// </summary>
 [CliIdempotent]
 [CliCommand(
-    Name = "create-global",
+    Name = "create",
     Description = "Create a new global option set (choice)."
 )]
 #pragma warning disable TXC003

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetDeleteGlobalCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetDeleteGlobalCliCommand.cs
@@ -10,11 +10,11 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Deletes an existing global option set (choice) from Dataverse.
-/// Usage: <c>txc environment entity optionset delete-global --name &lt;schema-name&gt; [-p profile] --apply</c>
+/// Usage: <c>txc environment entity optionset global delete --name &lt;schema-name&gt; [-p profile] --apply</c>
 /// </summary>
 [CliDestructive("Permanently deletes the global option set from the remote environment.")]
 [CliCommand(
-    Name = "delete-global",
+    Name = "delete",
     Description = "Delete a global option set (choice)."
 )]
 #pragma warning disable TXC003

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetDeleteOptionCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetDeleteOptionCliCommand.cs
@@ -10,11 +10,11 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Deletes an option value from a local or global option set.
-/// Usage: <c>txc environment entity optionset delete-option --value &lt;int&gt; (--global-optionset &lt;name&gt; | --entity &lt;name&gt; --attribute &lt;name&gt;)</c>
+/// Usage: <c>txc environment entity optionset option delete --value &lt;int&gt; (--global-optionset &lt;name&gt; | --entity &lt;name&gt; --attribute &lt;name&gt;)</c>
 /// </summary>
 [CliDestructive("Permanently deletes the option from the option set.")]
 [CliCommand(
-    Name = "delete-option",
+    Name = "delete",
     Description = "Delete an option value from a local or global option set."
 )]
 #pragma warning disable TXC003

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetListGlobalCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityOptionSetListGlobalCliCommand.cs
@@ -10,11 +10,11 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 
 /// <summary>
 /// Lists all global option sets in the environment.
-/// Usage: <c>txc environment entity optionset list-global [--format json]</c>
+/// Usage: <c>txc environment entity optionset global list [--format json]</c>
 /// </summary>
 [CliReadOnly]
 [CliCommand(
-    Name = "list-global",
+    Name = "list",
     Description = "List all global option sets in the environment."
 )]
 #pragma warning disable TXC003

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityRelationshipCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityRelationshipCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Environment.Entity;
 [CliCommand(
     Name = "relationship",
     Description = "Create and list entity relationships.",
-    Children = new[] { typeof(EntityRelationshipCreateCliCommand), typeof(EntityRelationshipListCliCommand), typeof(EntityRelationshipDeleteCliCommand) }
+    Children = new[] { typeof(EntityRelationshipCreateCliCommand), typeof(EntityRelationshipListCliCommand), typeof(EntityRelationshipDeleteCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EntityRelationshipCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentCliCommand.cs
@@ -6,7 +6,8 @@ namespace TALXIS.CLI.Features.Environment;
     Name = "environment",
     Alias = "env",
     Description = "Manage the footprint of your project in a live target environment (packages, solutions, deployment history).",
-    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand), typeof(Data.EnvDataCliCommand), typeof(Entity.EntityCliCommand), typeof(Setting.SettingCliCommand), typeof(Changeset.ChangesetCliCommand) }
+    Children = new[] { typeof(Package.PackageCliCommand), typeof(Solution.SolutionCliCommand), typeof(Deployment.DeploymentCliCommand), typeof(Data.EnvDataCliCommand), typeof(Entity.EntityCliCommand), typeof(Setting.SettingCliCommand), typeof(Changeset.ChangesetCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class EnvironmentCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Package/PackageCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Package/PackageCliCommand.cs
@@ -6,7 +6,8 @@ namespace TALXIS.CLI.Features.Environment.Package;
     Name = "package",
     Alias = "pkg",
     Description = "Manage deployable packages in the target environment.",
-    Children = new[] { typeof(PackageImportCliCommand), typeof(PackageUninstallCliCommand) }
+    Children = new[] { typeof(PackageImportCliCommand), typeof(PackageUninstallCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class PackageCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Package/PackageImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Package/PackageImportCliCommand.cs
@@ -19,7 +19,7 @@ public class PackageImportCliCommand : ProfiledCliCommand
     private readonly NuGetPackageInstallerService _packageInstaller = new();
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(PackageImportCliCommand));
 
-    [CliArgument(Name = "package", Description = "NuGet package name, local .pdpkg.zip/.pdpkg/.zip archive path, or extracted package folder path.", Required = true)]
+    [CliArgument(Name = "package", Description = "NuGet package name, local .pdpkg.zip/.pdpkg/.zip archive path, or extracted package folder path.")]
     public required string Package { get; set; }
 
     [CliOption(Name = "--version", Description = "NuGet package version (only when 'package' is a NuGet name).", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Package/PackageUninstallCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Package/PackageUninstallCliCommand.cs
@@ -18,7 +18,7 @@ public class PackageUninstallCliCommand : ProfiledCliCommand, IDestructiveComman
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(PackageUninstallCliCommand));
 
-    [CliArgument(Name = "package", Description = "NuGet package name, local .pdpkg.zip/.pdpkg/.zip archive path, or extracted package folder path.", Required = true)]
+    [CliArgument(Name = "package", Description = "NuGet package name, local .pdpkg.zip/.pdpkg/.zip archive path, or extracted package folder path.")]
     public required string Package { get; set; }
 
     [CliOption(Name = "--version", Description = "NuGet package version when 'package' is a NuGet name. Defaults to 'latest'.", Required = false)]
@@ -27,7 +27,7 @@ public class PackageUninstallCliCommand : ProfiledCliCommand, IDestructiveComman
     [CliOption(Name = "--output", Aliases = ["-o"], Description = "Directory for temporary/downloaded package assets when resolving from NuGet.", Required = false)]
     public string? OutputDirectory { get; set; }
 
-    [CliOption(Name = "--yes", Description = "Confirm destructive uninstall actions.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Setting/SettingCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Setting/SettingCliCommand.cs
@@ -10,7 +10,8 @@ namespace TALXIS.CLI.Features.Environment.Setting;
 [CliCommand(
     Name = "setting",
     Description = "Manage environment settings.",
-    Children = new[] { typeof(SettingListCliCommand), typeof(SettingUpdateCliCommand) }
+    Children = new[] { typeof(SettingListCliCommand), typeof(SettingUpdateCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class SettingCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Setting/SettingUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Setting/SettingUpdateCliCommand.cs
@@ -20,10 +20,10 @@ public class SettingUpdateCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SettingUpdateCliCommand));
 
-    [CliOption(Name = "--name", Aliases = new[] { "-n" }, Description = "Name of the setting to update (e.g. PowerApps_AllowCodeApps, isauditenabled).", Required = true)]
+    [CliArgument(Description = "Name of the setting to update (e.g. PowerApps_AllowCodeApps, isauditenabled).")]
     public required string Name { get; set; }
 
-    [CliOption(Name = "--value", Aliases = new[] { "-v" }, Description = "Value to set. Booleans (true/false) and integers are auto-coerced.", Required = true)]
+    [CliArgument(Description = "Value to set. Booleans (true/false) and integers are auto-coerced.")]
     public required string Value { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionCliCommand.cs
@@ -6,7 +6,8 @@ namespace TALXIS.CLI.Features.Environment.Solution;
     Name = "solution",
     Alias = "sln",
     Description = "Manage solutions in the target environment.",
-    Children = new[] { typeof(SolutionImportCliCommand), typeof(SolutionUninstallCliCommand), typeof(SolutionListCliCommand) }
+    Children = new[] { typeof(SolutionImportCliCommand), typeof(SolutionUninstallCliCommand), typeof(SolutionListCliCommand) },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class SolutionCliCommand
 {

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
@@ -18,7 +18,7 @@ public class SolutionImportCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SolutionImportCliCommand));
 
-    [CliArgument(Name = "solution-zip", Description = "Path to the solution .zip to import.", Required = true)]
+    [CliArgument(Name = "solution-zip", Description = "Path to the solution .zip to import.")]
     public required string SolutionZip { get; set; }
 
     [CliOption(Name = "--stage-and-upgrade", Description = "Use single-step upgrade when applicable.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionUninstallCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionUninstallCliCommand.cs
@@ -18,10 +18,10 @@ public class SolutionUninstallCliCommand : ProfiledCliCommand, IDestructiveComma
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SolutionUninstallCliCommand));
 
-    [CliArgument(Name = "name", Description = "Solution unique name.", Required = true)]
+    [CliArgument(Name = "name", Description = "Solution unique name.")]
     public required string Name { get; set; }
 
-    [CliOption(Name = "--yes", Description = "Confirm destructive uninstall action.", Required = false)]
+    [CliOption(Name = "--yes", Description = "Skip interactive confirmation for this destructive operation.", Required = false)]
     public bool Yes { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Workspace/ComponentCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ComponentCliCommand.cs
@@ -5,11 +5,12 @@ namespace TALXIS.CLI.Features.Workspace;
 [CliCommand(
     Description = "Create or modify components of your solution",
     Name = "component",
-    Alias = "c",
+    Alias = "comp",
     Children = new[]
     {
         typeof(ComponentCreateCliCommand)
-    })]
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None)]
 public class ComponentCliCommand
 {
     public void Run(CliContext context)
@@ -20,7 +21,8 @@ public class ComponentCliCommand
     [CliCommand(
         Description = "Parameters for a specific component",
         Children = new[] { typeof(ComponentParameterListCliCommand) },
-        Name = "parameter")]
+        Name = "parameter",
+        ShortFormAutoGenerate = CliNameAutoGenerate.None)]
     public class ComponentParameterCliCommand
     {
         public void Run(CliContext context)
@@ -32,7 +34,8 @@ public class ComponentCliCommand
     [CliCommand(
         Description = "Types of available components",
         Children = new[] { typeof(ComponentTypeListCliCommand), typeof(ComponentTypeExplainCliCommand) },
-        Name = "type")]
+        Name = "type",
+        ShortFormAutoGenerate = CliNameAutoGenerate.None)]
     public class ComponentTypeCliCommand
     {
         public void Run(CliContext context)

--- a/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
@@ -17,8 +17,8 @@ public class ComponentCreateCliCommand : TxcLeafCommand, ICliGetCompletions
     [CliArgument(Description = "Type of the component (e.g. 'pp-entity')")]
     public required string Type { get; set; }
 
-    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Directory path where the new component will be scaffolded")]
-    public required string OutputPath { get; set; }
+    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Directory path where the new component will be scaffolded", Required = true)]
+    public string OutputPath { get; set; } = null!;
 
     // Conflicts with OutputPath in our templates
     // [CliOption(Name = "name", Aliases = ["-n"], Description = "The name for the created output. If not specified, the name of the output directory is used.", Required = false)]

--- a/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
@@ -17,7 +17,7 @@ public class ComponentCreateCliCommand : TxcLeafCommand, ICliGetCompletions
     [CliArgument(Description = "Type of the component (e.g. 'pp-entity')")]
     public required string Type { get; set; }
 
-    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Output path for the new component")]
+    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Directory path where the new component will be scaffolded")]
     public required string OutputPath { get; set; }
 
     // Conflicts with OutputPath in our templates

--- a/src/TALXIS.CLI.Features.Workspace/Metamodel/MetamodelCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Metamodel/MetamodelCliCommand.cs
@@ -22,7 +22,6 @@ namespace TALXIS.CLI.Features.Workspace.Metamodel;
 [CliCommand(
     Description = "Reserved — not yet implemented.",
     Name = "metamodel",
-    Alias = "mm",
     Children = new[]
     {
         typeof(MetamodelDescribeCliCommand),

--- a/src/TALXIS.CLI.Features.Workspace/ProjectCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ProjectCliCommand.cs
@@ -4,11 +4,12 @@ namespace TALXIS.CLI.Features.Workspace;
 
 [CliCommand(
     Description = "Work with MSBuild projects in your workspace (solutions, plugins, libraries, controls...)",
-    Alias = "p",
+    Alias = "proj",
     Children = new[]
     {
         typeof(ProjectExplainCliCommand)
-    }
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class ProjectCliCommand
 {

--- a/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
@@ -10,7 +10,8 @@ namespace TALXIS.CLI.Features.Workspace;
         typeof(ComponentCliCommand),
         typeof(ProjectCliCommand),
         typeof(WorkspaceExplainCliCommand)
-    })]
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None)]
 public class WorkspaceCliCommand
 {
     public void Run(CliContext context)


### PR DESCRIPTION
## Summary

Comprehensive consistency pass across the `txc` CLI surface (~90 commands, 62 files changed).

### Breaking Changes ⚠️
- **Command aliases removed/changed**: `config` no longer has `c` alias; `config profile` no longer has `p`; `workspace project` alias changed `p` → `proj`; `workspace component` alias changed `c` → `comp`; `metamodel` alias `mm` removed
- **Optionset commands restructured**: `optionset create-global` → `optionset global create`, `optionset add-option` → `optionset option add`, etc.
- **`env setting update`**: `--name`/`--value` options changed to positional arguments (now: `txc env setting update <name> <value>`)
- **Entity attribute commands**: `--entity` changed from named option to positional argument across `get`, `create`, `update`, `delete`

### Non-Breaking Improvements
- Standardized `--yes` description across all 14 destructive commands
- Unified alias declaration syntax to C# 12 collection expressions (`Aliases = [...]`)
- Added missing `-o`/`-i` short aliases for `--output`/`--input` options
- Fixed typo "demostration" → "demonstration"
- Clarified `txc data` (offline) vs `txc env data` (live) scope in descriptions
- Clarified `--output` descriptions to specify file path vs directory path
- Standardized `required` keyword for arguments, `Required = true` attribute for options
- Added `[CliDestructive]` to `ConfigClear`, `[CliIdempotent]` to `AuthLogin`
- Added `ShortFormAutoGenerate = None` to all group commands to prevent auto-generated alias conflicts
