### PR TITLE
fix: remove stray return in comp layer commands causing silent exit 2

### DIFF
--- a/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerListCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerListCliCommand.cs
@@ -40,7 +40,6 @@ public class ComponentLayerListCliCommand : ProfiledCliCommand
         if (resolved is null)
             return ExitValidationError;
         var (componentId, typeName) = resolved.Value;
-            return ExitValidationError;
 
         var service = TxcServices.Get<ISolutionLayerQueryService>();
         var layers = await service.ListLayersAsync(Profile, componentId, typeName, CancellationToken.None).ConfigureAwait(false);

--- a/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerRemoveCustomizationCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerRemoveCustomizationCliCommand.cs
@@ -38,7 +38,6 @@ public class ComponentLayerRemoveCustomizationCliCommand : ProfiledCliCommand, I
         if (resolved is null)
             return ExitValidationError;
         var (componentId, typeName) = resolved.Value;
-            return ExitValidationError;
 
         if (!Guid.TryParse(componentId, out var guid))
         {

--- a/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerShowCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Layer/ComponentLayerShowCliCommand.cs
@@ -34,7 +34,6 @@ public class ComponentLayerShowCliCommand : ProfiledCliCommand
         if (resolved is null)
             return ExitValidationError;
         var (componentId, typeName) = resolved.Value;
-            return ExitValidationError;
 
         var service = TxcServices.Get<ISolutionLayerQueryService>();
         var json = await service.GetActiveLayerJsonAsync(Profile, componentId, typeName, CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
## Problem

All three `Component/Layer` commands (`list`, `show`, `remove-customization`) silently exit with code 2 (validation error) on every invocation, regardless of input.

## Root Cause

A stray `return ExitValidationError;` after the tuple deconstruction of `ComponentIdResolver.TryResolveAsync` result causes the method to return immediately. The rest of `ExecuteAsync()` is dead code:

```csharp
var resolved = await ComponentIdResolver.TryResolveAsync(...);
if (resolved is null)
    return ExitValidationError;
var (componentId, typeName) = resolved.Value;
    return ExitValidationError;  // ← BUG: always executes
```

The `Component/Dependency/` commands use the same pattern but do NOT have this issue.

## Fix

Remove the stray `return ExitValidationError;` from all three files.

## Affected Files

- `ComponentLayerListCliCommand.cs`
- `ComponentLayerShowCliCommand.cs`
- `ComponentLayerRemoveCustomizationCliCommand.cs`

## Testing

Found during comprehensive E2E testing of v1.8.0 against a sandbox environment. All `comp layer` commands now have the same pattern as the working `comp dep` commands.