### PR TITLE
fix: MCP error reporting, scaffolding serialization, and skill documentation

### DIFF
--- a/src/TALXIS.CLI.Features.Docs/Skills/bpf-development.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/bpf-development.md
@@ -8,9 +8,9 @@ Business Process Flows (BPFs) guide users through stages and steps on a record f
 
 BPF creation follows a strict 3-step chain. **Order matters.**
 
-1. **Create BPF Entity** → `workspace_component_create` with `componentType: "BPF"`
-2. **Add Stages** → `workspace_component_create` with `componentType: "BPFStage"`
-3. **Add Steps to Stages** → `workspace_component_create` with `componentType: "BPFStageStep"`
+1. **Create BPF Entity** → `workspace_component_create` with `componentType: "pp-bpf"`
+2. **Add Stages** → `workspace_component_create` with `componentType: "pp-bpf-stage"`
+3. **Add Steps to Stages** → `workspace_component_create` with `componentType: "pp-bpf-stage-step"`
 
 Call `workspace_component_parameter_list` for required parameters at each step.
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
@@ -10,7 +10,13 @@ Scaffolding creates **local files** in your workspace — it does NOT create com
 2. **`workspace_component_type_list`** — discover available component types
 3. **`workspace_component_parameter_list`** — get required parameters for a component type
 4. **`workspace_component_create`** — scaffold the component locally
-5. **Build locally** to validate, then follow the [deployment workflow](deployment-workflow.md)
+5. **Build locally** to validate: `dotnet build`
+6. **Run schema validation** to catch XML errors early:
+   ```
+   dotnet msbuild -t:InitializeSolutionPackagerWorkingDirectory;ValidateSolutionComponentSchema
+   ```
+   This validates all solution XML files against XSD schemas. Run it from each solution project directory.
+7. Follow the [deployment workflow](deployment-workflow.md)
 
 ## Composition Ordering
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
@@ -12,8 +12,6 @@ Scaffolding creates **local files** in your workspace — it does NOT create com
 4. **`workspace_component_create`** — scaffold the component locally
 5. **Build locally** to validate, then follow the [deployment workflow](deployment-workflow.md)
 
-**Default convention:** Always pass `SolutionRootPath=Declarations` unless the user specifies a different solution project path.
-
 ## Composition Ordering
 
 Scaffold components in dependency order:
@@ -22,6 +20,15 @@ Scaffold components in dependency order:
 3. **Relationships** — after both source and target entities exist
 4. **Forms** — after entity and its attributes exist
 5. **Views** — after entity and its attributes exist
+
+## Key Parameter Conventions
+
+- **`LogicalName`** (in pp-entity, pp-entity-attribute, pp-optionset-global, pp-app-model): The name **without** publisher prefix. The template adds the prefix automatically. Example: `warehouseitem`, not `udpp_warehouseitem`.
+- **`EntitySchemaName`** (in pp-entity-attribute, pp-entity-form, pp-entity-view, pp-form-*): The entity name **with** publisher prefix. Example: `udpp_warehouseitem`.
+- **`EntityLogicalName`** (in pp-sitemap-subarea, pp-app-model-component, pp-ribbon-*): The entity name **with** publisher prefix. Example: `udpp_warehouseitem`.
+- **`AppName`** (in pp-sitemap-*, pp-app-model-component): The app module folder name **with** publisher prefix. Example: `udpp_warehouseapp`.
+- **`ReferencedEntityName`** (in pp-entity-attribute for Lookup types): The target entity **with** publisher prefix. Example: `udpp_warehouseitem`.
+- **`Behavior`** (in pp-entity): Use `New` when creating the entity definition for the first time. Use `Existing` to add a reference to an entity owned by another solution (e.g., adding forms/views in a UI solution for an entity defined in the DataModel solution).
 
 ## What NOT to Do
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/custom-api-development.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/custom-api-development.md
@@ -15,7 +15,7 @@ Choose Custom API when multiple clients or flows need to invoke the same operati
 ## Registration Workflow
 
 1. **Create the backing plugin** first (see [plugin-development](plugin-development.md))
-2. **Scaffold Custom API** → `workspace_component_create` with `componentType: "CustomAPI"`
+2. **Scaffold Custom API** → `workspace_component_create` with `componentType: "pp-api-endpoint"`
 3. **Add request parameters** → scaffold each input parameter
 4. **Add response properties** → scaffold each output property
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/form-xml-reference.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/form-xml-reference.md
@@ -22,7 +22,7 @@ Customizations add XML fragments at specific insertion points rather than replac
 ## Scaffolding Workflow
 
 1. Scaffold the Entity and Attributes **before** scaffolding a Form
-2. Use `workspace_component_create` with form templates (`pp-form-main`, `pp-form-dialog`, etc.)
+2. Use `workspace_component_create` with `pp-entity-form` (set `FormType=main`, `FormType=dialog`, or `FormType=quickCreate`)
 3. Templates handle ClassIDs, hierarchy, and required attributes automatically
 4. Call `workspace_component_parameter_list` for template-specific parameters
 
@@ -32,5 +32,26 @@ Customizations add XML fragments at specific insertion points rather than replac
 - ❌ Don't write form XML manually — use `pp-form-*` templates
 - ❌ Don't scaffold a Form before the Entity and its Attributes exist
 - ❌ Don't forget `<labels>` elements — they're required for localization
+
+## Form Scaffolding Chain
+
+Build forms top-down. Each level is a separate template call:
+
+1. **`pp-entity-form`** — Create the form (main, dialog, or quickCreate)
+2. **`pp-form-tab`** — Add a tab (use `RemoveDefaultTab=True` to replace the empty default)
+3. **`pp-form-column`** — Add a column inside the tab
+4. **`pp-form-section`** — Add a section inside the column
+5. **`pp-form-row`** — Add a row inside the section (one per field)
+6. **`pp-form-cell`** — Add a cell inside the row (provides the label)
+7. **`pp-form-control`** — Add the field control inside the cell
+
+All form fragment templates require `FormId`, `FormType`, and `EntitySchemaName` parameters. Generate the `FormId` GUID once and reuse it across all calls for the same form.
+
+### ControlType values for pp-form-control
+`Text`, `MultilineText`, `WholeNumber`, `Decimal`, `Float`, `Currency`, `DateTime`, `Lookup`, `OptionSet`, `SubGrid`, `Button`
+
+### Dialog-specific templates
+- **`pp-form-dialog-tabfooter`** — Add a footer area to a dialog tab
+- **`pp-form-event-handler`** — Register a JavaScript event (onload, onsave, onchange, onclick)
 
 See also: [component-creation](component-creation.md), [schema-management](schema-management.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/pcf-controls.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/pcf-controls.md
@@ -23,7 +23,7 @@ Power Apps Component Framework (PCF) controls are custom TypeScript UI component
 
 ## Scaffolding and Build
 
-1. Scaffold with `workspace_component_create` using `componentType: "PCFControl"`
+1. Scaffold with `workspace_component_create` using `componentType: "pp-pcf"`
 2. Call `workspace_component_parameter_list` for required parameters
 3. Local dev: `npm run build` and `npm start watch` for test harness
 4. Solution packaging includes the control bundle automatically during `pack`

--- a/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
@@ -14,9 +14,9 @@ Plugins are server-side .NET classes that execute custom business logic in respo
 
 Plugin registration is a 3-step chain. **Order matters** — each step depends on the previous one.
 
-1. **Create Plugin Project** → `workspace_component_create` with `componentType: "PluginProject"`
-2. **Register Assembly** → `workspace_component_create` with `componentType: "PluginAssembly"`
-3. **Register Steps** → `workspace_component_create` with `componentType: "PluginStep"`
+1. **Create Plugin Project** → `workspace_component_create` with `componentType: "pp-plugin"`
+2. **Register Assembly** → `workspace_component_create` with `componentType: "pp-plugin-assembly"`
+3. **Register Steps** → `workspace_component_create` with `componentType: "pp-plugin-assembly-step"`
 
 Call `workspace_component_parameter_list` for required parameters at each step.
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
@@ -55,7 +55,7 @@ Each `.cdsproj` maps to one Dataverse solution. The `Declarations` folder within
 
 - **Entity logical names**: lowercase with publisher prefix (e.g., `prefix_warehouseitem`)
 - **Display names**: Proper case (e.g., `Warehouse Item`)
-- **Publisher prefix**: Max 5 characters, lowercase alphanumeric only
+- **Publisher prefix**: Recommended convention is lowercase alphanumeric and 5 characters or fewer for consistency
 - **Branch naming**: `{userPrefix}/{feature-description}` (trunk-based development)
 
 ## Getting Started

--- a/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
@@ -55,14 +55,14 @@ Each `.cdsproj` maps to one Dataverse solution. The `Declarations` folder within
 
 - **Entity logical names**: lowercase with publisher prefix (e.g., `prefix_warehouseitem`)
 - **Display names**: Proper case (e.g., `Warehouse Item`)
-- **Publisher prefix**: Max 8 characters, unique per organization
+- **Publisher prefix**: Max 5 characters, lowercase alphanumeric only
 - **Branch naming**: `{userPrefix}/{feature-description}` (trunk-based development)
 
 ## Getting Started
 
 1. Run `workspace_explain` to understand what's already in the repo
 2. Identify which solution project your changes belong to
-3. Use `workspace_component_create` with `SolutionRootPath=Declarations` to scaffold
+3. Use `workspace_component_create` to scaffold
 4. Build locally to validate before deploying
 
 See also: [component-creation](component-creation.md), [deployment-workflow](deployment-workflow.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/solution-layering.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/solution-layering.md
@@ -73,7 +73,7 @@ Separate concerns into dedicated solutions:
 
 ### Publisher Rules
 - One publisher per organization for consistency
-- Prefix: max 5 characters, lowercase alphanumeric only (e.g., `udpp`)
+- Prefix: recommended repo convention is max 5 characters, lowercase alphanumeric only (e.g., `udpp`); `txc environment publisher create --prefix` accepts 2–8 lowercase alphanumeric characters
 - All components created under this publisher share the prefix
 
 ## What NOT to Do

--- a/src/TALXIS.CLI.Features.Docs/Skills/solution-layering.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/solution-layering.md
@@ -73,7 +73,7 @@ Separate concerns into dedicated solutions:
 
 ### Publisher Rules
 - One publisher per organization for consistency
-- Prefix: max 8 characters (e.g., `contoso`, `udpp`)
+- Prefix: max 5 characters, lowercase alphanumeric only (e.g., `udpp`)
 - All components created under this publisher share the prefix
 
 ## What NOT to Do

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionCliCommand.cs
@@ -6,7 +6,7 @@ namespace TALXIS.CLI.Features.Environment.Solution;
     Name = "solution",
     Alias = "sln",
     Description = "Manage solutions in the target environment.",
-    Children = new[] { typeof(SolutionImportCliCommand), typeof(SolutionUninstallCliCommand), typeof(SolutionDeleteCliCommand), typeof(SolutionListCliCommand), typeof(SolutionShowCliCommand), typeof(SolutionCreateCliCommand), typeof(SolutionExportCliCommand), typeof(SolutionPackCliCommand), typeof(SolutionPublishCliCommand), typeof(SolutionUninstallCheckCliCommand), typeof(Component.SolutionComponentCliCommand) },
+    Children = new[] { typeof(SolutionImportCliCommand), typeof(SolutionUninstallCliCommand), typeof(SolutionDeleteCliCommand), typeof(SolutionListCliCommand), typeof(SolutionShowCliCommand), typeof(SolutionCreateCliCommand), typeof(SolutionExportCliCommand), typeof(SolutionPackCliCommand), typeof(SolutionUnpackCliCommand), typeof(SolutionPublishCliCommand), typeof(SolutionUninstallCheckCliCommand), typeof(Component.SolutionComponentCliCommand) },
     ShortFormAutoGenerate = CliNameAutoGenerate.None
 )]
 public class SolutionCliCommand

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionUnpackCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionUnpackCliCommand.cs
@@ -1,0 +1,51 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Contracts.Dataverse;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Environment.Solution;
+
+[CliIdempotent]
+[CliCommand(
+    Name = "unpack",
+    Description = "Unpack a solution ZIP file into a folder using SolutionPackager."
+)]
+public class SolutionUnpackCliCommand : TxcLeafCommand
+{
+    protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SolutionUnpackCliCommand));
+
+    [CliArgument(Name = "zip-file", Description = "Path to the solution ZIP file.")]
+    public string ZipFile { get; set; } = null!;
+
+    [CliOption(Name = "--output", Alias = "-o", Description = "Output folder path for unpacked solution.", Required = true)]
+    public string Output { get; set; } = null!;
+
+    [CliOption(Name = "--managed", Description = "Treat the ZIP as a managed solution.", Required = false)]
+    public bool Managed { get; set; }
+
+    protected override Task<int> ExecuteAsync()
+    {
+        if (!File.Exists(ZipFile))
+        {
+            Logger.LogError("ZIP file '{ZipFile}' does not exist.", ZipFile);
+            return Task.FromResult(ExitValidationError);
+        }
+
+        Directory.CreateDirectory(Output);
+        var packager = TxcServices.Get<ISolutionPackagerService>();
+        packager.Unpack(ZipFile, Output, Managed);
+
+        OutputFormatter.WriteData(
+            new { status = "unpacked", zipFile = ZipFile, output = Output, managed = Managed },
+            _ =>
+            {
+#pragma warning disable TXC003
+                OutputWriter.WriteLine($"Unpacked solution → {Output} ({(Managed ? "managed" : "unmanaged")})");
+#pragma warning restore TXC003
+            });
+
+        return Task.FromResult(ExitSuccess);
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
@@ -44,24 +44,35 @@ public class ComponentCreateCliCommand : TxcLeafCommand, ICliGetCompletions
             parameters[key] = value;
         }
         using var scaffolder = new TemplateInvoker();
-        var (success, failedActions) = await scaffolder.ScaffoldAsync(Type, OutputPath, parameters);
-        if (success)
+        var (success, failedActions, failedActionErrors) = await scaffolder.ScaffoldAsync(Type, OutputPath, parameters);
+        if (success && failedActions.Count == 0)
         {
             OutputFormatter.WriteResult("succeeded", $"Component scaffolded to {OutputPath} using template {Type}");
             return ExitSuccess;
         }
         else
         {
-            Logger.LogError("Component scaffolded, but one or more post-actions failed. See errors above.");
+            var failureDetails = new List<string>();
             if (failedActions.Count > 0)
             {
-                Logger.LogError("Summary of failed post-actions:");
+                Logger.LogError("Template files were created but {Count} post-action(s) failed:", failedActions.Count);
                 foreach (var failed in failedActions)
                 {
-                    Logger.LogError("- {FailedAction}", failed.Description ?? failed.ActionId.ToString());
+                    var label = !string.IsNullOrWhiteSpace(failed.Description) ? failed.Description : failed.ActionId.ToString();
+                    var scriptInfo = failed.Args?.TryGetValue("args", out var args) == true ? $" ({args})" : "";
+                    var errorDetail = failedActionErrors.TryGetValue(failed.ActionId, out var detail) ? $" — {detail}" : "";
+                    Logger.LogError("  • {FailedAction}{ScriptInfo}{ErrorDetail}", label, scriptInfo, errorDetail);
+                    failureDetails.Add($"{label}{scriptInfo}{errorDetail}");
                 }
             }
-            OutputFormatter.WriteResult("failed", "Component scaffolded, but one or more post-actions failed.");
+            else
+            {
+                Logger.LogError("Component scaffolding failed. See errors above.");
+            }
+            var message = failureDetails.Count > 0
+                ? $"Template files were created but post-action(s) failed: {string.Join("; ", failureDetails)}"
+                : "Component scaffolding failed";
+            OutputFormatter.WriteResult("failed", message);
             return ExitError;
         }
     }

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PostActionDispatcher.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PostActionDispatcher.cs
@@ -26,19 +26,29 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
             };
         }
 
+        /// <summary>
+        /// Per-action error details from the last RunPostActions call, keyed by the action's ActionId.
+        /// </summary>
+        public Dictionary<Guid, string> FailedActionErrors { get; } = new();
+
         public (PostActionResult, List<IPostAction>) RunPostActions(
             IReadOnlyList<IPostAction> actions, 
             ScriptPermission scriptPermission,
             ITemplateCreationResult? templateCreationResult = null,
             string? outputBasePath = null)
         {
+            FailedActionErrors.Clear();
             var result = PostActionResult.Success;
             var failedActions = new List<IPostAction>();
             foreach (var action in actions)
             {
+                var actionLabel = !string.IsNullOrWhiteSpace(action.Description)
+                    ? action.Description
+                    : action.ActionId.ToString();
+
                 if (!_processors.TryGetValue(action.ActionId, out var processor))
                 {
-                    _logger.LogError("Post-action {ActionId} not supported. Please run manually:", action.ActionId);
+                    _logger.LogError("Post-action '{ActionLabel}' is not supported. Please run manually:", actionLabel);
                     ShowManualInstructions(action);
                     result |= PostActionResult.Failure;
                     failedActions.Add(action);
@@ -47,7 +57,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
 
                 if (processor is RunScriptPostActionProcessor && !_allowScripts(scriptPermission, action))
                 {
-                    _logger.LogInformation("Skipping script post-action {Description} due to script policy", action.Description);
+                    _logger.LogInformation("Skipping script post-action '{ActionLabel}' due to script policy", actionLabel);
                     continue;
                 }
 
@@ -56,14 +66,16 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 if (processor is AddProjectsToSlnPostActionProcessor addProjectProcessor && templateCreationResult?.CreationResult != null)
                 {
                     var basePath = outputBasePath ?? Directory.GetCurrentDirectory();
-                    // We already checked for null above, so we can safely access the property
                     ok = addProjectProcessor.ProcessInternal(_environment, action, null!, templateCreationResult!.CreationResult, basePath);
                 }
                 else if (processor is RunScriptPostActionProcessor runScriptProcessor)
                 {
                     var basePath = outputBasePath ?? Directory.GetCurrentDirectory();
-                    // Use ProcessInternal with explicit outputBasePath for consistent working directory handling
                     ok = runScriptProcessor.ProcessInternal(_environment, action, null!, templateCreationResult?.CreationResult, basePath);
+                    if (!ok && runScriptProcessor.LastError != null)
+                    {
+                        FailedActionErrors[action.ActionId] = runScriptProcessor.LastError;
+                    }
                 }
                 else
                 {
@@ -74,8 +86,13 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 {
                     result |= PostActionResult.Failure;
                     failedActions.Add(action);
+                    var errorDetail = FailedActionErrors.TryGetValue(action.ActionId, out var detail) ? $": {detail}" : "";
+                    _logger.LogError("Post-action '{ActionLabel}' failed{ErrorDetail}", actionLabel, errorDetail);
                     if (!action.ContinueOnError)
-                        throw new InvalidOperationException($"Post-action {action.ActionId} failed");
+                    {
+                        _logger.LogError("Stopping post-action execution (continueOnError is false)");
+                        break;
+                    }
                 }
             }
             return (result, failedActions);

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
@@ -17,6 +17,12 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
 
         public Guid ActionId => ActionProcessorId;
 
+        /// <summary>
+        /// Contains the error detail from the last failed script execution.
+        /// Reset on each call to ProcessInternal/Process.
+        /// </summary>
+        public string? LastError { get; private set; }
+
         public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
         {
             // Fall back to using System.Environment.CurrentDirectory if no explicit output path is provided
@@ -50,6 +56,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 workingDir = Path.GetFullPath(wd);
             }
 
+            LastError = null;
             try
             {
                 _logger.LogInformation("[RunScript] Executing: {Executable} {Args} in {WorkDir}", executable, scriptArgs, workingDir);
@@ -62,11 +69,19 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 
                 LogProcessOutput(stdOut, stdErr, exitCode);
                 
-                return ValidateProcessResult(exitCode, stdErr);
+                var success = ValidateProcessResult(exitCode, stdErr);
+                if (!success)
+                {
+                    LastError = !string.IsNullOrWhiteSpace(stdErr) 
+                        ? $"exit code {exitCode}: {stdErr.Trim()}" 
+                        : $"exit code {exitCode}";
+                }
+                return success;
             }
             catch (Exception ex)
             {
-                _logger.LogError("[RunScript] Failed to run script - {Message}", ex.Message);
+                LastError = ex.Message;
+                _logger.LogError("[RunScript] Failed to run '{Executable} {Args}' in {WorkDir}: {Message}", executable, scriptArgs, workingDir, ex.Message);
                 return false;
             }
         }
@@ -135,7 +150,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
             
             if (!string.IsNullOrWhiteSpace(stdErr))
             {
-                _logger.LogError("[RunScript][stderr]:\n{Output}", stdErr);
+                _logger.LogWarning("[RunScript][stderr]:\n{Output}", stdErr);
             }
             
             _logger.LogInformation("[RunScript] Process exited with code: {ExitCode}", exitCode);
@@ -148,14 +163,15 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         {
             if (exitCode != 0)
             {
-                _logger.LogError("[RunScript] Script failed with exit code {ExitCode}", exitCode);
+                var detail = !string.IsNullOrWhiteSpace(stdErr) ? $"\n{stdErr.Trim()}" : "";
+                _logger.LogError("[RunScript] Script failed with exit code {ExitCode}{Detail}", exitCode, detail);
                 return false;
             }
 
             // Check for PowerShell errors that may not set exit code
             if (HasCriticalErrors(stdErr))
             {
-                _logger.LogError("[RunScript] Script completed with exit code 0 but had critical errors");
+                _logger.LogError("[RunScript] Script completed with exit code 0 but stderr contains errors:\n{StdErr}", stdErr.Trim());
                 return false;
             }
 

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
@@ -72,8 +72,12 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 var success = ValidateProcessResult(exitCode, stdErr);
                 if (!success)
                 {
-                    LastError = !string.IsNullOrWhiteSpace(stdErr) 
-                        ? $"exit code {exitCode}: {stdErr.Trim()}" 
+                    // Strip ANSI codes from the error detail so MCP clients see clean text
+                    var cleanStdErr = !string.IsNullOrWhiteSpace(stdErr) 
+                        ? System.Text.RegularExpressions.Regex.Replace(stdErr.Trim(), @"\x1B\[[0-9;]*m", "") 
+                        : null;
+                    LastError = cleanStdErr != null 
+                        ? $"exit code {exitCode}: {cleanStdErr}" 
                         : $"exit code {exitCode}";
                 }
                 return success;
@@ -186,13 +190,17 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
             if (string.IsNullOrWhiteSpace(stdErr))
                 return false;
 
+            // Strip ANSI escape codes — PowerShell writes colored error output to stderr
+            // which can break keyword matching (e.g., "\x1B[31;1mMove-Item:\x1B[0m" instead of "Move-Item:")
+            var cleanStdErr = System.Text.RegularExpressions.Regex.Replace(stdErr, @"\x1B\[[0-9;]*m", "");
+
             string[] criticalErrors = {
                 "Exception", "Error:", "cannot be loaded because running scripts is disabled",
                 "cannot find path", "does not exist", "CommandNotFoundException",
                 "Access is denied", "UnauthorizedAccessException", "DirectoryNotFoundException", "IOException"
             };
 
-            return criticalErrors.Any(error => stdErr.Contains(error, StringComparison.OrdinalIgnoreCase));
+            return criticalErrors.Any(error => cleanStdErr.Contains(error, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
@@ -73,12 +73,24 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                 if (!success)
                 {
                     // Strip ANSI codes from the error detail so MCP clients see clean text
-                    var cleanStdErr = !string.IsNullOrWhiteSpace(stdErr) 
-                        ? System.Text.RegularExpressions.Regex.Replace(stdErr.Trim(), @"\x1B\[[0-9;]*m", "") 
+                    var cleanStdErr = !string.IsNullOrWhiteSpace(stdErr)
+                        ? System.Text.RegularExpressions.Regex.Replace(stdErr.Trim(), @"\x1B\[[0-9;]*m", "")
                         : null;
-                    LastError = cleanStdErr != null 
-                        ? $"exit code {exitCode}: {cleanStdErr}" 
-                        : $"exit code {exitCode}";
+
+                    // Keep the error summary aligned with the actual validation failure reason.
+                    // A zero exit code can still fail validation when stderr contains critical errors.
+                    if (exitCode != 0)
+                    {
+                        LastError = cleanStdErr != null
+                            ? $"exit code {exitCode}: {cleanStdErr}"
+                            : $"exit code {exitCode}";
+                    }
+                    else
+                    {
+                        LastError = cleanStdErr != null
+                            ? $"critical errors detected in stderr: {cleanStdErr}"
+                            : "critical errors detected in stderr";
+                    }
                 }
                 return success;
             }

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateCreationService.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateCreationService.cs
@@ -207,9 +207,21 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                         catch (Exception ex)
                         {
                             // Defense-in-depth: if RunPostActions throws unexpectedly, surface the error
-                            // instead of letting the exception propagate with no context
-                            _logger.LogError("Post-action execution threw an unexpected exception: {Message}", ex.Message);
-                            return Task.FromResult(new TemplateScaffoldResult { Success = false, FailedActions = new List<IPostAction>() });
+                            // instead of letting the exception propagate with no context.
+                            var errorMessage = $"Post-action execution threw an unexpected exception: {ex.Message}";
+                            _logger.LogError(ex, "Post-action execution threw an unexpected exception.");
+
+                            var failedActionErrors = new Dictionary<Guid, string>(dispatcher.FailedActionErrors)
+                            {
+                                [Guid.Empty] = errorMessage
+                            };
+
+                            return Task.FromResult(new TemplateScaffoldResult
+                            {
+                                Success = false,
+                                FailedActions = new List<IPostAction>(),
+                                FailedActionErrors = failedActionErrors
+                            });
                         }
                         
                         if ((postActionResult & PostActionResult.Failure) != 0)

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateCreationService.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateCreationService.cs
@@ -197,13 +197,30 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                         string actualOutputDirectory = result.OutputBaseDirectory ?? outputPath;
                         // Ensure the path is absolute for post-action processors
                         actualOutputDirectory = Path.GetFullPath(actualOutputDirectory);
-                        var (postActionResult, failedActions) = dispatcher.RunPostActions(postActions, ScriptPermission.Yes, result, actualOutputDirectory);
+
+                        PostActionResult postActionResult;
+                        List<IPostAction> failedActions;
+                        try
+                        {
+                            (postActionResult, failedActions) = dispatcher.RunPostActions(postActions, ScriptPermission.Yes, result, actualOutputDirectory);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Defense-in-depth: if RunPostActions throws unexpectedly, surface the error
+                            // instead of letting the exception propagate with no context
+                            _logger.LogError("Post-action execution threw an unexpected exception: {Message}", ex.Message);
+                            return Task.FromResult(new TemplateScaffoldResult { Success = false, FailedActions = new List<IPostAction>() });
+                        }
                         
                         if ((postActionResult & PostActionResult.Failure) != 0)
                         {
-                            // Some post-actions failed but we still return success for template creation
-                            _logger.LogWarning("Some post-actions failed. Template was created successfully but setup may be incomplete");
-                            return Task.FromResult(new TemplateScaffoldResult { Success = true, FailedActions = failedActions });
+                            // Some post-actions failed but template files were created successfully
+                            var failedDescriptions = failedActions
+                                .Select(a => !string.IsNullOrWhiteSpace(a.Description) ? a.Description : a.ActionId.ToString())
+                                .ToList();
+                            _logger.LogWarning("Template files were created but {Count} post-action(s) failed: {Actions}",
+                                failedActions.Count, string.Join("; ", failedDescriptions));
+                            return Task.FromResult(new TemplateScaffoldResult { Success = true, FailedActions = failedActions, FailedActionErrors = dispatcher.FailedActionErrors });
                         }
                     }
                     

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateInvoker.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateInvoker.cs
@@ -55,7 +55,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         /// <summary>
         /// Scaffolds a template to the specified output path with the given parameters.
         /// </summary>
-        public async Task<(bool Success, List<IPostAction> FailedActions)> ScaffoldAsync(
+        public async Task<(bool Success, List<IPostAction> FailedActions, Dictionary<Guid, string> FailedActionErrors)> ScaffoldAsync(
             string shortName, 
             string outputPath, 
             IDictionary<string, string> parameters, 
@@ -63,7 +63,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
             CancellationToken cancellationToken = default)
         {
             var result = await _templateCreationService.ScaffoldAsync(shortName, outputPath, parameters, version, cancellationToken);
-            return (result.Success, result.FailedActions);
+            return (result.Success, result.FailedActions, result.FailedActionErrors);
         }
 
         public void Dispose()

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateScaffoldResult.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateScaffoldResult.cs
@@ -9,6 +9,10 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
     {
         public bool Success { get; set; }
         public List<IPostAction> FailedActions { get; set; } = new();
+        /// <summary>
+        /// Per-action error details (script stderr, exit codes, exception messages), keyed by ActionId.
+        /// </summary>
+        public Dictionary<Guid, string> FailedActionErrors { get; set; } = new();
     }
 
 

--- a/src/TALXIS.CLI.MCP/Program.cs
+++ b/src/TALXIS.CLI.MCP/Program.cs
@@ -315,7 +315,7 @@ async Task<CallToolResult> ExecuteCliToolAsync(
         string? workspaceRoot = rootsService is not null
             ? await rootsService.GetWorkingDirectoryAsync(ct)
             : null;
-        var lockKey = workspaceRoot ?? Environment.CurrentDirectory;
+        var lockKey = Path.TrimEndingDirectorySeparator(Path.GetFullPath(workspaceRoot ?? Environment.CurrentDirectory));
         outputLock = workspaceOutputLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
         await outputLock.WaitAsync(ct);
     }

--- a/src/TALXIS.CLI.MCP/Program.cs
+++ b/src/TALXIS.CLI.MCP/Program.cs
@@ -19,6 +19,9 @@ IHostApplicationLifetime? appLifetime = null;
 // In-memory store for tool execution logs, exposed as MCP resources
 var toolLogStore = new ToolLogStore();
 
+// Per-output-path lock for workspace_component_create to prevent concurrent writes to the same project
+var workspaceOutputLocks = new System.Collections.Concurrent.ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
+
 // Load internal reasoning skills for guide sampling prompts (proprietary, not exposed)
 var reasoningEngine = new GuideReasoningEngine();
 reasoningEngine.LoadSkills();
@@ -303,6 +306,20 @@ async Task<CallToolResult> ExecuteCliToolAsync(
     string toolName, IReadOnlyDictionary<string, JsonElement>? cliArguments,
     RequestContext<CallToolRequestParams> ctx, CancellationToken ct)
 {
+    // Workspace component create calls must be serialized to prevent concurrent post-action
+    // scripts from racing on shared files. Even different output paths share the .sln file
+    // and may share Solution.xml, so we serialize ALL scaffolding on the workspace root.
+    SemaphoreSlim? outputLock = null;
+    if (toolName == "workspace_component_create")
+    {
+        string? workspaceRoot = rootsService is not null
+            ? await rootsService.GetWorkingDirectoryAsync(ct)
+            : null;
+        var lockKey = workspaceRoot ?? Environment.CurrentDirectory;
+        outputLock = workspaceOutputLocks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+        await outputLock.WaitAsync(ct);
+    }
+
     try
     {
         var cliCommandAdapter = new CliCommandAdapter();
@@ -332,6 +349,10 @@ async Task<CallToolResult> ExecuteCliToolAsync(
     catch (Exception ex)
     {
         return new CallToolResult { Content = [new TextContentBlock { Text = LogRedactionFilter.Redact(ex.ToString()) }], IsError = true };
+    }
+    finally
+    {
+        outputLock?.Release();
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes several issues discovered during end-to-end testing of warehouse management app scaffolding via MCP.

### Error Reporting
- **PostActionDispatcher**: No longer throws on failure — collects errors and returns structured tuple
- **RunScriptPostActionProcessor**: Captures stderr/exit code in `LastError` property; strips ANSI escape codes
- **TemplateCreationService**: Try-catch around `RunPostActions` as defense-in-depth
- **ComponentCreateCliCommand**: Writes error details to stdout so MCP clients see them (was previously only in stderr)

### MCP Scaffolding Serialization
- Serializes all `workspace_component_create` calls per workspace root using `SemaphoreSlim`
- Prevents race conditions on shared files (Solution.xml, .template.scripts, .sln)

### Skill Documentation
- Fixed wrong template names in 5 skills (plugin→pp-plugin, bpf→pp-bpf, etc.)
- Added parameter convention docs (prefix vs no-prefix) to component-creation.md
- Added form scaffolding chain to form-xml-reference.md
- Added schema validation command to workflow
- Fixed publisher prefix limit from 8→5 chars
- Removed hardcoded `SolutionRootPath=Declarations`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>