### PR TITLE
feat: new data-querying and security-roles skills, enrich 4 existing skills

### DIFF
--- a/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
@@ -36,11 +36,19 @@ Scaffold components in dependency order:
 - **`ReferencedEntityName`** (in pp-entity-attribute for Lookup types): The target entity **with** publisher prefix. Example: `udpp_warehouseitem`.
 - **`Behavior`** (in pp-entity): Use `New` when creating the entity definition for the first time. Use `Existing` to add a reference to an entity owned by another solution (e.g., adding forms/views in a UI solution for an entity defined in the DataModel solution).
 
+## Prerequisites
+
+Some templates (pp-plugin-assembly, pp-plugin-assembly-step, pp-security-role-privilege) use C# scripts that require the `dotnet-script` global tool:
+```
+dotnet tool install --global dotnet-script
+```
+
 ## What NOT to Do
 
 - ❌ Don't use `environment_entity_create` for development — it bypasses source control
 - ❌ Don't scaffold a Form or View before the Entity and its Attributes exist — XML references will break
 - ❌ Don't scaffold a Relationship if the target table hasn't been created yet
+- ❌ Don't run `pp-plugin-assembly` before building the plugin project (`dotnet build`) — it reads the compiled DLL
 - ✅ Use environment tools only for inspection, troubleshooting, or emergency fixes
 
 See also: [project-structure](project-structure.md), [schema-management](schema-management.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/data-migration.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/data-migration.md
@@ -70,4 +70,15 @@ After any data operation, verify the results:
 - ❌ Don't import directly to production without testing on dev/test first
 - ❌ Don't skip post-import verification — silent data issues are hard to catch later
 
+## Bulk Import Best Practices
+
+**Adaptive Chunk Sizing:** Start with 1000 records per batch. Double on success (cap at 4000), halve on 413/500/timeout errors. This auto-tunes to the environment's capacity.
+
+**FK-Ordered Import:** When importing multiple related tables, import in dependency order:
+1. Tables with no foreign keys first (reference data)
+2. Then tables that depend on them (transactional data)
+3. Use `data record bulk upsert` for idempotent re-runs
+
+**Lookup Resolution:** Before importing records with lookups, query the target table to build a name→GUID map. Use this to populate lookup fields in the import data.
+
 See also: [environment-management](environment-management.md), [troubleshooting](troubleshooting.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/data-querying.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/data-querying.md
@@ -1,0 +1,66 @@
+# Data Querying
+
+## Choosing a Query Language
+
+| Scenario | Language | Tool |
+|---|---|---|
+| Analytics, joins, aggregation | SQL | `environment_data_query_sql` |
+| CRUD, filtering, lookup expansion | OData | `environment_data_query_odata` |
+| Complex Dataverse-native queries (linked entities, conditions) | FetchXML | `environment_data_query_fetchxml` |
+| Quick record listing with filters | — | `environment_data_record_list` |
+| Record counts | — | `environment_data_record_count` |
+
+## OData Query Patterns
+
+### Selecting and Filtering
+```
+?$select=name,revenue&$filter=revenue gt 1000000 and statecode eq 0
+```
+
+### Expanding Lookups
+```
+?$select=name&$expand=primarycontactid($select=fullname,emailaddress1)
+```
+Resolves lookup references inline — avoids separate requests.
+
+### Ordering and Paging
+```
+?$select=name&$orderby=createdon desc&$top=50
+```
+For large result sets, follow `@odata.nextLink` in the response to fetch subsequent pages.
+
+### Server-Side Aggregation ($apply)
+```
+?$apply=groupby((statuscode),aggregate($count as count))
+```
+Use `$apply` for GROUP BY equivalents — runs server-side, avoids pulling all records.
+
+### Formatted Values
+Lookups and option sets return raw GUIDs/integers by default. The response includes formatted display values in `@OData.Community.Display.V1.FormattedValue` annotations — use these for human-readable output.
+
+## SQL Patterns
+
+SQL is best for ad-hoc analytics and JOINs across tables:
+```sql
+SELECT a.name, c.fullname
+FROM account a
+JOIN contact c ON a.primarycontactid = c.contactid
+WHERE a.statecode = 0
+```
+
+## FetchXML Patterns
+
+FetchXML supports Dataverse-native features like linked entities and complex condition groups:
+```xml
+<fetch top="10">
+  <entity name="account">
+    <attribute name="name" />
+    <link-entity name="contact" from="contactid" to="primarycontactid">
+      <attribute name="fullname" />
+    </link-entity>
+    <filter>
+      <condition attribute="statecode" operator="eq" value="0" />
+    </filter>
+  </entity>
+</fetch>
+```

--- a/src/TALXIS.CLI.Features.Docs/Skills/deployment-workflow.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/deployment-workflow.md
@@ -26,7 +26,7 @@ Creates a `.zip` solution file from your local project. This is still a local op
 ```
 Tool: environment_solution_import
 ```
-Uploads the solution package to the target Dataverse environment. **Recommended:** use the `--wait` flag to block until import completes and get immediate feedback.
+Uploads the solution package to the target Dataverse environment. By default returns immediately with an `asyncOperationId`. **Do NOT use `--wait`** — solution imports take minutes and will time out the MCP request. Instead, monitor progress with `environment_deployment_show --solution-name <name>` until status is `Completed` or `Failed`.
 
 ### 5. Publish
 ```

--- a/src/TALXIS.CLI.Features.Docs/Skills/form-xml-reference.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/form-xml-reference.md
@@ -54,4 +54,35 @@ All form fragment templates require `FormId`, `FormType`, and `EntitySchemaName`
 - **`pp-form-dialog-tabfooter`** — Add a footer area to a dialog tab
 - **`pp-form-event-handler`** — Register a JavaScript event (onload, onsave, onchange, onclick)
 
+## Control ClassId Reference
+
+Each form control type maps to a ClassId GUID:
+
+| ControlType | ClassId |
+|---|---|
+| Text | `{4273EDBD-AC1D-40d3-9FB2-095C621B552D}` |
+| MultilineText | `{E0DECE4B-6FC8-4a8f-A065-082708572369}` |
+| WholeNumber | `{C3EFE0C3-0EC6-42be-8349-CBD9079DFD8E}` |
+| Decimal/Float | `{C3EFE0C3-0EC6-42be-8349-CBD9079DFD8E}` |
+| Currency | `{533B9E00-756B-4312-95A0-DC888637AC78}` |
+| DateTime | `{5B773807-9FB2-42db-97C3-7A91EFF8ADFF}` |
+| Lookup | `{270BD3DB-D9AF-4782-9025-509E298DEC0A}` |
+| OptionSet | `{3EF39988-22BB-4F0B-BBBE-64B5A3748AEE}` |
+| Boolean | `{67FAC785-CD58-4f9f-ABB3-4B7DDC6ED5ED}` |
+| SubGrid | `{E7A81278-8635-4d9e-8D4D-59480B391C5B}` |
+| Button | `{00AD73DA-BD4D-49C6-88A8-2F4F4CAD4A20}` |
+
+### Form Type Codes
+- `2` = Main form
+- `7` = Quick Create form
+- `6` = Quick View form
+- `11` = Card form
+
+### View querytype Values
+- `0` = Public (standard)
+- `1` = Advanced Find
+- `2` = Associated
+- `4` = Quick Find
+- `64` = Saved Query (lookup view)
+
 See also: [component-creation](component-creation.md), [schema-management](schema-management.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/index.json
+++ b/src/TALXIS.CLI.Features.Docs/Skills/index.json
@@ -12,5 +12,7 @@
   {"id": "custom-api-development", "title": "Custom API Development", "summary": "Custom API definition, request/response parameters, type codes, plugin backing, and registration workflow.", "tags": ["workspace", "local-development", "integration"]},
   {"id": "bpf-development", "title": "Business Process Flow Development", "summary": "BPF entity structure, stage and step configuration, branching logic, and scaffolding chain.", "tags": ["workspace", "local-development", "bpf"]},
   {"id": "pcf-controls", "title": "PCF Control Development", "summary": "PCF project structure, ControlManifest, lifecycle methods, dataset vs field controls, and build workflow.", "tags": ["workspace", "local-development", "pcf"]},
-  {"id": "build-errors", "title": "Build Error Recovery", "summary": "Diagnose and fix TALXISXSD001, TALXISGUID001, and other build validation errors.", "tags": ["troubleshooting", "build", "validation"]}
+  {"id": "build-errors", "title": "Build Error Recovery", "summary": "Diagnose and fix TALXISXSD001, TALXISGUID001, and other build validation errors.", "tags": ["troubleshooting", "build", "validation"]},
+  {"id": "data-querying", "title": "Data Querying", "summary": "Query Dataverse data using SQL, OData, and FetchXML — choosing the right language, OData patterns, aggregation, and pagination.", "tags": ["data-operations", "environment"]},
+  {"id": "security-roles", "title": "Security Role Scaffolding", "summary": "Scaffold security roles, add privileges, and assign roles to model-driven apps.", "tags": ["workspace", "local-development", "security"]}
 ]

--- a/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
@@ -14,11 +14,18 @@ Plugins are server-side .NET classes that execute custom business logic in respo
 
 Plugin registration is a 3-step chain. **Order matters** — each step depends on the previous one.
 
-1. **Create Plugin Project** → `workspace_component_create` with `componentType: "pp-plugin"`
-2. **Register Assembly** → `workspace_component_create` with `componentType: "pp-plugin-assembly"`
-3. **Register Steps** → `workspace_component_create` with `componentType: "pp-plugin-assembly-step"`
+1. **Create Plugin Project** → `workspace_component_create` with `Type: pp-plugin`
+2. **Write plugin classes** extending `PluginBase` (one `.cs` file per plugin)
+3. **Build the plugin project** → `dotnet build src/Plugins.{Domain}` — this MUST succeed before step 4
+4. **Register Assembly** → `workspace_component_create` with `Type: pp-plugin-assembly`
+   - Requires the plugin to be built first (reads compiled DLL for metadata)
+   - Requires `dotnet-script` global tool installed (`dotnet tool install --global dotnet-script`)
+5. **Register Steps** → `workspace_component_create` with `Type: pp-plugin-assembly-step`
+6. **Link projects** → `dotnet add reference ../Plugins.{Domain}` from the Logic solution
 
 Call `workspace_component_parameter_list` for required parameters at each step.
+
+**Prerequisites:** `dotnet-script` must be installed (`dotnet tool install --global dotnet-script`). The plugin assembly and step templates use C# scripts (`.csx`) for code generation.
 
 ## Execution Stage Decision Tree
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/schema-management.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/schema-management.md
@@ -32,4 +32,17 @@ Use `guide_environment` to discover environment schema tools and their parameter
 - ❌ Don't delete tables/columns without running `environment_component_dependency_delete_check` first
 - ❌ Don't forget to `environment_solution_publish` after schema changes
 
+## Metadata Propagation
+
+When creating multiple entities with relationships via environment tools, follow a phased approach:
+
+1. Create **all tables** first (no lookups)
+2. Wait 15-30 seconds for metadata to propagate
+3. Create **all lookup columns** and relationships
+4. Wait again before creating forms/views that reference the lookups
+
+**Column Naming Warning:** Never suffix custom column names with `Id` (e.g., `new_accountId`). Dataverse auto-generates navigation properties with that suffix for lookups, causing collisions and 400 errors.
+
+**Lock Contention:** If you get "another operation is running against this entity" errors, wait and retry. Multiple concurrent schema changes on the same entity cause lock conflicts.
+
 See also: [component-creation](component-creation.md), [solution-layering](solution-layering.md), [troubleshooting](troubleshooting.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/security-roles.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/security-roles.md
@@ -1,0 +1,47 @@
+# Security Roles
+
+## Scaffolding Chain
+
+1. **Create the role** — `pp-security-role` template inside an existing solution project.
+2. **Add privileges** — `pp-security-role-privilege` template to grant table-level access.
+3. **Assign to app** — `pp-app-security-role` template to bind the role to a model-driven app.
+
+## Privilege Types
+
+| Privilege | Purpose |
+|---|---|
+| Create | Create new records |
+| Read | View records |
+| Write | Update existing records |
+| Delete | Remove records |
+| Append | Attach a record to another (child side) |
+| AppendTo | Allow other records to attach to this record (parent side) |
+| Assign | Change record ownership |
+| Share | Share a record with another user/team |
+
+## Privilege Levels
+
+| Level | Scope |
+|---|---|
+| None | No access |
+| User / Basic | Own records only |
+| BusinessUnit | Records in the user's business unit |
+| ParentChild | Records in the user's BU and child BUs |
+| Global | All records in the organization |
+
+## Design Pattern: One Role Per Persona
+
+Create a dedicated role for each user persona (e.g., `Sales Rep`, `Warehouse Manager`). Avoid catch-all roles — they make auditing and least-privilege enforcement difficult.
+
+## PrivilegeTypeAndLevel Format
+
+When using `pp-security-role-privilege`, specify privileges as a JSON array:
+```json
+[
+  { "type": "Read", "level": "Global" },
+  { "type": "Write", "level": "BusinessUnit" },
+  { "type": "Create", "level": "User" },
+  { "type": "Delete", "level": "None" }
+]
+```
+Each entry maps a privilege type to the desired depth. Omitted types default to `None`.

--- a/src/TALXIS.CLI.Features.Docs/Skills/troubleshooting.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/troubleshooting.md
@@ -80,4 +80,18 @@ If data or schema doesn't match expectations:
 | Wrong data showing | `config_profile_show` |
 | Changes not visible | `environment_solution_publish` |
 
+## Common Dataverse Error Codes
+
+| Hex Code | Meaning | Recovery |
+|---|---|---|
+| `0x80040216` | Entity relationship already exists | Skip or use force-overwrite on import |
+| `0x80048d19` | Duplicate alternate key value | Check key columns for unique constraint violations |
+| `0x80040237` | Record does not exist | Verify the GUID; record may have been deleted |
+| `0x8004431a` | Privilege denied | Check security role assignments for the user |
+| `0x80060891` | Async operation failed | Check async operation status for details |
+| `0x80040220` | Attribute already exists | Skip or import with overwrite flag |
+
+### Metadata Lock Contention
+If schema operations fail with "another operation is running against this entity," the entity metadata is locked by a concurrent operation. Wait 10-30 seconds and retry. Avoid parallel schema changes on the same entity.
+
 See also: [deployment-workflow](deployment-workflow.md), [solution-layering](solution-layering.md)


### PR DESCRIPTION
## New Skills
- **data-querying.md** — SQL vs OData vs FetchXML decision guide, $apply aggregation, $expand, formatted values, pagination. Mapped to CLI `data query` tools.
- **security-roles.md** — Scaffolding chain (pp-security-role → pp-security-role-privilege → pp-app-security-role), privilege types/levels, PrivilegeTypeAndLevel format.

## Enrichments
- **schema-management.md** — Metadata propagation delays, column naming `*Id` anti-pattern, lock contention
- **data-migration.md** — Adaptive chunk sizing, FK-ordered import, lookup resolution
- **form-xml-reference.md** — Control ClassId table (all 11 types), form type codes, view querytype values
- **troubleshooting.md** — Common Dataverse hex error codes with recovery actions, lock contention retry

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>