### PR TITLE
feat: ModelPreferences for guide sampling

### DIFF
--- a/src/TALXIS.CLI.MCP/GuideHandler.cs
+++ b/src/TALXIS.CLI.MCP/GuideHandler.cs
@@ -208,6 +208,12 @@ RECIPE RULES:
             ],
             SystemPrompt = systemPrompt,
             MaxTokens = 1500,
+            ModelPreferences = new ModelPreferences
+            {
+                SpeedPriority = 0.8f,
+                CostPriority = 0.6f,
+                IntelligencePriority = 0.4f
+            },
         };
 
         var result = await server.SampleAsync(samplingParams, ct);


### PR DESCRIPTION
Guide tool sampling requests now include `ModelPreferences` per the [MCP spec](https://modelcontextprotocol.io/specification/draft/client/sampling):

- **SpeedPriority = 0.8** — prefer fast responses
- **CostPriority = 0.6** — cost-conscious
- **IntelligencePriority = 0.4** — tool selection needs decent reasoning but not frontier

Clients that support model preferences can route guide sampling to a faster/cheaper model instead of the primary conversation model. Tested against live MCP server — guide recipes return correctly.