### PR TITLE
docs: remove dotnet-script refs, cross-solution workflow, prerequisite check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ TALXIS DevKit CLI (`txc`) is a code-first toolkit for Power Platform and Dataver
 
 - [**.NET 10 SDK**](https://dotnet.microsoft.com/download/dotnet/10.0) or later (`dotnet --version` should show `10.0.x`+)
 - [**PowerShell**](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) (`pwsh`) — required by template post-action scripts
-- [**dotnet-script**](https://github.com/dotnet-script/dotnet-script) — required by plugin and security role templates (`dotnet tool install --global dotnet-script`)
 - [**GitHub Copilot CLI**](https://github.com/features/copilot/cli) (or an alternative AI harness like Claude Code) for MCP
 
 ### MCP Server (recommended)

--- a/src/TALXIS.CLI.Core/Shared/PrerequisiteChecker.cs
+++ b/src/TALXIS.CLI.Core/Shared/PrerequisiteChecker.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+
+namespace TALXIS.CLI.Core.Shared;
+
+/// <summary>
+/// Validates that required external tools are available.
+/// Returns a list of problems — callers decide how to report them.
+/// </summary>
+public static class PrerequisiteChecker
+{
+    /// <summary>
+    /// Checks that pwsh is available. Returns an empty list if all prerequisites are met.
+    /// .NET SDK version is not checked — if the CLI is running, the SDK is already sufficient.
+    /// </summary>
+    public static List<string> CheckScaffoldingPrerequisites()
+    {
+        var problems = new List<string>();
+
+        if (!IsCommandAvailable("pwsh", "--version"))
+            problems.Add("PowerShell (pwsh) is not installed. Template post-action scripts require it. Install from: https://learn.microsoft.com/powershell/scripting/install/installing-powershell");
+
+        return problems;
+    }
+
+    private static bool IsCommandAvailable(string command, string args)
+    {
+        try
+        {
+            using var proc = Process.Start(new ProcessStartInfo(command, args)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+            proc?.WaitForExit(5000);
+            return proc is not null && proc.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
@@ -38,10 +38,7 @@ Scaffold components in dependency order:
 
 ## Prerequisites
 
-Some templates (pp-plugin-assembly, pp-plugin-assembly-step, pp-security-role-privilege) use C# scripts that require the `dotnet-script` global tool:
-```
-dotnet tool install --global dotnet-script
-```
+Some templates use C# file-based apps (`.cs`) for code generation. These run natively with .NET 10 SDK — no additional tools required.
 
 ## What NOT to Do
 

--- a/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/plugin-development.md
@@ -19,13 +19,12 @@ Plugin registration is a 3-step chain. **Order matters** — each step depends o
 3. **Build the plugin project** → `dotnet build src/Plugins.{Domain}` — this MUST succeed before step 4
 4. **Register Assembly** → `workspace_component_create` with `Type: pp-plugin-assembly`
    - Requires the plugin to be built first (reads compiled DLL for metadata)
-   - Requires `dotnet-script` global tool installed (`dotnet tool install --global dotnet-script`)
 5. **Register Steps** → `workspace_component_create` with `Type: pp-plugin-assembly-step`
 6. **Link projects** → `dotnet add reference ../Plugins.{Domain}` from the Logic solution
 
 Call `workspace_component_parameter_list` for required parameters at each step.
 
-**Prerequisites:** `dotnet-script` must be installed (`dotnet tool install --global dotnet-script`). The plugin assembly and step templates use C# scripts (`.csx`) for code generation.
+**Prerequisites:** The plugin assembly and step templates use C# file-based apps (`.cs`) for code generation — runs natively with .NET 10 SDK.
 
 ## Execution Stage Decision Tree
 

--- a/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/ComponentCreateCliCommand.cs
@@ -29,6 +29,12 @@ public class ComponentCreateCliCommand : TxcLeafCommand, ICliGetCompletions
 
     protected override async Task<int> ExecuteAsync()
     {
+        var prereqProblems = TALXIS.CLI.Core.Shared.PrerequisiteChecker.CheckScaffoldingPrerequisites();
+        foreach (var problem in prereqProblems)
+            Logger.LogError("{Problem}", problem);
+        if (prereqProblems.Count > 0)
+            return ExitError;
+
         var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         // Parse template-specific parameters

--- a/src/TALXIS.CLI.MCP/Skills/Internal/schema-workflow.md
+++ b/src/TALXIS.CLI.MCP/Skills/Internal/schema-workflow.md
@@ -14,13 +14,22 @@
 ```
 → NEVER scaffold Form/View before the Entity and Attributes exist — XML references will break
 
-### Adding to existing table
+### Adding to existing table (same solution)
 ```
 1. workspace_explain                           — confirm table exists, find SolutionRootPath
 2. workspace_component_create (Attribute/Form/View)
 3. Build locally to validate
 ```
 → SKIP step 1 ONLY if you already know the project structure from prior context
+
+### Adding views/forms for an entity from another solution
+```
+1. workspace_component_create (Entity, Behavior=Existing)  — creates entity folder reference, no full metadata
+2. workspace_component_create (Form/View)                  — scaffolds into the referenced entity folder
+3. Build locally to validate
+```
+→ Use this when e.g. Solutions.UI needs forms/views for an entity defined in Solutions.DataModel
+→ Behavior=Existing creates the entity folder structure without duplicating the entity definition
 
 ### Creating a relationship
 ```


### PR DESCRIPTION
- Remove dotnet-script from prerequisites (templates now use .NET 10 file-based apps)
- Add cross-solution workflow (Behavior=Existing) to schema-workflow skill
- PrerequisiteChecker validates pwsh before scaffolding
- Update plugin-development and component-creation skills