### PR TITLE
feat: activate workspace validate command

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
+++ b/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.201" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="10.0.201" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="TALXIS.Platform.Metadata" Version="0.1.3" />
+    <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.1.3" />
+    <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.1.3" />
   </ItemGroup>
 
 </Project>

--- a/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
@@ -9,7 +9,8 @@ namespace TALXIS.CLI.Features.Workspace;
     {
         typeof(ComponentCliCommand),
         typeof(ProjectCliCommand),
-        typeof(WorkspaceExplainCliCommand)
+        typeof(WorkspaceExplainCliCommand),
+        typeof(WorkspaceValidateCliCommand)
     },
     ShortFormAutoGenerate = CliNameAutoGenerate.None)]
 public class WorkspaceCliCommand

--- a/src/TALXIS.CLI.Features.Workspace/WorkspaceValidateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/WorkspaceValidateCliCommand.cs
@@ -1,33 +1,68 @@
-#pragma warning disable TXC001 // Reserved stub — will inherit TxcLeafCommand when implemented
-#pragma warning disable TXC004 // Reserved stub — safety annotation deferred until implemented
-// Reserved skeleton — intentionally NOT wired into any parent's `Children` array.
-//
-// This class exists to pin the design: `txc workspace validate` is the planned
-// slot for object-model-driven validation of the local workspace (schema,
-// references, metadata consistency) — the next step beyond template-engine
-// scaffolding.
-//
-// Because it is unreachable from `WorkspaceCliCommand.Children`, DotMake will
-// not surface it to the CLI and the MCP adapter will not surface it as a tool.
-// Activating this command is a two-edit change:
-//   1. Add `typeof(WorkspaceValidateCliCommand)` to the parent's `Children` array.
-//   2. Replace the `NotImplementedException` body with a real implementation.
-//
-// Please read `CONTRIBUTING.md` before changing the shape of this class.
-
 using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Logging;
+using TALXIS.Platform.Metadata.Validation;
 
 namespace TALXIS.CLI.Features.Workspace;
 
+[CliReadOnly]
 [CliCommand(
-    Description = "Reserved — not yet implemented.",
-    Name = "validate")]
-public sealed class WorkspaceValidateCliCommand
+    Name = "validate",
+    Description = "Validates solution workspace files against XSD schemas and checks for structural issues.")]
+public sealed class WorkspaceValidateCliCommand : TxcLeafCommand
 {
-    public Task<int> RunAsync()
+    protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(WorkspaceValidateCliCommand));
+
+    [CliArgument(Description = "Path to the solution project directory to validate.")]
+    public string Path { get; set; } = ".";
+
+    protected override async Task<int> ExecuteAsync()
     {
-        throw new NotImplementedException(
-            "`workspace validate` is reserved for a future object-model-driven "
-            + "validation workflow and is not yet implemented. See CONTRIBUTING.md.");
+        var fullPath = System.IO.Path.GetFullPath(Path);
+        if (!Directory.Exists(fullPath))
+        {
+            Logger.LogError("Directory not found: {Path}", fullPath);
+            return ExitError;
+        }
+
+        var schemaValidator = new SchemaValidator();
+        var guidValidator = new GuidValidator();
+        var allResults = new List<ValidationResult>();
+
+        foreach (var xmlFile in Directory.EnumerateFiles(fullPath, "*.xml", SearchOption.AllDirectories))
+        {
+            var results = schemaValidator.ValidateFile(xmlFile);
+            allResults.AddRange(results);
+        }
+
+        var guidResults = guidValidator.ValidateDirectory(fullPath);
+        allResults.AddRange(guidResults);
+
+        int errors = 0;
+        int warnings = 0;
+        foreach (var result in allResults)
+        {
+            if (result.Severity == ValidationSeverity.Error)
+            {
+                Logger.LogError("[{File}] {Message}", result.FilePath ?? "unknown", result.Message);
+                errors++;
+            }
+            else
+            {
+                Logger.LogWarning("[{File}] {Message}", result.FilePath ?? "unknown", result.Message);
+                warnings++;
+            }
+        }
+
+        if (errors == 0 && warnings == 0)
+        {
+            OutputFormatter.WriteResult("succeeded", $"Validation passed — no issues found in {fullPath}");
+            return ExitSuccess;
+        }
+
+        OutputFormatter.WriteResult(errors > 0 ? "failed" : "succeeded",
+            $"Validation complete: {errors} error(s), {warnings} warning(s)");
+        return errors > 0 ? ExitError : ExitSuccess;
     }
 }


### PR DESCRIPTION
Wires TALXIS.Platform.Metadata packages into the CLI and activates the workspace validate command.

### Changes
- Added `TALXIS.Platform.Metadata`, `TALXIS.Platform.Metadata.Validation`, and `TALXIS.Platform.Metadata.Serialization.Xml` (v0.1.3) to the Workspace project
- Replaced the reserved stub in `WorkspaceValidateCliCommand` with a real implementation using `SchemaValidator` (XSD) and `GuidValidator` (duplicate GUID detection)
- Registered the command in `WorkspaceCliCommand.Children`
- Removed pragma warning suppressions from the stub