### PR TITLE
fix: remove unused package references from workspace project

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
+++ b/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
@@ -18,8 +18,6 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.201" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="10.0.201" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="TALXIS.Platform.Metadata" Version="0.1.3" />
-    <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.1.3" />
     <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.1.3" />
   </ItemGroup>
 


### PR DESCRIPTION
WorkspaceValidateCliCommand only uses Validation package. Serialization.Xml and core are unnecessary direct refs. Found in post-merge review.