### PR TITLE
chore: bump TALXIS.Platform.Metadata to v0.2.0

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
+++ b/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
@@ -18,7 +18,8 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.201" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="10.0.201" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-    <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.1.3" />
+    <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.2.0" />
+    <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bumps platform-metadata packages from 0.1.3 to 0.2.0.

- `TALXIS.Platform.Metadata.Validation` 0.1.3 → 0.2.0
- Added `TALXIS.Platform.Metadata.Serialization.Xml` 0.2.0

v0.2.0 adds: 12 new model types, expanded reader/writer, label fixes, solution layering, merge engine, error reporting via Workspace.LoadErrors.

> **Note:** v0.2.0 packages are not yet indexed on NuGet. CI will pass once they're published.