### PR TITLE
Make ActionProcessorId static in IPostActionProcessor

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddProjectsToSlnPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddProjectsToSlnPostActionProcessor.cs
@@ -12,7 +12,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
     public class AddProjectsToSlnPostActionProcessor : IPostActionProcessor
     {
         private static readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(AddProjectsToSlnPostActionProcessor));
-        public Guid ActionId => new Guid("D396686C-DE0E-4DE6-906D-291CD29FC5DE");
+        public static Guid ActionProcessorId => new Guid("D396686C-DE0E-4DE6-906D-291CD29FC5DE");
 
         public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
         {

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddReferencePostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddReferencePostActionProcessor.cs
@@ -8,7 +8,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
     public class AddReferencePostActionProcessor : IPostActionProcessor
     {
         private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(AddReferencePostActionProcessor));
-        public Guid ActionId => new Guid("B17581D1-C5C9-4489-8F0A-004BE667B814");
+        public static Guid ActionProcessorId => new Guid("B17581D1-C5C9-4489-8F0A-004BE667B814");
 
         public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
         {

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddRootComponentToSolutionXmlProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/AddRootComponentToSolutionXmlProcessor.cs
@@ -1,0 +1,109 @@
+using System.Xml;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Workspace.TemplateEngine
+{
+    /// <summary>
+    /// Post-action processor that appends a RootComponent element to the nearest Solution.xml.
+    /// Used by item templates (pp-entity, pp-form, etc.) that need to register components
+    /// in the parent solution's Solution.xml after template instantiation.
+    /// </summary>
+    public class AddRootComponentToSolutionXmlProcessor : IPostActionProcessor
+    {
+        private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(AddRootComponentToSolutionXmlProcessor));
+        public static Guid ActionProcessorId => new Guid("A1B2C3D4-1001-4000-8000-000000000001");
+
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
+        {
+            return ProcessInternal(environment, action, null!, null!, System.Environment.CurrentDirectory);
+        }
+
+        public bool ProcessInternal(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects creationEffects, ICreationResult? templateCreationResult, string outputBasePath)
+        {
+            var args = action.Args;
+
+            if (!args.TryGetValue("type", out var componentType))
+            {
+                _logger.LogError("[AddRootComponent] Missing required 'type' argument");
+                return false;
+            }
+
+            if (!args.TryGetValue("behavior", out var behavior))
+            {
+                behavior = "0";
+            }
+
+            // Find Solution.xml by walking up from outputBasePath
+            var solutionXmlPath = LocateSolutionXml(outputBasePath);
+            if (solutionXmlPath == null)
+            {
+                _logger.LogError("[AddRootComponent] Could not locate Solution.xml by walking up from '{OutputBasePath}'", outputBasePath);
+                return false;
+            }
+
+            try
+            {
+                _logger.LogInformation("[AddRootComponent] Adding component (type={Type}) to {Path}", componentType, solutionXmlPath);
+
+                var doc = new XmlDocument { PreserveWhitespace = true };
+                doc.Load(solutionXmlPath);
+
+                var rootComponents = doc.SelectSingleNode("//RootComponents");
+                if (rootComponents == null)
+                {
+                    _logger.LogError("[AddRootComponent] Could not find //RootComponents node in {Path}", solutionXmlPath);
+                    return false;
+                }
+
+                var newComponent = doc.CreateElement("RootComponent");
+                newComponent.SetAttribute("type", componentType);
+
+                // Entity-type components use schemaName, form-type components use id
+                if (args.TryGetValue("schemaName", out var schemaName))
+                {
+                    newComponent.SetAttribute("schemaName", schemaName);
+                }
+
+                if (args.TryGetValue("id", out var id))
+                {
+                    newComponent.SetAttribute("id", id);
+                }
+
+                newComponent.SetAttribute("behavior", behavior);
+
+                rootComponents.AppendChild(newComponent);
+
+                doc.Save(solutionXmlPath);
+
+                _logger.LogInformation("[AddRootComponent] Successfully added component to Solution.xml");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("[AddRootComponent] Failed to modify Solution.xml: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Locates Solution.xml by walking up from the output path, looking for Other/Solution.xml.
+        /// This mirrors the pattern used by the PowerShell scripts which resolve relative to output.
+        /// </summary>
+        private static string? LocateSolutionXml(string startPath)
+        {
+            var dir = new DirectoryInfo(startPath);
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "Other", "Solution.xml");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                dir = dir.Parent;
+            }
+            return null;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/IPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/IPostActionProcessor.cs
@@ -11,7 +11,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         /// <summary>
         /// Gets the unique identifier for this post action processor.
         /// </summary>
-        Guid ActionId { get; }
+        static virtual Guid ActionProcessorId => Guid.Empty;
 
         /// <summary>
         /// Processes the post action.

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PostActionDispatcher.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PostActionDispatcher.cs
@@ -20,9 +20,12 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
             _allowScripts = allowScripts;
             _processors = new Dictionary<Guid, IPostActionProcessor>
             {
-                { new Guid("3A7C4B45-1F5D-4A30-959A-51B88E82B5D2"), new RunScriptPostActionProcessor() },
-                { new Guid("B17581D1-C5C9-4489-8F0A-004BE667B814"), new AddReferencePostActionProcessor() },
-                { new Guid("D396686C-DE0E-4DE6-906D-291CD29FC5DE"), new AddProjectsToSlnPostActionProcessor() }
+                { RunScriptPostActionProcessor.ActionProcessorId, new RunScriptPostActionProcessor() },
+                { AddReferencePostActionProcessor.ActionProcessorId, new AddReferencePostActionProcessor() },
+                { AddProjectsToSlnPostActionProcessor.ActionProcessorId, new AddProjectsToSlnPostActionProcessor() },
+                { AddRootComponentToSolutionXmlProcessor.ActionProcessorId, new AddRootComponentToSolutionXmlProcessor() },
+                { SortXmlElementsProcessor.ActionProcessorId, new SortXmlElementsProcessor() },
+                { ReplaceOptionValuePrefixProcessor.ActionProcessorId, new ReplaceOptionValuePrefixProcessor() }
             };
         }
 
@@ -84,6 +87,39 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
                         FailedActionErrors[action.ActionId] = runScriptProcessor.LastError;
                     }
                 }
+                else if (processor is AddRootComponentToSolutionXmlProcessor addRootComponentProcessor)
+                {
+                    var basePath = outputBasePath ?? Directory.GetCurrentDirectory();
+                    if (transaction != null)
+                    {
+                        // Track the Solution.xml file for rollback before modification
+                        var solutionXmlPath = FindSolutionXml(basePath);
+                        if (solutionXmlPath != null)
+                        {
+                            transaction.TrackFile(solutionXmlPath);
+                        }
+                    }
+                    ok = addRootComponentProcessor.ProcessInternal(_environment, action, null!, templateCreationResult?.CreationResult, basePath);
+                }
+                else if (processor is SortXmlElementsProcessor sortXmlProcessor)
+                {
+                    var basePath = outputBasePath ?? Directory.GetCurrentDirectory();
+                    ok = sortXmlProcessor.ProcessInternal(_environment, action, null!, templateCreationResult?.CreationResult, basePath);
+                }
+                else if (processor is ReplaceOptionValuePrefixProcessor replaceOptionValuePrefixProcessor)
+                {
+                    var basePath = outputBasePath ?? Directory.GetCurrentDirectory();
+                    if (transaction != null)
+                    {
+                        // Track the Solution.xml file for rollback before modification
+                        var solutionXmlPath = FindSolutionXml(basePath);
+                        if (solutionXmlPath != null)
+                        {
+                            transaction.TrackFile(solutionXmlPath);
+                        }
+                    }
+                    ok = replaceOptionValuePrefixProcessor.ProcessInternal(_environment, action, null!, templateCreationResult?.CreationResult, basePath);
+                }
                 else
                 {
                     ok = processor.Process(_environment, action);
@@ -114,6 +150,24 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         private void ShowManualInstructions(IPostAction action)
         {
             _logger.LogInformation("{Instructions}", action.ManualInstructions ?? "No manual instructions provided.");
+        }
+
+        /// <summary>
+        /// Locates Solution.xml by walking up from the given path, looking for Other/Solution.xml.
+        /// </summary>
+        private static string? FindSolutionXml(string startPath)
+        {
+            var dir = new DirectoryInfo(startPath);
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "Other", "Solution.xml");
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+                dir = dir.Parent;
+            }
+            return null;
         }
     }
 

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PublisherPrefixHasher.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/PublisherPrefixHasher.cs
@@ -1,0 +1,31 @@
+namespace TALXIS.CLI.Features.Workspace.TemplateEngine;
+
+/// <summary>
+/// Computes a deterministic option-value prefix (10 000–99 999) from a publisher
+/// customization prefix string. Used by post-action processors to replace placeholder
+/// values in scaffolded Solution.xml files.
+/// </summary>
+public static class PublisherPrefixHasher
+{
+    private const string SpecialUuid = "D21AAB71-79E7-11DD-8874-00188B01E34F";
+
+    /// <summary>
+    /// Returns a deterministic integer in the range [10 000, 99 999] derived from
+    /// the given publisher prefix (case-insensitive).
+    /// </summary>
+    public static int ComputeOptionValuePrefix(string input)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(input);
+
+        if (input.Equals(SpecialUuid, StringComparison.InvariantCultureIgnoreCase)) return 10_000;
+
+        int hash = 0;
+        foreach (char c in input.ToUpperInvariant())
+        {
+            hash = (hash << 5) - hash + c;
+            hash &= hash;
+        }
+
+        return Math.Abs(hash) % 90_000 + 10_000;
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/ReplaceOptionValuePrefixProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/ReplaceOptionValuePrefixProcessor.cs
@@ -1,0 +1,103 @@
+using System.Xml;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Workspace.TemplateEngine;
+
+/// <summary>
+/// Post-action processor that replaces the placeholder value inside
+/// <c>&lt;CustomizationOptionValuePrefix&gt;</c> in Solution.xml with a
+/// deterministic hash derived from the publisher's customization prefix.
+/// </summary>
+public class ReplaceOptionValuePrefixProcessor : IPostActionProcessor
+{
+    private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(ReplaceOptionValuePrefixProcessor));
+    public static Guid ActionProcessorId => new("A1B2C3D4-1003-4000-8000-000000000003");
+
+    public Guid ActionId => ActionProcessorId;
+
+    public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
+    {
+        return ProcessInternal(environment, action, null!, null!, Environment.CurrentDirectory);
+    }
+
+    public bool ProcessInternal(
+        IEngineEnvironmentSettings environment,
+        IPostAction action,
+        ICreationEffects creationEffects,
+        ICreationResult? templateCreationResult,
+        string outputBasePath)
+    {
+        var solutionXmlPath = LocateSolutionXml(outputBasePath);
+        if (solutionXmlPath == null)
+        {
+            _logger.LogError(
+                "[ReplaceOptionValuePrefix] Could not locate Solution.xml by walking up from '{OutputBasePath}'",
+                outputBasePath);
+            return false;
+        }
+
+        try
+        {
+            var doc = new XmlDocument { PreserveWhitespace = true };
+            doc.Load(solutionXmlPath);
+
+            // Read the customization prefix directly from Solution.xml
+            // (the template engine already substituted this value in the output file)
+            var prefixNode = doc.SelectSingleNode("//CustomizationPrefix");
+            if (prefixNode == null || string.IsNullOrWhiteSpace(prefixNode.InnerText))
+            {
+                _logger.LogError(
+                    "[ReplaceOptionValuePrefix] Could not find <CustomizationPrefix> in {Path}",
+                    solutionXmlPath);
+                return false;
+            }
+
+            var customizationPrefix = prefixNode.InnerText.Trim();
+            var computedValue = PublisherPrefixHasher.ComputeOptionValuePrefix(customizationPrefix);
+
+            _logger.LogInformation(
+                "[ReplaceOptionValuePrefix] Computed option value prefix {Value} from '{Prefix}' in {Path}",
+                computedValue, customizationPrefix, solutionXmlPath);
+
+            var node = doc.SelectSingleNode("//CustomizationOptionValuePrefix");
+            if (node == null)
+            {
+                _logger.LogError(
+                    "[ReplaceOptionValuePrefix] Could not find <CustomizationOptionValuePrefix> in {Path}",
+                    solutionXmlPath);
+                return false;
+            }
+
+            node.InnerText = computedValue.ToString();
+            doc.Save(solutionXmlPath);
+
+            _logger.LogInformation("[ReplaceOptionValuePrefix] Successfully updated Solution.xml");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("[ReplaceOptionValuePrefix] Failed to modify Solution.xml: {Message}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Locates Solution.xml by walking up from the given path, looking for Other/Solution.xml.
+    /// </summary>
+    private static string? LocateSolutionXml(string startPath)
+    {
+        var dir = new DirectoryInfo(startPath);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Other", "Solution.xml");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/RunScriptPostActionProcessor.cs
@@ -13,9 +13,7 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
     public class RunScriptPostActionProcessor : IPostActionProcessor
     {
         private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(RunScriptPostActionProcessor));
-        internal static readonly Guid ActionProcessorId = new Guid("3A7C4B45-1F5D-4A30-959A-51B88E82B5D2");
-
-        public Guid ActionId => ActionProcessorId;
+        public static Guid ActionProcessorId => new Guid("3A7C4B45-1F5D-4A30-959A-51B88E82B5D2");
 
         /// <summary>
         /// Contains the error detail from the last failed script execution.

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/SortXmlElementsProcessor.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/SortXmlElementsProcessor.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using System.Xml;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Workspace.TemplateEngine
+{
+    /// <summary>
+    /// Post-action processor that sorts child XML elements of a matched node by a specified attribute.
+    /// Used to maintain deterministic ordering of elements like entity attributes in Entity.xml.
+    /// </summary>
+    public class SortXmlElementsProcessor : IPostActionProcessor
+    {
+        private readonly ILogger _logger = TxcLoggerFactory.CreateLogger(nameof(SortXmlElementsProcessor));
+        public static Guid ActionProcessorId => new Guid("A1B2C3D4-1002-4000-8000-000000000002");
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction action)
+        {
+            return ProcessInternal(environment, action, null!, null!, System.Environment.CurrentDirectory);
+        }
+
+        public bool ProcessInternal(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects creationEffects, ICreationResult? templateCreationResult, string outputBasePath)
+        {
+            var args = action.Args;
+
+            if (!args.TryGetValue("filePattern", out var filePattern))
+            {
+                _logger.LogError("[SortXmlElements] Missing required 'filePattern' argument");
+                return false;
+            }
+
+            if (!args.TryGetValue("xpath", out var xpath))
+            {
+                _logger.LogError("[SortXmlElements] Missing required 'xpath' argument");
+                return false;
+            }
+
+            if (!args.TryGetValue("sortBy", out var sortBy))
+            {
+                _logger.LogError("[SortXmlElements] Missing required 'sortBy' argument");
+                return false;
+            }
+
+            var caseSensitive = args.TryGetValue("caseSensitive", out var cs) &&
+                                cs.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+            try
+            {
+                var matchingFiles = FindMatchingFiles(outputBasePath, filePattern);
+                if (matchingFiles.Count == 0)
+                {
+                    _logger.LogInformation("[SortXmlElements] No files matching '{Pattern}' found in '{Path}' — skipping", filePattern, outputBasePath);
+                    return true;
+                }
+
+                foreach (var filePath in matchingFiles)
+                {
+                    _logger.LogInformation("[SortXmlElements] Sorting elements in {Path} (xpath={XPath}, sortBy={SortBy})", filePath, xpath, sortBy);
+                    SortElementsInFile(filePath, xpath, sortBy, caseSensitive);
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("[SortXmlElements] Failed: {Message}", ex.Message);
+                return false;
+            }
+        }
+
+        private void SortElementsInFile(string filePath, string xpath, string sortBy, bool caseSensitive)
+        {
+            var doc = new XmlDocument { PreserveWhitespace = false };
+            doc.Load(filePath);
+
+            var parentNodes = doc.SelectNodes(xpath);
+            if (parentNodes == null || parentNodes.Count == 0)
+            {
+                _logger.LogInformation("[SortXmlElements] No nodes matching xpath '{XPath}' in {Path}", xpath, filePath);
+                return;
+            }
+
+            foreach (XmlNode parentNode in parentNodes)
+            {
+                var children = new List<XmlNode>();
+                foreach (XmlNode child in parentNode.ChildNodes)
+                {
+                    if (child.NodeType == XmlNodeType.Element)
+                    {
+                        children.Add(child);
+                    }
+                }
+
+                if (children.Count == 0) continue;
+
+                var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+                var sorted = children
+                    .OrderBy(node => (node as XmlElement)?.GetAttribute(sortBy) ?? "", comparer)
+                    .ToList();
+
+                // Remove all element children
+                foreach (var child in children)
+                {
+                    parentNode.RemoveChild(child);
+                }
+
+                // Re-add in sorted order
+                foreach (var child in sorted)
+                {
+                    parentNode.AppendChild(child);
+                }
+            }
+
+            // Save with settings matching the original PowerShell script behavior
+            var settings = new XmlWriterSettings
+            {
+                Indent = true,
+                NewLineHandling = NewLineHandling.None,
+                OmitXmlDeclaration = false,
+                Encoding = new UTF8Encoding(true) // UTF-8 with BOM
+            };
+
+            using var writer = XmlWriter.Create(filePath, settings);
+            doc.Save(writer);
+        }
+
+        /// <summary>
+        /// Finds files matching a glob-like pattern relative to a base path.
+        /// Supports simple patterns like "Entities/*/Entity.xml".
+        /// </summary>
+        private static List<string> FindMatchingFiles(string basePath, string pattern)
+        {
+            var results = new List<string>();
+
+            // Split the pattern into directory parts
+            var parts = pattern.Replace('\\', '/').Split('/');
+            SearchRecursive(basePath, parts, 0, results);
+
+            return results;
+        }
+
+        private static void SearchRecursive(string currentDir, string[] parts, int partIndex, List<string> results)
+        {
+            if (!Directory.Exists(currentDir)) return;
+
+            if (partIndex >= parts.Length) return;
+
+            var part = parts[partIndex];
+            var isLastPart = partIndex == parts.Length - 1;
+
+            if (part == "*" || part == "**")
+            {
+                // Wildcard: match all subdirectories at this level
+                foreach (var dir in Directory.GetDirectories(currentDir))
+                {
+                    if (isLastPart)
+                    {
+                        // * as last part doesn't match files, only if the pattern has more
+                        continue;
+                    }
+                    SearchRecursive(dir, parts, partIndex + 1, results);
+                }
+
+                // For **, also try matching deeper
+                if (part == "**")
+                {
+                    foreach (var dir in Directory.GetDirectories(currentDir))
+                    {
+                        SearchRecursive(dir, parts, partIndex, results);
+                    }
+                    // Also try matching the next part in the current directory
+                    SearchRecursive(currentDir, parts, partIndex + 1, results);
+                }
+            }
+            else if (isLastPart)
+            {
+                // Last part: match files
+                var filePath = Path.Combine(currentDir, part);
+                if (File.Exists(filePath))
+                {
+                    results.Add(filePath);
+                }
+            }
+            else
+            {
+                // Exact directory name: descend into it
+                var nextDir = Path.Combine(currentDir, part);
+                if (Directory.Exists(nextDir))
+                {
+                    SearchRecursive(nextDir, parts, partIndex + 1, results);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Change interface member to static virtual Guid ActionProcessorId
- Convert all implementations from internal static readonly fields to public static properties
- Remove leftover ActionId property from AddRootComponentToSolutionXmlProcessor