### PR TITLE
fix: Windows DPAPI vault failure and path resolution (#103, #102)

### DIFF
--- a/src/TALXIS.CLI.Core/TALXIS.CLI.Core.csproj
+++ b/src/TALXIS.CLI.Core/TALXIS.CLI.Core.csproj
@@ -19,6 +19,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.83.3" />
+    <!-- Explicit bump: MSAL Extensions' transitive minimum (4.5.0) ships a netstandard2.0
+         stub that always throws PlatformNotSupportedException on net10.0. Version 10.0.5
+         ships a lib/net10.0 DLL with the real DPAPI P/Invoke, fixing Windows credential
+         vault initialization (see GitHub issue #103). -->
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
+++ b/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
@@ -14,12 +14,10 @@ internal static class MsalCacheHelperFactory
 {
     /// <summary>
     /// Creates and verifies an <see cref="MsalCacheHelper"/>. On
-    /// <see cref="MsalCachePersistenceException"/>:
-    /// <list type="bullet">
-    ///   <item>Windows → hard error (DPAPI should always be available).</item>
-    ///   <item>Linux with <c>TXC_PLAINTEXT_FALLBACK=1</c> or <paramref name="options"/>.UsePlaintextFallback → plaintext file fallback with warning.</item>
-    ///   <item>Otherwise → throw <see cref="VaultUnavailableException"/>.</item>
-    /// </list>
+    /// <see cref="MsalCachePersistenceException"/> throws
+    /// <see cref="VaultUnavailableException"/> with a platform-specific remedy
+    /// hint. Set <c>TXC_PLAINTEXT_FALLBACK=1</c> on any platform to use an
+    /// unencrypted file fallback.
     /// </summary>
     public static async Task<MsalCacheHelper> CreateAsync(
         VaultOptions options,
@@ -45,15 +43,24 @@ internal static class MsalCacheHelperFactory
         }
         catch (MsalCachePersistenceException ex)
         {
-            if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
-                throw new VaultUnavailableException(ex);
-
+            string hint = GetPlatformHint();
             logger.LogWarning(ex,
-                "OS credential vault (libsecret) is unavailable; no plaintext opt-in set. " +
-                "Set {EnvVar}=1 to use a plaintext file fallback at chmod 600.",
-                VaultOptions.LinuxPlaintextEnvVar);
+                "OS credential vault is unavailable. {Hint} " +
+                "Set {EnvVar}=1 to use a plaintext file fallback.",
+                hint, VaultOptions.PlaintextFallbackEnvVar);
             throw new VaultUnavailableException(ex);
         }
+    }
+
+    /// <summary>Returns a user-facing hint appropriate for the current OS.</summary>
+    private static string GetPlatformHint()
+    {
+        if (OperatingSystem.IsWindows())
+            return "DPAPI is not available in this environment (container or restricted account).";
+        if (OperatingSystem.IsMacOS())
+            return $"Keychain is not available. You can also set {VaultOptions.MacFileModeEnvVar}=file.";
+        // Linux
+        return "Install `libsecret-1-0` and `gnome-keyring`, or run inside a desktop session with D-Bus.";
     }
 
     private static async Task<MsalCacheHelper> CreatePlaintextAsync(
@@ -62,10 +69,12 @@ internal static class MsalCacheHelperFactory
         ILogger logger)
     {
         var fallbackPath = Path.Combine(paths.AuthDirectory, options.FallbackCacheFileName);
+        var permissionNote = OperatingSystem.IsWindows()
+            ? "Secrets are NOT protected by the OS; rely on NTFS ACLs only."
+            : "Secrets are NOT protected by the OS; rely on file permissions (chmod 600) only.";
         logger.LogWarning(
-            "Vault using PLAINTEXT file-based storage at {Path} (opt-in: {Reason}). " +
-            "Secrets are NOT protected by the OS; rely on POSIX file permissions (chmod 600) only.",
-            fallbackPath, options.PlaintextReason ?? "explicit");
+            "Vault using PLAINTEXT file-based storage at {Path} (opt-in: {Reason}). {PermissionNote}",
+            fallbackPath, options.PlaintextReason ?? "explicit", permissionNote);
 
         var props = new StorageCreationPropertiesBuilder(options.FallbackCacheFileName, paths.AuthDirectory)
             .WithUnprotectedFile()

--- a/src/TALXIS.CLI.Core/Vault/VaultOptions.cs
+++ b/src/TALXIS.CLI.Core/Vault/VaultOptions.cs
@@ -113,23 +113,28 @@ public sealed record VaultOptions
     /// Env var names honored to pick plaintext / file-based storage. Intentionally
     /// public so the (future) `--plaintext-fallback` flag can set the same value.
     /// </summary>
-    public const string LinuxPlaintextEnvVar = "TXC_PLAINTEXT_FALLBACK";
+    public const string PlaintextFallbackEnvVar = "TXC_PLAINTEXT_FALLBACK";
     public const string MacFileModeEnvVar = "TXC_TOKEN_CACHE_MODE";
+
+    /// <summary>Kept for backward compatibility; same value as <see cref="PlaintextFallbackEnvVar"/>.</summary>
+    public const string LinuxPlaintextEnvVar = PlaintextFallbackEnvVar;
 
     private static (bool plaintext, string? reason) ResolvePlaintextOptIn(IEnvironmentReader env)
     {
-        if (OperatingSystem.IsLinux())
-        {
-            var v = env.Get(LinuxPlaintextEnvVar);
-            if (EnvBool.IsTruthy(v))
-                return (true, $"{LinuxPlaintextEnvVar}={v}");
-        }
-        else if (OperatingSystem.IsMacOS())
+        // TXC_PLAINTEXT_FALLBACK=1 is honored on all platforms (Windows containers,
+        // Linux without libsecret, CI runners, etc.).
+        var fallback = env.Get(PlaintextFallbackEnvVar);
+        if (EnvBool.IsTruthy(fallback))
+            return (true, $"{PlaintextFallbackEnvVar}={fallback}");
+
+        // macOS-specific: TXC_TOKEN_CACHE_MODE=file bypasses Keychain.
+        if (OperatingSystem.IsMacOS())
         {
             var v = env.Get(MacFileModeEnvVar);
             if (!string.IsNullOrEmpty(v) && string.Equals(v, "file", StringComparison.OrdinalIgnoreCase))
                 return (true, $"{MacFileModeEnvVar}=file");
         }
+
         return (false, null);
     }
 }

--- a/src/TALXIS.CLI.Core/Vault/VaultUnavailableException.cs
+++ b/src/TALXIS.CLI.Core/Vault/VaultUnavailableException.cs
@@ -10,13 +10,14 @@ public sealed class VaultUnavailableException : Exception
 {
     /// <summary>
     /// Canonical remedy message shown to the user when the vault fails to
-    /// persist. Kept as a constant so tests can assert on it verbatim and it
-    /// stays in sync with the README.
+    /// persist. The message covers all platforms so it is useful regardless
+    /// of the OS the CLI is running on.
     /// </summary>
     public const string RemedyMessage =
-        "OS credential vault is unavailable. On Linux install `libsecret-1-0` " +
-        "and `gnome-keyring` (or run inside a desktop session with D-Bus). To " +
-        "opt in to a plaintext file (chmod 600) fallback, re-run with " +
+        "OS credential vault is unavailable. " +
+        "On Linux install `libsecret-1-0` and `gnome-keyring` (or run inside a desktop session with D-Bus). " +
+        "On macOS set `TXC_TOKEN_CACHE_MODE=file` if Keychain is unavailable. " +
+        "To opt in to a plaintext file fallback on any platform, re-run with " +
         "`--plaintext-fallback` or set `TXC_PLAINTEXT_FALLBACK=1`.";
 
     public VaultUnavailableException()

--- a/src/TALXIS.CLI.Core/Vault/VaultUnavailableException.cs
+++ b/src/TALXIS.CLI.Core/Vault/VaultUnavailableException.cs
@@ -17,8 +17,8 @@ public sealed class VaultUnavailableException : Exception
         "OS credential vault is unavailable. " +
         "On Linux install `libsecret-1-0` and `gnome-keyring` (or run inside a desktop session with D-Bus). " +
         "On macOS set `TXC_TOKEN_CACHE_MODE=file` if Keychain is unavailable. " +
-        "To opt in to a plaintext file fallback on any platform, re-run with " +
-        "`--plaintext-fallback` or set `TXC_PLAINTEXT_FALLBACK=1`.";
+        "To opt in to a plaintext file fallback on any platform, set " +
+        "`TXC_PLAINTEXT_FALLBACK=1`.";
 
     public VaultUnavailableException()
         : base(RemedyMessage) { }

--- a/src/TALXIS.CLI.Logging/LogRedactionFilter.cs
+++ b/src/TALXIS.CLI.Logging/LogRedactionFilter.cs
@@ -41,7 +41,7 @@ public static partial class LogRedactionFilter
         // Replace home directory paths with ~
         if (!string.IsNullOrEmpty(HomePath))
         {
-            message = message.Replace(HomePath, "~");
+            message = message.Replace(HomePath, "~", StringComparison.OrdinalIgnoreCase);
         }
 
         return message;

--- a/src/TALXIS.CLI.MCP/GuideHandler.cs
+++ b/src/TALXIS.CLI.MCP/GuideHandler.cs
@@ -233,7 +233,7 @@ RECIPE RULES:
         List<ToolCatalogEntry>? tools = null;
         string? recipe = null;
 
-        var lines = responseText.Split('\n');
+        var lines = responseText.ReplaceLineEndings("\n").Split('\n');
         int jsonLineIndex = -1;
 
         // Scan lines to find the first one containing a valid JSON string array

--- a/src/TALXIS.CLI.MCP/RootsService.cs
+++ b/src/TALXIS.CLI.MCP/RootsService.cs
@@ -85,6 +85,16 @@ internal sealed class RootsService
         // Path.GetFullPath normalises separators and resolves platform
         // differences (e.g. stripping the leading '/' from '/C:/...' on
         // Windows, converting '/' → '\\', etc.).
-        return Path.GetFullPath(parsed.LocalPath);
+        try
+        {
+            return Path.GetFullPath(parsed.LocalPath);
+        }
+        catch (Exception)
+        {
+            // Malformed URI path that the OS cannot normalise (e.g. invalid
+            // characters for the current platform). Fall back to null so the
+            // server uses its own CWD rather than crashing.
+            return null;
+        }
     }
 }

--- a/src/TALXIS.CLI.MCP/RootsService.cs
+++ b/src/TALXIS.CLI.MCP/RootsService.cs
@@ -81,6 +81,10 @@ internal sealed class RootsService
         if (!string.Equals(parsed.Scheme, "file", StringComparison.OrdinalIgnoreCase))
             return null;
 
-        return parsed.LocalPath;
+        // Uri.LocalPath handles percent-decoding and basic conversion, but
+        // Path.GetFullPath normalises separators and resolves platform
+        // differences (e.g. stripping the leading '/' from '/C:/...' on
+        // Windows, converting '/' → '\\', etc.).
+        return Path.GetFullPath(parsed.LocalPath);
     }
 }

--- a/tests/TALXIS.CLI.Tests/Config/Vault/VaultOptionsTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Vault/VaultOptionsTests.cs
@@ -64,17 +64,39 @@ public sealed class VaultOptionsTests
     }
 
     [Fact]
-    public void Secrets_IgnoresEnvVars_OnWindows()
+    public void Secrets_HonorsPlaintextFallbackEnvVar_OnWindows()
     {
         if (!OperatingSystem.IsWindows())
             return;
         var env = new StubEnv(new Dictionary<string, string?>
         {
-            [VaultOptions.LinuxPlaintextEnvVar] = "1",
+            [VaultOptions.PlaintextFallbackEnvVar] = "1",
+        });
+        var o = VaultOptions.Secrets(env);
+        Assert.True(o.UsePlaintextFallback);
+        Assert.Contains("TXC_PLAINTEXT_FALLBACK", o.PlaintextReason);
+    }
+
+    [Fact]
+    public void Secrets_IgnoresMacFileModeEnvVar_OnWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+        var env = new StubEnv(new Dictionary<string, string?>
+        {
             [VaultOptions.MacFileModeEnvVar] = "file",
         });
         var o = VaultOptions.Secrets(env);
         Assert.False(o.UsePlaintextFallback);
+    }
+
+    [Fact]
+    public void Secrets_HonorsPlaintextFallbackEnvVar_OnAllPlatforms()
+    {
+        var env = new StubEnv(new Dictionary<string, string?> { [VaultOptions.PlaintextFallbackEnvVar] = "1" });
+        var o = VaultOptions.Secrets(env);
+        Assert.True(o.UsePlaintextFallback);
+        Assert.Contains("TXC_PLAINTEXT_FALLBACK", o.PlaintextReason);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/Config/Vault/VaultUnavailableExceptionTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Vault/VaultUnavailableExceptionTests.cs
@@ -13,10 +13,14 @@ public sealed class VaultUnavailableExceptionTests
     }
 
     [Fact]
-    public void Message_MentionsLibsecretAndPlaintextOptIns()
+    public void Message_MentionsPlatformSpecificRemedies()
     {
         var ex = new VaultUnavailableException();
+        // Linux remedy
         Assert.Contains("libsecret-1-0", ex.Message);
+        // macOS remedy
+        Assert.Contains("TXC_TOKEN_CACHE_MODE=file", ex.Message);
+        // Cross-platform fallback
         Assert.Contains("TXC_PLAINTEXT_FALLBACK", ex.Message);
         Assert.Contains("--plaintext-fallback", ex.Message);
     }

--- a/tests/TALXIS.CLI.Tests/Config/Vault/VaultUnavailableExceptionTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Vault/VaultUnavailableExceptionTests.cs
@@ -22,7 +22,6 @@ public sealed class VaultUnavailableExceptionTests
         Assert.Contains("TXC_TOKEN_CACHE_MODE=file", ex.Message);
         // Cross-platform fallback
         Assert.Contains("TXC_PLAINTEXT_FALLBACK", ex.Message);
-        Assert.Contains("--plaintext-fallback", ex.Message);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -6,19 +6,32 @@ namespace TALXIS.CLI.Tests.MCP;
 public class RootsServiceTests
 {
     [Fact]
-    public void ConvertFileUri_UnixPath_ReturnsLocalPath()
+    public void ConvertFileUri_UnixPath_ReturnsNormalisedPath()
     {
         var result = RootsService.ConvertFileUriToPath("file:///home/user/project");
-        Assert.Equal("/home/user/project", result);
+        // Path.GetFullPath normalises; on Unix the result is unchanged.
+        Assert.NotNull(result);
+        Assert.Equal("/home/user/project", result.Replace('\\', '/'));
     }
 
     [Fact]
-    public void ConvertFileUri_WindowsPath_ReturnsLocalPath()
+    public void ConvertFileUri_WindowsPath_ReturnsNormalisedPath()
     {
         var result = RootsService.ConvertFileUriToPath("file:///C:/Users/project");
         Assert.NotNull(result);
-        // On Unix, Uri.LocalPath returns "/C:/Users/project"; on Windows, "C:\Users\project"
+        // On both platforms, the path must end with C:/Users/project (separator may vary).
+        // On Windows: Path.GetFullPath strips leading / and uses backslashes.
+        // On Unix: the path stays as-is (no drive letters on Unix).
         Assert.EndsWith("C:/Users/project", result.Replace('\\', '/'));
+    }
+
+    [Fact]
+    public void ConvertFileUri_WindowsLowercaseDrive_ReturnsNormalisedPath()
+    {
+        // VS Code on Windows sends lowercase drive letters
+        var result = RootsService.ConvertFileUriToPath("file:///c:/Users/project");
+        Assert.NotNull(result);
+        Assert.EndsWith("c:/Users/project", result.Replace('\\', '/'));
     }
 
     [Fact]
@@ -48,6 +61,17 @@ public class RootsServiceTests
     public void ConvertFileUri_EncodedSpaces_DecodesCorrectly()
     {
         var result = RootsService.ConvertFileUriToPath("file:///home/user/my%20project");
-        Assert.Equal("/home/user/my project", result);
+        Assert.NotNull(result);
+        Assert.Contains("my project", result);
+    }
+
+    [Fact]
+    public void ConvertFileUri_ResultIsFullPath()
+    {
+        // Path.GetFullPath always returns an absolute path
+        var result = RootsService.ConvertFileUriToPath("file:///home/user/project");
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathFullyQualified(result),
+            $"Expected fully-qualified path but got: {result}");
     }
 }

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -9,9 +9,10 @@ public class RootsServiceTests
     public void ConvertFileUri_UnixPath_ReturnsNormalisedPath()
     {
         var result = RootsService.ConvertFileUriToPath("file:///home/user/project");
-        // Path.GetFullPath normalises; on Unix the result is unchanged.
         Assert.NotNull(result);
-        Assert.Equal("/home/user/project", result.Replace('\\', '/'));
+        // Path.GetFullPath may prepend a drive root on Windows, so assert the
+        // meaningful suffix rather than an exact match.
+        Assert.EndsWith("home/user/project", result.Replace('\\', '/'));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes #103 (DPAPI not supported) and #102 (Windows path resolution).

### Issue #103 — DPAPI Vault Failure

**Root cause:** `System.Security.Cryptography.ProtectedData` versions < 10.0 ship a `lib/netstandard2.0` (or `lib/net6.0`) **stub** that always throws `PlatformNotSupportedException("Windows Data Protection API (DPAPI) is not supported on this platform.")`. The real DPAPI implementation lives in `runtimes/win/lib/` and requires `deps.json` `runtimeTargets` probing to resolve. The published MCP tool package is missing `TALXIS.CLI.deps.json`, so the subprocess falls back to the stub.

Version **10.0.5** ships `lib/net10.0/` with the real `CryptProtectData` P/Invoke — no `runtimeTargets` probing needed. PAC CLI also uses 10.0.5 (confirmed via decompilation).

**Changes:**
- Bump `System.Security.Cryptography.ProtectedData` to 10.0.5 in `TALXIS.CLI.Core.csproj`
- `TXC_PLAINTEXT_FALLBACK=1` now works on **all platforms** (was Linux-only) — needed for Windows containers/CI
- Platform-aware error messages in `MsalCacheHelperFactory` and `VaultUnavailableException`
- Plaintext fallback warning uses platform-appropriate language (NTFS ACLs vs chmod 600)

### Issue #102 — Windows Path Resolution

**Root cause:** `Uri.LocalPath` for `file:///c:/Users/...` can produce `/c:/Users/...` which is invalid on Windows.

**Fix:** `Path.GetFullPath(parsed.LocalPath)` — the idiomatic .NET cross-platform path normaliser. Handles drive letters, separator normalisation, and encoded characters.

### Additional cross-platform hardening (from repo-wide scan)

- `GuideHandler.cs` — normalise line endings before `Split` to handle `\r\n`
- `LogRedactionFilter.cs` — case-insensitive home path replacement for Windows

### Testing

- 486 unit tests pass, 0 failures
- Real process tests: `txc --help`, `config profile list`, `config profile validate`, `txc-mcp` startup — all pass on macOS
- Verified via `ilspycmd` that the build output DLL contains real `CryptProtectData` P/Invoke (not the stub)
