### PR TITLE
feat: smooth flow dev workflow — auto-build import, project-dir export, file-based url open

### DIFF
--- a/src/TALXIS.CLI.Core/Resolution/SolutionProjectResolver.cs
+++ b/src/TALXIS.CLI.Core/Resolution/SolutionProjectResolver.cs
@@ -1,0 +1,101 @@
+using System.Xml.Linq;
+
+namespace TALXIS.CLI.Core.Resolution;
+
+/// <summary>
+/// Resolves Dataverse solution project conventions: finds <c>.cdsproj</c> / <c>.csproj</c>
+/// files, reads the <c>SolutionRootPath</c> MSBuild property, and locates
+/// <c>Other/Solution.xml</c> to extract the solution unique name.
+/// </summary>
+/// <remarks>
+/// Multiple commands need these conventions (import, export, url open, data model convert).
+/// Centralizing them here avoids duplication and ensures consistent behavior.
+/// </remarks>
+public static class SolutionProjectResolver
+{
+    /// <summary>Default fallback when <c>SolutionRootPath</c> is not declared in the project file.</summary>
+    public const string DefaultSolutionRootPath = "src";
+
+    /// <summary>
+    /// Finds the first <c>.cdsproj</c> or <c>.csproj</c> in the given directory.
+    /// <c>.cdsproj</c> is preferred (Dataverse convention); <c>.csproj</c> is the fallback.
+    /// Returns null if no project file is found.
+    /// </summary>
+    public static string? FindProjectFile(string directoryPath)
+    {
+        if (!Directory.Exists(directoryPath))
+            return null;
+
+        return Directory.EnumerateFiles(directoryPath, "*.cdsproj").FirstOrDefault()
+            ?? Directory.EnumerateFiles(directoryPath, "*.csproj").FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Reads the <c>SolutionRootPath</c> MSBuild property from a project file.
+    /// Returns the raw property value, or null if the property is not defined.
+    /// </summary>
+    public static string? ReadSolutionRootPath(string projectFilePath)
+    {
+        var doc = XDocument.Load(projectFilePath);
+        var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+        return doc.Descendants(ns + "SolutionRootPath").FirstOrDefault()?.Value;
+    }
+
+    /// <summary>
+    /// Resolves the solution root directory from a project file.
+    /// Reads <c>SolutionRootPath</c> from the project, falls back to <paramref name="fallback"/>,
+    /// and returns the absolute path. Returns null if the resolved directory does not exist.
+    /// </summary>
+    public static string? ResolveSolutionRoot(string projectFilePath, string fallback = DefaultSolutionRootPath)
+    {
+        var projectDir = Path.GetDirectoryName(projectFilePath)!;
+        var solutionRootPath = ReadSolutionRootPath(projectFilePath);
+
+        if (string.IsNullOrWhiteSpace(solutionRootPath))
+            solutionRootPath = fallback;
+
+        var resolved = Path.GetFullPath(Path.Combine(projectDir, solutionRootPath));
+        return Directory.Exists(resolved) ? resolved : null;
+    }
+
+    /// <summary>
+    /// Reads the <c>&lt;UniqueName&gt;</c> from <c>Other/Solution.xml</c> under the given solution root.
+    /// Returns null if the file does not exist or the element is missing.
+    /// </summary>
+    public static string? ReadSolutionUniqueName(string solutionRootPath)
+    {
+        var solutionXmlPath = Path.Combine(solutionRootPath, "Other", "Solution.xml");
+        if (!File.Exists(solutionXmlPath))
+            return null;
+
+        var doc = XDocument.Load(solutionXmlPath);
+        return doc.Descendants("UniqueName").FirstOrDefault()?.Value;
+    }
+
+    /// <summary>
+    /// Walks up from a file path to find the solution workspace root —
+    /// the directory containing <c>Other/Solution.xml</c>. Also checks for
+    /// <c>.cdsproj</c> / <c>.csproj</c> files that declare a <c>SolutionRootPath</c>.
+    /// Returns null if no workspace root can be found.
+    /// </summary>
+    public static string? FindWorkspaceRoot(string startPath)
+    {
+        var dir = File.Exists(startPath) ? Path.GetDirectoryName(startPath) : startPath;
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir, "Other", "Solution.xml")))
+                return dir;
+
+            var projectFile = FindProjectFile(dir);
+            if (projectFile is not null)
+            {
+                var solutionRootPath = ReadSolutionRootPath(projectFile) ?? ".";
+                var candidateRoot = Path.GetFullPath(Path.Combine(dir, solutionRootPath));
+                if (File.Exists(Path.Combine(candidateRoot, "Other", "Solution.xml")))
+                    return candidateRoot;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+}

--- a/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
@@ -1,8 +1,8 @@
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
+using TALXIS.Platform.Metadata;
+using TALXIS.Platform.Metadata.Serialization.Xml;
 
 namespace TALXIS.CLI.Features.Environment.Component.Url;
 
@@ -19,32 +19,28 @@ public abstract class UrlCommandBase : ProfiledCliCommand
     [CliOption(Name = "--param", Description = "URL parameter in key=value format. Can be specified multiple times. Available parameters depend on the component type.", Required = false)]
     public List<string> Param { get; set; } = new();
 
-    [CliOption(Name = "--file", Description = "Path to a local component file. Auto-detects component type and GUID from the file path and metadata.", Required = false)]
+    [CliOption(Name = "--file", Description = "Path to a local component file. Auto-detects component type and GUID by loading the workspace with the platform metadata library.", Required = false)]
     public string? File { get; set; }
-
-    /// <summary>
-    /// Regex for extracting a GUID from a file name (e.g. {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}).
-    /// </summary>
-    private static readonly Regex GuidInFileNamePattern = new(
-        @"\{?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\}?",
-        RegexOptions.Compiled);
 
     /// <summary>
     /// Builds the URL from the shared options. Returns null on failure (error already logged).
     /// </summary>
     protected async Task<UrlBuilderResult?> BuildUrlFromOptionsAsync()
     {
-        // When --file is provided, resolve type and id from the file before the normal flow.
+        // When --file is provided, resolve type and params from the workspace metadata.
         if (!string.IsNullOrWhiteSpace(File))
         {
             var resolved = ResolveFromFile(Path.GetFullPath(File));
             if (resolved is null)
                 return null;
             Type ??= resolved.Value.Type;
-            // Inject the resolved id into --param unless already provided
+            // Inject resolved params unless the user already specified them
             var existingParams = UrlBuilder.ParseParams(Param);
-            if (!existingParams.ContainsKey("id"))
-                Param.Add($"id={resolved.Value.Id}");
+            foreach (var kvp in resolved.Value.Params)
+            {
+                if (!existingParams.ContainsKey(kvp.Key))
+                    Param.Add($"{kvp.Key}={kvp.Value}");
+            }
         }
 
         if (string.IsNullOrWhiteSpace(Type))
@@ -58,180 +54,134 @@ public abstract class UrlCommandBase : ProfiledCliCommand
     }
 
     /// <summary>
-    /// Auto-detects the component type and GUID from a local file path and its metadata.
+    /// Auto-detects the component type and URL parameters from a local file path by loading
+    /// the workspace with <see cref="XmlWorkspaceReader"/> and matching the file to a component.
     /// </summary>
-    private (string Type, string Id)? ResolveFromFile(string absolutePath)
+    /// <remarks>
+    /// The SourceDocumentKey carries structured identifiers per type:
+    /// <list type="bullet">
+    ///   <item><c>Entity:logicalname</c> — ObjectId is the entity logical name</item>
+    ///   <item><c>Form:entityname:{guid}</c> — ObjectId is the form GUID</item>
+    ///   <item><c>View:entityname:{guid}</c> — ObjectId is the view GUID</item>
+    ///   <item><c>Workflow:name</c> — ObjectId is the workflow GUID</item>
+    /// </list>
+    /// </remarks>
+    private (string Type, Dictionary<string, string> Params)? ResolveFromFile(string absolutePath)
     {
-        var normalizedPath = absolutePath.Replace('\\', '/');
-        var segments = normalizedPath.Split('/');
-
-        string? componentType = null;
-        string? componentId = null;
-
-        // Detect component type from path segments
-        for (int i = 0; i < segments.Length; i++)
+        var workspaceRoot = FindWorkspaceRoot(absolutePath);
+        if (workspaceRoot is null)
         {
-            var segment = segments[i];
-
-            if (segment.Equals("Workflows", StringComparison.OrdinalIgnoreCase) && i + 1 < segments.Length)
-            {
-                componentType = "Workflow";
-                // Read GUID from companion .data.xml file
-                var dataXmlPath = absolutePath + ".data.xml";
-                if (System.IO.File.Exists(dataXmlPath))
-                {
-                    componentId = ExtractWorkflowIdFromDataXml(dataXmlPath);
-                }
-                break;
-            }
-
-            if (segment.Equals("Entities", StringComparison.OrdinalIgnoreCase) && i + 1 < segments.Length)
-            {
-                // Determine sub-type based on further path segments
-                if (i + 2 < segments.Length && segments[i + 2].Equals("FormXml", StringComparison.OrdinalIgnoreCase))
-                {
-                    componentType = "SystemForm";
-                    componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
-                }
-                else if (i + 2 < segments.Length && segments[i + 2].Equals("SavedQueries", StringComparison.OrdinalIgnoreCase))
-                {
-                    componentType = "SavedQuery";
-                    componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
-                }
-                else if (i + 1 < segments.Length && segments.Length > i + 2 && segments[i + 2].Equals("Entity.xml", StringComparison.OrdinalIgnoreCase))
-                {
-                    componentType = "Entity";
-                    componentId = ExtractGuidFromXmlContent(absolutePath, "EntityId", "MetadataId");
-                }
-                else
-                {
-                    // Generic entity path — check if it's Entity.xml directly
-                    var fileName = Path.GetFileName(absolutePath);
-                    if (fileName.Equals("Entity.xml", StringComparison.OrdinalIgnoreCase))
-                    {
-                        componentType = "Entity";
-                        componentId = ExtractGuidFromXmlContent(absolutePath, "EntityId", "MetadataId");
-                    }
-                }
-                break;
-            }
-
-            if (segment.Equals("Roles", StringComparison.OrdinalIgnoreCase))
-            {
-                componentType = "Role";
-                componentId = ExtractGuidFromFileName(absolutePath);
-                break;
-            }
-
-            if (segment.Equals("WebResources", StringComparison.OrdinalIgnoreCase))
-            {
-                componentType = "WebResource";
-                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
-                break;
-            }
-
-            if (segment.Equals("AppModules", StringComparison.OrdinalIgnoreCase))
-            {
-                componentType = "AppModule";
-                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
-                break;
-            }
-
-            if (segment.Equals("OptionSets", StringComparison.OrdinalIgnoreCase))
-            {
-                componentType = "OptionSet";
-                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
-                break;
-            }
-        }
-
-        if (componentType is null)
-        {
-            Logger.LogError("Could not determine component type from file path: {Path}.", absolutePath);
+            Logger.LogError("Could not find workspace root (Other/Solution.xml) for file: {Path}.", absolutePath);
             return null;
         }
 
-        if (componentId is null)
+        var reader = new XmlWorkspaceReader();
+        var workspace = reader.Load(workspaceRoot);
+
+        var normalizedFile = Path.GetFullPath(absolutePath);
+
+        foreach (var component in workspace.EnumerateLayerComponents())
         {
-            Logger.LogError("Could not extract component GUID from file: {Path}.", absolutePath);
-            return null;
+            if (!IsFileMatch(component, normalizedFile, workspaceRoot))
+                continue;
+
+            var typeName = component.Type.ToString();
+            var resolvedParams = ExtractUrlParams(component);
+
+            Logger.LogInformation("Resolved --file to type '{Type}' with params: {Params}.",
+                typeName, string.Join(", ", resolvedParams.Select(p => $"{p.Key}={p.Value}")));
+
+            return (typeName, resolvedParams);
         }
 
-        Logger.LogInformation("Resolved --file to type '{Type}' with id '{Id}'.", componentType, componentId);
-        return (componentType, componentId);
-    }
-
-    /// <summary>
-    /// Reads the WorkflowId from a companion .data.xml file.
-    /// Expected format: <c>&lt;Workflow WorkflowId="{guid}" ...&gt;</c>
-    /// </summary>
-    private static string? ExtractWorkflowIdFromDataXml(string dataXmlPath)
-    {
-        var doc = XDocument.Load(dataXmlPath);
-        var workflowId = doc.Root?.Attribute("WorkflowId")?.Value
-            ?? doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Workflow")?.Attribute("WorkflowId")?.Value;
-        if (workflowId is not null)
-            return workflowId.Trim('{', '}');
+        Logger.LogError("Could not match file to any component in workspace: {Path}.", absolutePath);
         return null;
     }
 
     /// <summary>
-    /// Extracts a GUID from the file name using regex.
+    /// Walks up from the file to find the solution workspace root (directory containing Other/Solution.xml).
+    /// Also checks for .cdsproj/.csproj files that declare a SolutionRootPath property.
     /// </summary>
-    private static string? ExtractGuidFromFileName(string filePath)
+    private static string? FindWorkspaceRoot(string absolutePath)
     {
-        var fileName = Path.GetFileName(filePath);
-        var match = GuidInFileNamePattern.Match(fileName);
-        return match.Success ? match.Groups[1].Value : null;
-    }
+        var dir = Path.GetDirectoryName(absolutePath);
+        while (dir is not null)
+        {
+            if (System.IO.File.Exists(Path.Combine(dir, "Other", "Solution.xml")))
+                return dir;
 
-    /// <summary>
-    /// Tries to extract a GUID from the file name first, then falls back to XML content.
-    /// </summary>
-    private static string? ExtractGuidFromPathOrContent(string filePath, string[] segments)
-    {
-        // Try file name first
-        var fromName = ExtractGuidFromFileName(filePath);
-        if (fromName is not null)
-            return fromName;
-
-        // Try XML content with common attribute patterns
-        if (filePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) && System.IO.File.Exists(filePath))
-            return ExtractGuidFromXmlContent(filePath, "id", "formid", "savedqueryid", "webresourceid");
-
+            var csproj = Directory.GetFiles(dir, "*.cdsproj").FirstOrDefault()
+                      ?? Directory.GetFiles(dir, "*.csproj").FirstOrDefault();
+            if (csproj is not null)
+            {
+                var projDoc = System.Xml.Linq.XDocument.Load(csproj);
+                var ns = projDoc.Root?.Name.Namespace ?? System.Xml.Linq.XNamespace.None;
+                var solutionRootPath = projDoc.Descendants(ns + "SolutionRootPath").FirstOrDefault()?.Value ?? ".";
+                var candidateRoot = Path.GetFullPath(Path.Combine(dir, solutionRootPath));
+                if (System.IO.File.Exists(Path.Combine(candidateRoot, "Other", "Solution.xml")))
+                    return candidateRoot;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
         return null;
     }
 
     /// <summary>
-    /// Searches XML content for a GUID in common id-bearing attributes or elements.
+    /// Checks whether the given component matches the target file path.
+    /// Uses the metadata source file path for an exact match.
     /// </summary>
-    private static string? ExtractGuidFromXmlContent(string xmlPath, params string[] attributeNames)
+    private static bool IsFileMatch(
+        TALXIS.Platform.Metadata.Solutions.LayerComponentDescriptor component,
+        string normalizedFile,
+        string workspaceRoot)
     {
-        if (!System.IO.File.Exists(xmlPath))
-            return null;
-        var doc = XDocument.Load(xmlPath);
-        // Check root element attributes
-        if (doc.Root is not null)
+        if (component.Metadata?.Source?.FilePath is null)
+            return false;
+
+        // Source.FilePath is absolute from the workspace reader
+        var componentFile = Path.GetFullPath(component.Metadata.Source.FilePath);
+        return string.Equals(componentFile, normalizedFile, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Extracts URL parameters from a matched component based on its type and SourceDocumentKey.
+    /// Different types produce different parameter sets for the URL builder.
+    /// </summary>
+    private static Dictionary<string, string> ExtractUrlParams(
+        TALXIS.Platform.Metadata.Solutions.LayerComponentDescriptor component)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // SourceDocumentKey format: "Type:entityname:{guid}" or "Type:name"
+        var keyParts = component.SourceDocumentKey?.Split(':') ?? Array.Empty<string>();
+
+        switch (component.Type)
         {
-            foreach (var attrName in attributeNames)
-            {
-                var attr = doc.Root.Attributes()
-                    .FirstOrDefault(a => a.Name.LocalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
-                if (attr is not null && Guid.TryParse(attr.Value.Trim('{', '}'), out _))
-                    return attr.Value.Trim('{', '}');
-            }
-            // Check child elements with those names
-            foreach (var attrName in attributeNames)
-            {
-                var elem = doc.Descendants()
-                    .FirstOrDefault(e => e.Name.LocalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
-                if (elem is not null && Guid.TryParse(elem.Value.Trim('{', '}'), out _))
-                    return elem.Value.Trim('{', '}');
-            }
+            case ComponentType.Entity:
+                // ObjectId is the entity logical name
+                result["entity"] = component.ObjectId;
+                break;
+
+            case ComponentType.SystemForm:
+                // SourceDocumentKey: "Form:entityname:{guid}"
+                result["id"] = component.ObjectId;
+                if (keyParts.Length >= 2)
+                    result["entity"] = keyParts[1];
+                break;
+
+            case ComponentType.SavedQuery:
+                // SourceDocumentKey: "View:entityname:{guid}"
+                result["id"] = component.ObjectId;
+                if (keyParts.Length >= 2)
+                    result["entity"] = keyParts[1];
+                break;
+
+            default:
+                // For most types (Workflow, Role, AppModule, etc.), ObjectId is the GUID
+                result["id"] = component.ObjectId;
+                break;
         }
-        // Last resort: search entire content for a GUID
-        var content = System.IO.File.ReadAllText(xmlPath);
-        var match = GuidInFileNamePattern.Match(content);
-        return match.Success ? match.Groups[1].Value : null;
+
+        return result;
     }
 }

--- a/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
@@ -1,6 +1,7 @@
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Resolution;
 using TALXIS.Platform.Metadata;
 using TALXIS.Platform.Metadata.Serialization.Xml;
 
@@ -68,7 +69,7 @@ public abstract class UrlCommandBase : ProfiledCliCommand
     /// </remarks>
     private (string Type, Dictionary<string, string> Params)? ResolveFromFile(string absolutePath)
     {
-        var workspaceRoot = FindWorkspaceRoot(absolutePath);
+        var workspaceRoot = SolutionProjectResolver.FindWorkspaceRoot(absolutePath);
         if (workspaceRoot is null)
         {
             Logger.LogError("Could not find workspace root (Other/Solution.xml) for file: {Path}.", absolutePath);
@@ -82,7 +83,7 @@ public abstract class UrlCommandBase : ProfiledCliCommand
 
         foreach (var component in workspace.EnumerateLayerComponents())
         {
-            if (!IsFileMatch(component, normalizedFile, workspaceRoot))
+            if (!IsFileMatch(component, normalizedFile))
                 continue;
 
             var typeName = component.Type.ToString();
@@ -99,41 +100,12 @@ public abstract class UrlCommandBase : ProfiledCliCommand
     }
 
     /// <summary>
-    /// Walks up from the file to find the solution workspace root (directory containing Other/Solution.xml).
-    /// Also checks for .cdsproj/.csproj files that declare a SolutionRootPath property.
-    /// </summary>
-    private static string? FindWorkspaceRoot(string absolutePath)
-    {
-        var dir = Path.GetDirectoryName(absolutePath);
-        while (dir is not null)
-        {
-            if (System.IO.File.Exists(Path.Combine(dir, "Other", "Solution.xml")))
-                return dir;
-
-            var csproj = Directory.GetFiles(dir, "*.cdsproj").FirstOrDefault()
-                      ?? Directory.GetFiles(dir, "*.csproj").FirstOrDefault();
-            if (csproj is not null)
-            {
-                var projDoc = System.Xml.Linq.XDocument.Load(csproj);
-                var ns = projDoc.Root?.Name.Namespace ?? System.Xml.Linq.XNamespace.None;
-                var solutionRootPath = projDoc.Descendants(ns + "SolutionRootPath").FirstOrDefault()?.Value ?? ".";
-                var candidateRoot = Path.GetFullPath(Path.Combine(dir, solutionRootPath));
-                if (System.IO.File.Exists(Path.Combine(candidateRoot, "Other", "Solution.xml")))
-                    return candidateRoot;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        return null;
-    }
-
-    /// <summary>
     /// Checks whether the given component matches the target file path.
     /// Uses the metadata source file path for an exact match.
     /// </summary>
     private static bool IsFileMatch(
         TALXIS.Platform.Metadata.Solutions.LayerComponentDescriptor component,
-        string normalizedFile,
-        string workspaceRoot)
+        string normalizedFile)
     {
         if (component.Metadata?.Source?.FilePath is null)
             return false;
@@ -158,8 +130,9 @@ public abstract class UrlCommandBase : ProfiledCliCommand
         switch (component.Type)
         {
             case ComponentType.Entity:
-                // ObjectId is the entity logical name
-                result["entity"] = component.ObjectId;
+                // ObjectId is the entity logical name — set as 'name' so the URL builder
+                // resolves it to MetadataId via the Dataverse API
+                result["name"] = component.ObjectId;
                 break;
 
             case ComponentType.SystemForm:

--- a/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
+++ b/src/TALXIS.CLI.Features.Environment/Component/Url/UrlCommandBase.cs
@@ -1,4 +1,7 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
 
 namespace TALXIS.CLI.Features.Environment.Component.Url;
@@ -10,18 +13,225 @@ namespace TALXIS.CLI.Features.Environment.Component.Url;
 [CliReadOnly]
 public abstract class UrlCommandBase : ProfiledCliCommand
 {
-    [CliOption(Name = "--type", Description = "Component type — accepts canonical name (Entity, Workflow), alias (Table, Flow), template name (pp-entity), or integer type code.", Required = true)]
-    public string Type { get; set; } = null!;
+    [CliOption(Name = "--type", Description = "Component type — accepts canonical name (Entity, Workflow), alias (Table, Flow), template name (pp-entity), or integer type code.", Required = false)]
+    public string? Type { get; set; }
 
     [CliOption(Name = "--param", Description = "URL parameter in key=value format. Can be specified multiple times. Available parameters depend on the component type.", Required = false)]
     public List<string> Param { get; set; } = new();
+
+    [CliOption(Name = "--file", Description = "Path to a local component file. Auto-detects component type and GUID from the file path and metadata.", Required = false)]
+    public string? File { get; set; }
+
+    /// <summary>
+    /// Regex for extracting a GUID from a file name (e.g. {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}).
+    /// </summary>
+    private static readonly Regex GuidInFileNamePattern = new(
+        @"\{?([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\}?",
+        RegexOptions.Compiled);
 
     /// <summary>
     /// Builds the URL from the shared options. Returns null on failure (error already logged).
     /// </summary>
     protected async Task<UrlBuilderResult?> BuildUrlFromOptionsAsync()
     {
+        // When --file is provided, resolve type and id from the file before the normal flow.
+        if (!string.IsNullOrWhiteSpace(File))
+        {
+            var resolved = ResolveFromFile(Path.GetFullPath(File));
+            if (resolved is null)
+                return null;
+            Type ??= resolved.Value.Type;
+            // Inject the resolved id into --param unless already provided
+            var existingParams = UrlBuilder.ParseParams(Param);
+            if (!existingParams.ContainsKey("id"))
+                Param.Add($"id={resolved.Value.Id}");
+        }
+
+        if (string.IsNullOrWhiteSpace(Type))
+        {
+            Logger.LogError("'--type' is required (or use '--file' to auto-detect).");
+            return null;
+        }
+
         var parameters = UrlBuilder.ParseParams(Param);
         return await UrlBuilder.BuildUrlAsync(Type, parameters, Profile, Logger).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Auto-detects the component type and GUID from a local file path and its metadata.
+    /// </summary>
+    private (string Type, string Id)? ResolveFromFile(string absolutePath)
+    {
+        var normalizedPath = absolutePath.Replace('\\', '/');
+        var segments = normalizedPath.Split('/');
+
+        string? componentType = null;
+        string? componentId = null;
+
+        // Detect component type from path segments
+        for (int i = 0; i < segments.Length; i++)
+        {
+            var segment = segments[i];
+
+            if (segment.Equals("Workflows", StringComparison.OrdinalIgnoreCase) && i + 1 < segments.Length)
+            {
+                componentType = "Workflow";
+                // Read GUID from companion .data.xml file
+                var dataXmlPath = absolutePath + ".data.xml";
+                if (System.IO.File.Exists(dataXmlPath))
+                {
+                    componentId = ExtractWorkflowIdFromDataXml(dataXmlPath);
+                }
+                break;
+            }
+
+            if (segment.Equals("Entities", StringComparison.OrdinalIgnoreCase) && i + 1 < segments.Length)
+            {
+                // Determine sub-type based on further path segments
+                if (i + 2 < segments.Length && segments[i + 2].Equals("FormXml", StringComparison.OrdinalIgnoreCase))
+                {
+                    componentType = "SystemForm";
+                    componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
+                }
+                else if (i + 2 < segments.Length && segments[i + 2].Equals("SavedQueries", StringComparison.OrdinalIgnoreCase))
+                {
+                    componentType = "SavedQuery";
+                    componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
+                }
+                else if (i + 1 < segments.Length && segments.Length > i + 2 && segments[i + 2].Equals("Entity.xml", StringComparison.OrdinalIgnoreCase))
+                {
+                    componentType = "Entity";
+                    componentId = ExtractGuidFromXmlContent(absolutePath, "EntityId", "MetadataId");
+                }
+                else
+                {
+                    // Generic entity path — check if it's Entity.xml directly
+                    var fileName = Path.GetFileName(absolutePath);
+                    if (fileName.Equals("Entity.xml", StringComparison.OrdinalIgnoreCase))
+                    {
+                        componentType = "Entity";
+                        componentId = ExtractGuidFromXmlContent(absolutePath, "EntityId", "MetadataId");
+                    }
+                }
+                break;
+            }
+
+            if (segment.Equals("Roles", StringComparison.OrdinalIgnoreCase))
+            {
+                componentType = "Role";
+                componentId = ExtractGuidFromFileName(absolutePath);
+                break;
+            }
+
+            if (segment.Equals("WebResources", StringComparison.OrdinalIgnoreCase))
+            {
+                componentType = "WebResource";
+                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
+                break;
+            }
+
+            if (segment.Equals("AppModules", StringComparison.OrdinalIgnoreCase))
+            {
+                componentType = "AppModule";
+                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
+                break;
+            }
+
+            if (segment.Equals("OptionSets", StringComparison.OrdinalIgnoreCase))
+            {
+                componentType = "OptionSet";
+                componentId = ExtractGuidFromPathOrContent(absolutePath, segments);
+                break;
+            }
+        }
+
+        if (componentType is null)
+        {
+            Logger.LogError("Could not determine component type from file path: {Path}.", absolutePath);
+            return null;
+        }
+
+        if (componentId is null)
+        {
+            Logger.LogError("Could not extract component GUID from file: {Path}.", absolutePath);
+            return null;
+        }
+
+        Logger.LogInformation("Resolved --file to type '{Type}' with id '{Id}'.", componentType, componentId);
+        return (componentType, componentId);
+    }
+
+    /// <summary>
+    /// Reads the WorkflowId from a companion .data.xml file.
+    /// Expected format: <c>&lt;Workflow WorkflowId="{guid}" ...&gt;</c>
+    /// </summary>
+    private static string? ExtractWorkflowIdFromDataXml(string dataXmlPath)
+    {
+        var doc = XDocument.Load(dataXmlPath);
+        var workflowId = doc.Root?.Attribute("WorkflowId")?.Value
+            ?? doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Workflow")?.Attribute("WorkflowId")?.Value;
+        if (workflowId is not null)
+            return workflowId.Trim('{', '}');
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts a GUID from the file name using regex.
+    /// </summary>
+    private static string? ExtractGuidFromFileName(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        var match = GuidInFileNamePattern.Match(fileName);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>
+    /// Tries to extract a GUID from the file name first, then falls back to XML content.
+    /// </summary>
+    private static string? ExtractGuidFromPathOrContent(string filePath, string[] segments)
+    {
+        // Try file name first
+        var fromName = ExtractGuidFromFileName(filePath);
+        if (fromName is not null)
+            return fromName;
+
+        // Try XML content with common attribute patterns
+        if (filePath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) && System.IO.File.Exists(filePath))
+            return ExtractGuidFromXmlContent(filePath, "id", "formid", "savedqueryid", "webresourceid");
+
+        return null;
+    }
+
+    /// <summary>
+    /// Searches XML content for a GUID in common id-bearing attributes or elements.
+    /// </summary>
+    private static string? ExtractGuidFromXmlContent(string xmlPath, params string[] attributeNames)
+    {
+        if (!System.IO.File.Exists(xmlPath))
+            return null;
+        var doc = XDocument.Load(xmlPath);
+        // Check root element attributes
+        if (doc.Root is not null)
+        {
+            foreach (var attrName in attributeNames)
+            {
+                var attr = doc.Root.Attributes()
+                    .FirstOrDefault(a => a.Name.LocalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
+                if (attr is not null && Guid.TryParse(attr.Value.Trim('{', '}'), out _))
+                    return attr.Value.Trim('{', '}');
+            }
+            // Check child elements with those names
+            foreach (var attrName in attributeNames)
+            {
+                var elem = doc.Descendants()
+                    .FirstOrDefault(e => e.Name.LocalName.Equals(attrName, StringComparison.OrdinalIgnoreCase));
+                if (elem is not null && Guid.TryParse(elem.Value.Trim('{', '}'), out _))
+                    return elem.Value.Trim('{', '}');
+            }
+        }
+        // Last resort: search entire content for a GUID
+        var content = System.IO.File.ReadAllText(xmlPath);
+        var match = GuidInFileNamePattern.Match(content);
+        return match.Success ? match.Groups[1].Value : null;
     }
 }

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionExportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionExportCliCommand.cs
@@ -1,3 +1,4 @@
+using System.Xml.Linq;
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
@@ -16,7 +17,7 @@ public class SolutionExportCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SolutionExportCliCommand));
 
-    [CliArgument(Name = "name", Description = "Solution unique name.")]
+    [CliArgument(Name = "name", Description = "Solution unique name, or a project directory path (.cdsproj/.csproj) to auto-detect the solution name.")]
     public string Name { get; set; } = null!;
 
     [CliOption(Name = "--output", Alias = "-o", Description = "Output path (directory for unpacked, file path for ZIP). Default: current directory.", Required = false)]
@@ -30,23 +31,110 @@ public class SolutionExportCliCommand : ProfiledCliCommand
 
     protected override async Task<int> ExecuteAsync()
     {
-        var outputPath = Output ?? Directory.GetCurrentDirectory();
+        var solutionName = Name;
+        var outputPath = Output;
+
+        // Detect project-dir mode: if the argument looks like a directory path, try to
+        // resolve the solution unique name from the project's Solution.xml.
+        if (IsDirectoryPath(solutionName))
+        {
+            var resolved = ResolveFromProjectDirectory(Path.GetFullPath(solutionName));
+            if (resolved is null)
+                return ExitValidationError;
+            solutionName = resolved.Value.UniqueName;
+            // Auto-set output to the solution root path so files unpack to the right place
+            outputPath ??= resolved.Value.SolutionRootPath;
+        }
+
+        outputPath ??= Directory.GetCurrentDirectory();
         var unpack = !Zip;
 
-        var options = new SolutionExportOptions(Name, Managed, outputPath, unpack);
+        var options = new SolutionExportOptions(solutionName, Managed, outputPath, unpack);
         var service = TxcServices.Get<ISolutionExportService>();
         var resultPath = await service.ExportAsync(Profile, options, CancellationToken.None).ConfigureAwait(false);
 
         var mode = unpack ? "unpacked" : "ZIP";
         OutputFormatter.WriteData(
-            new { status = "exported", solution = Name, managed = Managed, format = mode, path = resultPath },
+            new { status = "exported", solution = solutionName, managed = Managed, format = mode, path = resultPath },
             _ =>
             {
 #pragma warning disable TXC003
-                OutputWriter.WriteLine($"Exported solution '{Name}' ({(Managed ? "managed" : "unmanaged")}) → {resultPath} ({mode})");
+                OutputWriter.WriteLine($"Exported solution '{solutionName}' ({(Managed ? "managed" : "unmanaged")}) → {resultPath} ({mode})");
 #pragma warning restore TXC003
             });
 
         return ExitSuccess;
+    }
+
+    /// <summary>
+    /// Returns true if the argument looks like a directory path rather than a plain solution name.
+    /// </summary>
+    private static bool IsDirectoryPath(string value)
+    {
+        if (value == ".")
+            return true;
+        if (value.Contains('/') || value.Contains('\\'))
+            return true;
+        if (Directory.Exists(value))
+            return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves solution unique name and solution root path from a project directory
+    /// containing a .cdsproj or .csproj with a SolutionRootPath property.
+    /// </summary>
+    private (string UniqueName, string SolutionRootPath)? ResolveFromProjectDirectory(string dirPath)
+    {
+        if (!Directory.Exists(dirPath))
+        {
+            Logger.LogError("Directory not found: {Path}.", dirPath);
+            return null;
+        }
+
+        var projectFile = Directory.EnumerateFiles(dirPath, "*.cdsproj").FirstOrDefault()
+            ?? Directory.EnumerateFiles(dirPath, "*.csproj").FirstOrDefault();
+
+        if (projectFile is null)
+        {
+            Logger.LogError("No .cdsproj or .csproj found in '{Dir}'.", dirPath);
+            return null;
+        }
+
+        var doc = XDocument.Load(projectFile);
+        XNamespace ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+        var solutionRootPath = doc.Descendants(ns + "SolutionRootPath").FirstOrDefault()?.Value;
+
+        if (string.IsNullOrWhiteSpace(solutionRootPath))
+        {
+            // Fallback: use src/ as the default convention
+            solutionRootPath = "src";
+        }
+
+        var resolvedRoot = Path.GetFullPath(Path.Combine(dirPath, solutionRootPath));
+        if (!Directory.Exists(resolvedRoot))
+        {
+            Logger.LogError("Solution root path '{SolutionRootPath}' does not exist at '{Resolved}'.", solutionRootPath, resolvedRoot);
+            return null;
+        }
+
+        // Read the unique name from Other/Solution.xml
+        var solutionXmlPath = Path.Combine(resolvedRoot, "Other", "Solution.xml");
+        if (!File.Exists(solutionXmlPath))
+        {
+            Logger.LogError("Solution.xml not found at '{Path}'.", solutionXmlPath);
+            return null;
+        }
+
+        var solutionDoc = XDocument.Load(solutionXmlPath);
+        var uniqueName = solutionDoc.Descendants("UniqueName").FirstOrDefault()?.Value;
+        if (string.IsNullOrWhiteSpace(uniqueName))
+        {
+            Logger.LogError("Could not read <UniqueName> from '{Path}'.", solutionXmlPath);
+            return null;
+        }
+
+        Logger.LogInformation("Resolved solution '{UniqueName}' from project directory.", uniqueName);
+        return (uniqueName, resolvedRoot);
     }
 }

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionExportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionExportCliCommand.cs
@@ -1,9 +1,9 @@
-using System.Xml.Linq;
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
 using TALXIS.CLI.Core.Contracts.Dataverse;
 using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Resolution;
 using TALXIS.CLI.Logging;
 
 namespace TALXIS.CLI.Features.Environment.Solution;
@@ -92,45 +92,25 @@ public class SolutionExportCliCommand : ProfiledCliCommand
             return null;
         }
 
-        var projectFile = Directory.EnumerateFiles(dirPath, "*.cdsproj").FirstOrDefault()
-            ?? Directory.EnumerateFiles(dirPath, "*.csproj").FirstOrDefault();
-
+        var projectFile = SolutionProjectResolver.FindProjectFile(dirPath);
         if (projectFile is null)
         {
             Logger.LogError("No .cdsproj or .csproj found in '{Dir}'.", dirPath);
             return null;
         }
 
-        var doc = XDocument.Load(projectFile);
-        XNamespace ns = doc.Root?.Name.Namespace ?? XNamespace.None;
-        var solutionRootPath = doc.Descendants(ns + "SolutionRootPath").FirstOrDefault()?.Value;
-
-        if (string.IsNullOrWhiteSpace(solutionRootPath))
+        var resolvedRoot = SolutionProjectResolver.ResolveSolutionRoot(projectFile);
+        if (resolvedRoot is null)
         {
-            // Fallback: use src/ as the default convention
-            solutionRootPath = "src";
-        }
-
-        var resolvedRoot = Path.GetFullPath(Path.Combine(dirPath, solutionRootPath));
-        if (!Directory.Exists(resolvedRoot))
-        {
-            Logger.LogError("Solution root path '{SolutionRootPath}' does not exist at '{Resolved}'.", solutionRootPath, resolvedRoot);
+            var raw = SolutionProjectResolver.ReadSolutionRootPath(projectFile) ?? SolutionProjectResolver.DefaultSolutionRootPath;
+            Logger.LogError("Solution root path '{SolutionRootPath}' does not exist.", raw);
             return null;
         }
 
-        // Read the unique name from Other/Solution.xml
-        var solutionXmlPath = Path.Combine(resolvedRoot, "Other", "Solution.xml");
-        if (!File.Exists(solutionXmlPath))
-        {
-            Logger.LogError("Solution.xml not found at '{Path}'.", solutionXmlPath);
-            return null;
-        }
-
-        var solutionDoc = XDocument.Load(solutionXmlPath);
-        var uniqueName = solutionDoc.Descendants("UniqueName").FirstOrDefault()?.Value;
+        var uniqueName = SolutionProjectResolver.ReadSolutionUniqueName(resolvedRoot);
         if (string.IsNullOrWhiteSpace(uniqueName))
         {
-            Logger.LogError("Could not read <UniqueName> from '{Path}'.", solutionXmlPath);
+            Logger.LogError("Could not read <UniqueName> from '{Path}'.", Path.Combine(resolvedRoot, "Other", "Solution.xml"));
             return null;
         }
 

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
@@ -237,7 +237,14 @@ public class SolutionImportCliCommand : ProfiledCliCommand
             return null;
         }
 
-        var zipPath = zipFiles[0];
+        // Pick the most recently written ZIP to avoid using stale build artifacts
+        var zipPath = zipFiles
+            .OrderByDescending(f => new FileInfo(f).LastWriteTimeUtc)
+            .First();
+
+        if (zipFiles.Length > 1)
+            Logger.LogWarning("Multiple .zip files found in '{OutputDir}'. Using newest: {ZipPath}", outputDir, Path.GetFileName(zipPath));
+
         Logger.LogInformation("Using build output: {ZipPath}", zipPath);
         return zipPath;
     }

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Xml.Linq;
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
 using TALXIS.CLI.Core.Contracts.Dataverse;
 using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Resolution;
 using TALXIS.CLI.Logging;
 
 namespace TALXIS.CLI.Features.Environment.Solution;
@@ -54,24 +54,19 @@ public class SolutionImportCliCommand : ProfiledCliCommand
         // Auto-detect input format:
         // 1. ZIP file → use directly
         // 2. Directory with Build SDK .csproj → dotnet build, use output ZIP
-        // 3. Directory with *.cdsproj → unpacked solution root is <dir>/src
+        // 3. Directory with .cdsproj/.csproj → resolve SolutionRootPath, pack
         // 4. Directory with Other/Solution.xml → unpacked solution folder
         // 5. Directory → treated as unpacked solution folder
         if (Directory.Exists(solutionPath))
         {
-            // Check for Dataverse project convention: <project-dir>/src is the solution root.
-            // *.cdsproj is the Dataverse convention (always use src/).
-            // *.csproj is checked as a fallback — Build SDK projects are built directly,
-            // others only used if src/ exists (avoids false positives with non-Dataverse C# projects).
-            var srcFolder = Path.Combine(solutionPath, "src");
-            var hasCdsProj = Directory.GetFiles(solutionPath, "*.cdsproj").Length > 0;
-            var csProjFiles = Directory.GetFiles(solutionPath, "*.csproj");
-            var hasCsProj = csProjFiles.Length > 0;
+            var projectFile = SolutionProjectResolver.FindProjectFile(solutionPath);
 
-            // Build SDK projects: run dotnet build and use the output ZIP directly
-            if (hasCsProj && !hasCdsProj)
+            if (projectFile is not null)
             {
-                var buildSdkProj = FindBuildSdkProject(csProjFiles);
+                // Build SDK projects: run dotnet build and use the output ZIP directly
+                var csProjFiles = Directory.GetFiles(solutionPath, "*.csproj");
+                var buildSdkProj = csProjFiles.Length > 0 ? FindBuildSdkProject(csProjFiles) : null;
+
                 if (buildSdkProj is not null)
                 {
                     var zipPath = await BuildAndLocateZipAsync(buildSdkProj);
@@ -79,25 +74,21 @@ public class SolutionImportCliCommand : ProfiledCliCommand
                         return ExitError;
                     solutionPath = zipPath;
                 }
-                else if (Directory.Exists(srcFolder))
-                {
-                    // .csproj with src/ subfolder — likely a Dataverse project (non-Build SDK)
-                    Logger.LogInformation("Found .csproj with src/ folder — using '{SrcFolder}' as solution root.", srcFolder);
-                    solutionPath = srcFolder;
-                }
-            }
-
-            if (hasCdsProj)
-            {
-                if (Directory.Exists(srcFolder))
-                {
-                    Logger.LogInformation("Found .cdsproj — using '{SrcFolder}' as solution root.", srcFolder);
-                    solutionPath = srcFolder;
-                }
                 else
                 {
-                    Logger.LogError("Found .cdsproj but '{SrcFolder}' does not exist.", srcFolder);
-                    return ExitValidationError;
+                    // Non-Build SDK project — resolve the solution root from SolutionRootPath property
+                    var resolvedRoot = SolutionProjectResolver.ResolveSolutionRoot(projectFile);
+                    if (resolvedRoot is not null)
+                    {
+                        Logger.LogInformation("Using solution root '{SolutionRoot}' from project.", resolvedRoot);
+                        solutionPath = resolvedRoot;
+                    }
+                    else
+                    {
+                        var raw = SolutionProjectResolver.ReadSolutionRootPath(projectFile) ?? SolutionProjectResolver.DefaultSolutionRootPath;
+                        Logger.LogError("Solution root path '{SolutionRootPath}' does not exist.", raw);
+                        return ExitValidationError;
+                    }
                 }
             }
 

--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel;
+using System.Diagnostics;
+using System.Xml.Linq;
 using DotMake.CommandLine;
 using Microsoft.Extensions.Logging;
 using TALXIS.CLI.Core;
@@ -18,8 +20,9 @@ public class SolutionImportCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(SolutionImportCliCommand));
 
-    [CliArgument(Name = "solution-path", Description = "Path to a solution .zip file, an unpacked solution folder, or a project directory (.cdsproj/.csproj).")]
-    public string SolutionZip { get; set; } = null!;
+    [CliArgument(Name = "solution-path", Description = "Path to a solution .zip file, an unpacked solution folder, or a project directory (.cdsproj/.csproj). Defaults to current directory.")]
+    [DefaultValue(".")]
+    public string SolutionZip { get; set; } = ".";
 
     [CliOption(Name = "--stage-and-upgrade", Description = "Use single-step upgrade when applicable.", Required = false)]
     [DefaultValue(true)]
@@ -45,29 +48,44 @@ public class SolutionImportCliCommand : ProfiledCliCommand
 
     protected override async Task<int> ExecuteAsync()
     {
-        if (string.IsNullOrWhiteSpace(SolutionZip))
-        {
-            Logger.LogError("'solution-path' argument is required.");
-            return ExitValidationError;
-        }
-
         string solutionPath = Path.GetFullPath(SolutionZip);
         string? tempZipPath = null;
 
         // Auto-detect input format:
         // 1. ZIP file → use directly
-        // 2. Directory with *.cdsproj → unpacked solution root is <dir>/src
-        // 3. Directory with Other/Solution.xml → unpacked solution folder
-        // 4. Directory → treated as unpacked solution folder
+        // 2. Directory with Build SDK .csproj → dotnet build, use output ZIP
+        // 3. Directory with *.cdsproj → unpacked solution root is <dir>/src
+        // 4. Directory with Other/Solution.xml → unpacked solution folder
+        // 5. Directory → treated as unpacked solution folder
         if (Directory.Exists(solutionPath))
         {
             // Check for Dataverse project convention: <project-dir>/src is the solution root.
             // *.cdsproj is the Dataverse convention (always use src/).
-            // *.csproj is checked as a fallback but only used if src/ exists (avoids false
-            // positives with non-Dataverse C# projects in the same directory).
+            // *.csproj is checked as a fallback — Build SDK projects are built directly,
+            // others only used if src/ exists (avoids false positives with non-Dataverse C# projects).
             var srcFolder = Path.Combine(solutionPath, "src");
             var hasCdsProj = Directory.GetFiles(solutionPath, "*.cdsproj").Length > 0;
-            var hasCsProj = Directory.GetFiles(solutionPath, "*.csproj").Length > 0;
+            var csProjFiles = Directory.GetFiles(solutionPath, "*.csproj");
+            var hasCsProj = csProjFiles.Length > 0;
+
+            // Build SDK projects: run dotnet build and use the output ZIP directly
+            if (hasCsProj && !hasCdsProj)
+            {
+                var buildSdkProj = FindBuildSdkProject(csProjFiles);
+                if (buildSdkProj is not null)
+                {
+                    var zipPath = await BuildAndLocateZipAsync(buildSdkProj);
+                    if (zipPath is null)
+                        return ExitError;
+                    solutionPath = zipPath;
+                }
+                else if (Directory.Exists(srcFolder))
+                {
+                    // .csproj with src/ subfolder — likely a Dataverse project (non-Build SDK)
+                    Logger.LogInformation("Found .csproj with src/ folder — using '{SrcFolder}' as solution root.", srcFolder);
+                    solutionPath = srcFolder;
+                }
+            }
 
             if (hasCdsProj)
             {
@@ -82,16 +100,13 @@ public class SolutionImportCliCommand : ProfiledCliCommand
                     return ExitValidationError;
                 }
             }
-            else if (hasCsProj && Directory.Exists(srcFolder))
-            {
-                // .csproj with src/ subfolder — likely a Dataverse project
-                Logger.LogInformation("Found .csproj with src/ folder — using '{SrcFolder}' as solution root.", srcFolder);
-                solutionPath = srcFolder;
-            }
-            // Otherwise: treat directory as-is (unpacked solution folder)
 
-            Logger.LogInformation("Input is a folder — packing to ZIP before import...");
-            tempZipPath = Path.Combine(Path.GetTempPath(), $"txc_import_{Guid.NewGuid():N}.zip");
+            // If we didn't resolve to a ZIP via Build SDK, pack the folder
+            if (Directory.Exists(solutionPath))
+            {
+                Logger.LogInformation("Input is a folder — packing to ZIP before import...");
+                tempZipPath = Path.Combine(Path.GetTempPath(), $"txc_import_{Guid.NewGuid():N}.zip");
+            }
         }
         else if (!File.Exists(solutionPath))
         {
@@ -167,4 +182,72 @@ public class SolutionImportCliCommand : ProfiledCliCommand
         SolutionImportPath.Upgrade => "single-step upgrade",
         _ => path.ToString()
     };
+
+    /// <summary>
+    /// Returns the first .csproj that uses TALXIS.DevKit.Build.Sdk, or null if none match.
+    /// </summary>
+    private static string? FindBuildSdkProject(string[] csProjFiles)
+    {
+        foreach (var proj in csProjFiles)
+        {
+            var content = File.ReadAllText(proj);
+            if (content.Contains("TALXIS.DevKit.Build.Sdk", StringComparison.OrdinalIgnoreCase))
+                return proj;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Runs <c>dotnet build</c> on a Build SDK project and locates the output ZIP.
+    /// Returns the ZIP path on success, or null on failure.
+    /// </summary>
+    private async Task<string?> BuildAndLocateZipAsync(string csProjPath)
+    {
+        var config = Managed ? "Release" : "Debug";
+        Logger.LogInformation("Building '{Project}' with configuration '{Config}'...", Path.GetFileName(csProjPath), config);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"build \"{csProjPath}\" -c {config}",
+            WorkingDirectory = Path.GetDirectoryName(csProjPath),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = psi };
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) Logger.LogInformation("{Line}", e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) Logger.LogWarning("{Line}", e.Data); };
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        await process.WaitForExitAsync().ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            Logger.LogError("dotnet build failed with exit code {ExitCode}.", process.ExitCode);
+            return null;
+        }
+
+        // Build SDK convention: output ZIP is in bin/{config}/net462/*.zip
+        var outputDir = Path.Combine(Path.GetDirectoryName(csProjPath)!, "bin", config, "net462");
+        if (!Directory.Exists(outputDir))
+        {
+            Logger.LogError("Build output directory not found: {OutputDir}.", outputDir);
+            return null;
+        }
+
+        var zipFiles = Directory.GetFiles(outputDir, "*.zip");
+        if (zipFiles.Length == 0)
+        {
+            Logger.LogError("No .zip file found in build output directory: {OutputDir}.", outputDir);
+            return null;
+        }
+
+        var zipPath = zipFiles[0];
+        Logger.LogInformation("Using build output: {ZipPath}", zipPath);
+        return zipPath;
+    }
 }

--- a/src/TALXIS.CLI.Features.Environment/TALXIS.CLI.Features.Environment.csproj
+++ b/src/TALXIS.CLI.Features.Environment/TALXIS.CLI.Features.Environment.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotMake.CommandLine" Version="2.6.7" />
+    <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Three changes for a frictionless component authoring loop:

```bash
txc ws component create pp-solution --output src/Sol ...
txc ws component create pp-flow --output src/Sol ...
txc env solution import src/Sol --wait -p dev      # auto-builds!
txc env component url open --file src/Sol/Workflows/*.json -p dev  # no GUID needed!
txc env solution export src/Sol -p dev             # unpacks to project dir!
```

### 1. Solution import auto-builds from project directory

When the path contains a `.csproj` using `TALXIS.DevKit.Build.Sdk`:
- Runs `dotnet build` (`-c Release` for `--managed`, `-c Debug` for unmanaged)
- Picks ZIP from `bin/{config}/net462/*.zip`
- Falls through to SolutionPackager for non-Build-SDK projects
- `solution-path` argument defaults to `.` (run from project dir)

### 2. Solution export accepts project directory

When a directory path with `.csproj` is provided:
- Reads `SolutionRootPath` from the csproj
- Extracts solution unique name from `Other/Solution.xml`
- Auto-sets output to solution root (unpacks in place)
- Works with `.` for CWD

### 3. url open/get accepts --file

Point at a local component file — auto-detects type and GUID:
- Detects type from path (`Workflows/` → Workflow, `Entities/` → Entity, etc.)
- Extracts GUID from `.data.xml` or filename
- No `--type` or `--param` needed

### E2E verified

Full roundtrip against `udpp26-txc-demo.crm4.dynamics.com`: scaffold → auto-build import → url open via file → export back to project dir. All steps work.

### Tests

486 unit tests pass. 2 integration test failures are pre-existing on master.

### Companion PR

[tools-devkit-templates PR #96](https://github.com/TALXIS/tools-devkit-templates/pull/96): Fixed pp-flow template (GUID casing, dunders, schemaVersion, publisher prefix, operationMetadataId, ModernFlowType)