### PR TITLE
docs: add ScriptLibrary to MCP skill docs (#116)

### DIFF
--- a/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/component-creation.md
@@ -26,6 +26,10 @@ Scaffold components in dependency order:
 3. **Relationships** — after both source and target entities exist
 4. **Forms** — after entity and its attributes exist
 5. **Views** — after entity and its attributes exist
+6. **Separate projects** (Plugin, ScriptLibrary, WorkflowActivity, CodeApp, PCF) — scaffold with their respective `pp-*` template, creates a separate .csproj
+7. **Project Reference** — `dotnet add reference` from solution project to the separate project. The Build SDK auto-detects the project type and handles registration (assembly data.xml, web resource data.xml, etc.) during `dotnet build`
+8. **Ribbon Buttons** (`pp-ribbon-button`) — after entity and script library exist. References the web resource via `LibraryLogicalName=prefix_name`
+9. **Form Event Handlers** (`pp-form-event-handler`) — after entity, form, and script library exist. References via `libraryName=prefix_name.js` and `functionName=prefix_name.ClassName.methodName`
 
 ## Key Parameter Conventions
 
@@ -46,6 +50,9 @@ Some templates use C# file-based apps (`.cs`) for code generation. These run nat
 - ❌ Don't scaffold a Form or View before the Entity and its Attributes exist — XML references will break
 - ❌ Don't scaffold a Relationship if the target table hasn't been created yet
 - ❌ Don't run `pp-plugin-assembly` before building the plugin project (`dotnet build`) — it reads the compiled DLL
+- ❌ Don't run `pp-webresource` for script libraries — the Build SDK auto-generates the web resource when a ScriptLibrary project is referenced via `dotnet add reference`
+- ❌ Don't call `npm install` or `npm run build` manually for script libraries — `dotnet build` handles everything
+- ❌ Don't manually create assembly data.xml for plugins or workflow activities — the Build SDK auto-generates them from project references
 - ✅ Use environment tools only for inspection, troubleshooting, or emergency fixes
 
 See also: [project-structure](project-structure.md), [schema-management](schema-management.md)

--- a/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/project-structure.md
@@ -11,6 +11,7 @@ A Power Platform monorepo follows a structured layout where solution projects, p
 │   ├── Solutions.DataModel/      # Dataverse schema and data model (.cdsproj)
 │   ├── Solutions.Logic/          # Business logic and plugins (.cdsproj)
 │   ├── Solutions.UI/             # User interface components (.cdsproj)
+│   ├── Solutions.UI.Scripts/     # TypeScript web resource library (.csproj)
 │   ├── Solutions.Security/       # Security roles and permissions (.cdsproj)
 │   ├── Plugins.{Domain}/        # Plugin projects (e.g., Plugins.Warehouse)
 │   └── Packages.Main/           # Package Deployer project
@@ -23,25 +24,63 @@ A Power Platform monorepo follows a structured layout where solution projects, p
 
 ## Project Types
 
-### Solution Projects (`.cdsproj`)
+All projects use `<ProjectType>` in their `.csproj` to declare their type. The Build SDK routes each type to its specific build logic automatically.
+
+### Solution Projects (`ProjectType=Solution`)
 These contain Dataverse solution metadata and components as XML files:
 - **Solutions.DataModel** — Tables, columns, relationships, option sets
 - **Solutions.Logic** — Workflows, business rules, plugin step registrations
 - **Solutions.UI** — Forms, views, model-driven apps, sitemaps
 - **Solutions.Security** — Security roles, field-level security profiles
 
-Each `.cdsproj` maps to one Dataverse solution. The `Declarations` folder within a solution project holds the component XML files.
+Each solution project maps to one Dataverse solution. Solution projects are the **hub** — they reference other project types via `dotnet add reference`, and the Build SDK auto-handles each reference type during `dotnet build`.
 
-### Plugin Projects
-- Pattern: `Plugins.{DomainArea}` (e.g., `Plugins.Warehouse`, `Plugins.Sales`)
-- Standard .NET class libraries containing plugin classes
-- Plugin classes follow `{Action}{Entity}Plugin.cs` naming (e.g., `ValidateWarehouseTransactionPlugin.cs`)
-- Referenced by solution projects that register the plugin steps
+### Plugin Projects (`ProjectType=Plugin`)
+- Scaffold with `pp-plugin` → `pp-plugin-assembly` → `pp-plugin-assembly-step`
+- .NET class libraries containing plugin classes that extend `PluginBase`
+- Referenced by solution projects — Build SDK auto-generates plugin assembly data.xml
 
-### Package Deployer Projects
-- `Packages.Main` — orchestrates deployment of multiple solutions in order
-- Defines import sequence and any pre/post-deployment data operations
-- Used for full environment provisioning
+### Script Library Projects (`ProjectType=ScriptLibrary`)
+- Scaffold with `pp-script-library` (provides `PublisherPrefix` and `LibraryName`)
+- TypeScript + Rollup project producing a single UMD JavaScript web resource
+- The UMD global (`prefix_name`) is what Dataverse forms and ribbon buttons reference as function namespace (e.g., `prefix_name.Main.onLoad`)
+- Referenced by solution projects — Build SDK auto-generates web resource data.xml
+- `dotnet build` handles everything: npm install → Rollup bundle → web resource registration
+- No need to run `pp-webresource` manually or call npm directly
+
+### Workflow Activity Projects (`ProjectType=WorkflowActivity`)
+- Scaffold with `pp-workflow-activity`
+- .NET class libraries containing custom workflow steps that extend `WorkflowActivityBase`
+- Referenced by solution projects — Build SDK auto-generates assembly data.xml and copies DLL
+
+### Code App Projects (`ProjectType=CodeApp`)
+- Scaffold with `pp-app-code`
+- Node.js/TypeScript projects for Power Apps code-first apps
+- Referenced by solution projects — Build SDK runs npm build and generates CanvasApp metadata
+
+### PCF Control Projects
+- Scaffold with `pp-pcf`
+- Uses Microsoft's PAC infrastructure directly
+- Referenced by solution projects — handled by standard PAC pipeline
+
+### Package Deployer Projects (`ProjectType=PdPackage`)
+- Scaffold with `pp-package`
+- Orchestrates deployment of multiple solutions in order
+- References solution projects — collects their output ZIPs for packaging
+
+## Project References (`dotnet add reference`)
+
+Solution projects act as the hub. When you add a project reference, the Build SDK **auto-detects the referenced project's type** via the `GetProjectType` MSBuild protocol and handles it accordingly:
+
+```bash
+# From a solution project directory:
+dotnet add reference ../Plugins.Warehouse/Plugins.Warehouse.csproj      # Plugin → auto-generates assembly data.xml
+dotnet add reference ../Solutions.UI.Scripts/Solutions.UI.Scripts.csproj  # ScriptLibrary → auto-generates web resource
+dotnet add reference ../WorkflowActivities/WorkflowActivities.csproj     # WorkflowActivity → auto-generates assembly data.xml
+dotnet add reference ../Solutions.DataModel/Solutions.DataModel.csproj    # Solution → dependency chain
+```
+
+All auto-generation happens during `dotnet build` — no manual registration steps needed.
 
 ## Key Tools
 


### PR DESCRIPTION
## Summary

Adds Script Library project type and workflow chain to the MCP skill docs so the coding agent knows how to guide users through creating and using TypeScript web resources.

## Changes

### `project-structure.md`
- Added `Solutions.UI.Scripts/` to the repo structure diagram
- Added **Script Library Projects** section documenting:
  - Scaffold with `pp-script-library` (PublisherPrefix + LibraryName)
  - Rollup UMD output, auto web resource generation
  - `dotnet build` handles everything (npm + rollup + web resource)
  - No need for manual `pp-webresource` or npm calls

### `component-creation.md`
- Added steps 6-9 to **Composition Ordering**: Script Library → Project Reference → Web Resource (auto) → Form Event Handlers / Ribbon Buttons
- Added two don'ts: no manual `pp-webresource` for script libs, no manual npm

## Context
Complements templates PR [tools-devkit-templates#95](https://github.com/TALXIS/tools-devkit-templates/pull/95) which redesigned `pp-script-library` with Rollup bundler and UMD output.

Closes #116