### PR TITLE
fix: MCP error display, self-dependency tracking, and telemetry flush

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <!-- Treat banned API usage and CLI convention violations as build errors -->
-    <WarningsAsErrors>$(WarningsAsErrors);RS0030;TXC001;TXC002;TXC003;TXC004;TXC005;TXC006;TXC007;TXC008;TXC009</WarningsAsErrors>
+    <WarningsAsErrors>$(WarningsAsErrors);RS0030;TXC001;TXC002;TXC003;TXC004;TXC005;TXC006;TXC007;TXC008;TXC009;TXC010</WarningsAsErrors>
   </PropertyGroup>
 
   <!-- Telemetry is only active in Release builds. Debug/local 'dotnet run' never emits telemetry. -->

--- a/src/TALXIS.CLI.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/TALXIS.CLI.Analyzers/AnalyzerReleases.Unshipped.md
@@ -26,3 +26,8 @@ TXC021 | TALXIS.CLI.Design | Warning | Use TxcActivitySource.CurrentOperationId 
 TXC022 | TALXIS.CLI.Design | Warning | GetInnermostException must only be in ExceptionHelpers
 TXC023 | TALXIS.CLI.Design | Info | Prefer named interfaces over Func/Action in constructors
 TXC024 | TALXIS.CLI.Design | Info | DI-injected classes should not access static singletons
+TXC025 | TALXIS.CLI.Design | Warning | Do not call Activity.SetTag/SetStatus/AddEvent in command code
+TXC026 | TALXIS.CLI.Design | Warning | Do not spawn processes directly in command code
+TXC027 | TALXIS.CLI.Design | Warning | Mutative commands must call OutputFormatter.WriteResult()
+TXC028 | TALXIS.CLI.Design | Warning | [CliReadOnly] commands must not call OutputFormatter.WriteResult()
+TXC029 | TALXIS.CLI.Design | Warning | Do not construct CallToolResult directly — use McpToolResultFactory

--- a/src/TALXIS.CLI.Analyzers/DiagnosticIds.cs
+++ b/src/TALXIS.CLI.Analyzers/DiagnosticIds.cs
@@ -76,4 +76,19 @@ internal static class DiagnosticIds
 
     /// <summary>DI-injected classes should not access static singletons — inject them instead.</summary>
     public const string NoStaticSingletonInDiServices = "TXC024";
+
+    /// <summary>Command code must not call Activity.SetTag/SetStatus/AddEvent/RecordException directly — use CommandActivityScope and ILogger.</summary>
+    public const string NoDirectActivityTagging = "TXC025";
+
+    /// <summary>Command code must not spawn processes directly — use CliSubprocessRunner or infrastructure.</summary>
+    public const string NoDirectProcessStart = "TXC026";
+
+    /// <summary>Mutative commands ([CliDestructive]/[CliIdempotent]) must call OutputFormatter.WriteResult() to produce a CommandResultEnvelope.</summary>
+    public const string MustUseWriteResultForMutations = "TXC027";
+
+    /// <summary>[CliReadOnly] commands must not call OutputFormatter.WriteResult() — use WriteData/WriteList/WriteDynamicTable for data output.</summary>
+    public const string NoWriteResultInReadOnly = "TXC028";
+
+    /// <summary>Do not construct CallToolResult directly — use McpToolResultFactory to ensure content/structuredContent consistency.</summary>
+    public const string NoDirectCallToolResult = "TXC029";
 }

--- a/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
@@ -1,0 +1,76 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TALXIS.CLI.Analyzers;
+
+/// <summary>
+/// TXC027: Mutative commands (<c>[CliDestructive]</c> or <c>[CliIdempotent]</c>) must call
+/// <c>OutputFormatter.WriteResult()</c> to produce a <c>CommandResultEnvelope</c>.
+/// Without <c>WriteResult</c>, the MCP server cannot detect the envelope and build
+/// proper <c>content</c>/<c>structuredContent</c> for the client.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.MustUseWriteResultForMutations,
+        title: "Mutative commands must call OutputFormatter.WriteResult()",
+        messageFormat: "'{0}' is a mutative command but does not call OutputFormatter.WriteResult(). Mutative commands must produce a CommandResultEnvelope so the MCP server can build consistent responses.",
+        category: "TALXIS.CLI.Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        if (type.IsAbstract || type.TypeKind != TypeKind.Class)
+            return;
+
+        // Must be a mutative command ([CliDestructive] or [CliIdempotent])
+        bool isMutative = type.GetAttributes().Any(a =>
+            a.AttributeClass?.Name is "CliDestructiveAttribute" or "CliIdempotentAttribute");
+        if (!isMutative)
+            return;
+
+        // Must inherit TxcLeafCommand
+        if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
+            return;
+
+        // Look for WriteResult call in ExecuteAsync method body
+        var executeAsync = type.GetMembers("ExecuteAsync")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.IsOverride || m.DeclaredAccessibility == Accessibility.Protected);
+        if (executeAsync == null)
+            return;
+
+        // Check all syntax references for WriteResult invocations
+        foreach (var syntaxRef in executeAsync.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax(context.CancellationToken);
+            var text = syntax.ToFullString();
+            // Simple text-based check for WriteResult presence.
+            // A full semantic check would require a SyntaxNodeAction + SemanticModel
+            // which is significantly more complex. This is sufficient since
+            // OutputFormatter.WriteResult is a distinctive call site.
+            if (text.Contains("WriteResult"))
+                return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            type.Locations.FirstOrDefault(),
+            type.Name));
+    }
+}

--- a/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
@@ -1,7 +1,9 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace TALXIS.CLI.Analyzers;
 
@@ -10,6 +12,7 @@ namespace TALXIS.CLI.Analyzers;
 /// <c>OutputFormatter.WriteResult()</c> to produce a <c>CommandResultEnvelope</c>.
 /// Without <c>WriteResult</c>, the MCP server cannot detect the envelope and build
 /// proper <c>content</c>/<c>structuredContent</c> for the client.
+/// Uses semantic analysis to detect actual <c>OutputFormatter.WriteResult</c> invocations.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
@@ -29,48 +32,52 @@ public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
-    }
 
-    private static void AnalyzeNamedType(SymbolAnalysisContext context)
-    {
-        var type = (INamedTypeSymbol)context.Symbol;
-        if (type.IsAbstract || type.TypeKind != TypeKind.Class)
-            return;
-
-        // Must be a mutative command ([CliDestructive] or [CliIdempotent])
-        bool isMutative = type.GetAttributes().Any(a =>
-            a.AttributeClass?.Name is "CliDestructiveAttribute" or "CliIdempotentAttribute");
-        if (!isMutative)
-            return;
-
-        // Must inherit TxcLeafCommand
-        if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
-            return;
-
-        // Look for WriteResult call in ExecuteAsync method body
-        var executeAsync = type.GetMembers("ExecuteAsync")
-            .OfType<IMethodSymbol>()
-            .FirstOrDefault(m => m.IsOverride || m.DeclaredAccessibility == Accessibility.Protected);
-        if (executeAsync == null)
-            return;
-
-        // Check all syntax references for WriteResult invocations
-        foreach (var syntaxRef in executeAsync.DeclaringSyntaxReferences)
+        context.RegisterCompilationStartAction(compilationContext =>
         {
-            var syntax = syntaxRef.GetSyntax(context.CancellationToken);
-            var text = syntax.ToFullString();
-            // Simple text-based check for WriteResult presence.
-            // A full semantic check would require a SyntaxNodeAction + SemanticModel
-            // which is significantly more complex. This is sufficient since
-            // OutputFormatter.WriteResult is a distinctive call site.
-            if (text.Contains("WriteResult"))
-                return;
-        }
+            // Track which mutative command types call WriteResult
+            var typesWithWriteResult = new ConcurrentDictionary<INamedTypeSymbol, bool>(SymbolEqualityComparer.Default);
 
-        context.ReportDiagnostic(Diagnostic.Create(
-            Rule,
-            type.Locations.FirstOrDefault(),
-            type.Name));
+            // Detect WriteResult invocations semantically
+            compilationContext.RegisterOperationAction(operationContext =>
+            {
+                var invocation = (IInvocationOperation)operationContext.Operation;
+                if (invocation.TargetMethod.Name != "WriteResult")
+                    return;
+
+                var receiverType = invocation.TargetMethod.ContainingType;
+                if (receiverType?.Name != "OutputFormatter")
+                    return;
+
+                // Walk up to find the containing named type
+                var containingType = operationContext.ContainingSymbol?.ContainingType;
+                if (containingType != null)
+                    typesWithWriteResult[containingType] = true;
+            }, OperationKind.Invocation);
+
+            // At end of compilation, check mutative types that never called WriteResult
+            compilationContext.RegisterSymbolAction(symbolContext =>
+            {
+                var type = (INamedTypeSymbol)symbolContext.Symbol;
+                if (type.IsAbstract || type.TypeKind != TypeKind.Class)
+                    return;
+
+                bool isMutative = type.GetAttributes().Any(a =>
+                    a.AttributeClass?.Name is "CliDestructiveAttribute" or "CliIdempotentAttribute");
+                if (!isMutative)
+                    return;
+
+                if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
+                    return;
+
+                if (typesWithWriteResult.ContainsKey(type))
+                    return;
+
+                symbolContext.ReportDiagnostic(Diagnostic.Create(
+                    Rule,
+                    type.Locations.FirstOrDefault(),
+                    type.Name));
+            }, SymbolKind.NamedType);
+        });
     }
 }

--- a/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/MustUseWriteResultForMutationsAnalyzer.cs
@@ -37,6 +37,7 @@ public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
         {
             // Track which mutative command types call WriteResult
             var typesWithWriteResult = new ConcurrentDictionary<INamedTypeSymbol, bool>(SymbolEqualityComparer.Default);
+            var mutativeCommandTypes = new ConcurrentDictionary<INamedTypeSymbol, bool>(SymbolEqualityComparer.Default);
 
             // Detect WriteResult invocations semantically
             compilationContext.RegisterOperationAction(operationContext =>
@@ -55,7 +56,6 @@ public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
                     typesWithWriteResult[containingType] = true;
             }, OperationKind.Invocation);
 
-            // At end of compilation, check mutative types that never called WriteResult
             compilationContext.RegisterSymbolAction(symbolContext =>
             {
                 var type = (INamedTypeSymbol)symbolContext.Symbol;
@@ -70,14 +70,24 @@ public sealed class MustUseWriteResultForMutationsAnalyzer : DiagnosticAnalyzer
                 if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
                     return;
 
-                if (typesWithWriteResult.ContainsKey(type))
-                    return;
-
-                symbolContext.ReportDiagnostic(Diagnostic.Create(
-                    Rule,
-                    type.Locations.FirstOrDefault(),
-                    type.Name));
+                mutativeCommandTypes[type] = true;
             }, SymbolKind.NamedType);
+
+            // Report only after all symbol and operation actions have run. Reporting from
+            // the symbol action races with invocation analysis under concurrent execution.
+            compilationContext.RegisterCompilationEndAction(endContext =>
+            {
+                foreach (var type in mutativeCommandTypes.Keys)
+                {
+                    if (typesWithWriteResult.ContainsKey(type))
+                        continue;
+
+                    endContext.ReportDiagnostic(Diagnostic.Create(
+                        Rule,
+                        type.Locations.FirstOrDefault(),
+                        type.Name));
+                }
+            });
         });
     }
 }

--- a/src/TALXIS.CLI.Analyzers/NoDirectActivityTaggingAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/NoDirectActivityTaggingAnalyzer.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace TALXIS.CLI.Analyzers;
+
+/// <summary>
+/// TXC025: Command code must not call <c>Activity.SetTag()</c>, <c>Activity.SetStatus()</c>,
+/// <c>Activity.AddEvent()</c>, or <c>Activity.RecordException()</c> directly.
+/// Commands should use <c>CommandActivityScope</c> (managed by <c>TxcLeafCommand.RunAsync</c>)
+/// and <c>ILogger</c> (bridged by <c>TxcTelemetryLogProvider</c>) for telemetry.
+/// Direct Activity manipulation bypasses the standardized pipeline and can create
+/// inconsistent tag names or conflicting status overwrites.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoDirectActivityTaggingAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.NoDirectActivityTagging,
+        title: "Do not call Activity.SetTag/SetStatus/AddEvent/RecordException in command code",
+        messageFormat: "'{0}' directly calls Activity.{1}(). Use CommandActivityScope and ILogger instead.",
+        category: "TALXIS.CLI.Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly string[] BannedMethods =
+        ["SetTag", "SetStatus", "AddEvent", "RecordException"];
+
+    /// <summary>
+    /// Telemetry infrastructure types that legitimately manipulate Activity.
+    /// </summary>
+    private static readonly string[] ExemptTypes =
+    [
+        "CommandActivityScope",
+        "TxcTelemetryLogProvider",
+        "TxcTelemetryLogger",
+        "SessionIdActivityProcessor",
+        "ActivityIdentityTagger",
+        "TxcActivitySource"
+    ];
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+
+        // Check if this is a call to Activity.SetTag/SetStatus/AddEvent/RecordException
+        if (Array.IndexOf(BannedMethods, method.Name) < 0)
+            return;
+
+        var receiverType = method.ContainingType;
+        if (receiverType?.Name != "Activity" || receiverType.ContainingNamespace?.ToDisplayString() != "System.Diagnostics")
+            return;
+
+        // Check if we're inside a [CliCommand] class
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType == null)
+            return;
+
+        // Exempt telemetry infrastructure types
+        if (Array.IndexOf(ExemptTypes, containingType.Name) >= 0)
+            return;
+
+        // Only flag [CliCommand]-attributed types and their ancestors
+        if (!HasCliCommandAttribute(containingType) && !InheritsFromTxcLeafCommand(containingType))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.Syntax.GetLocation(),
+            containingType.Name,
+            method.Name));
+    }
+
+    private static bool HasCliCommandAttribute(INamedTypeSymbol type)
+    {
+        return type.GetAttributes().Any(a =>
+            a.AttributeClass?.Name is "CliCommandAttribute");
+    }
+
+    private static bool InheritsFromTxcLeafCommand(INamedTypeSymbol type)
+    {
+        return RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand");
+    }
+}

--- a/src/TALXIS.CLI.Analyzers/NoDirectCallToolResultAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/NoDirectCallToolResultAnalyzer.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace TALXIS.CLI.Analyzers;
+
+/// <summary>
+/// TXC029: Do not construct <c>new CallToolResult</c> directly — use
+/// <c>McpToolResultFactory</c> to ensure <c>content</c>/<c>structuredContent</c> consistency.
+/// The factory guarantees both surfaces carry the same information, preventing
+/// mismatches where <c>content</c> says one thing and <c>structuredContent</c> says another.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoDirectCallToolResultAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.NoDirectCallToolResult,
+        title: "Do not construct CallToolResult directly — use McpToolResultFactory",
+        messageFormat: "'{0}' constructs CallToolResult directly. Use McpToolResultFactory methods to ensure content/structuredContent consistency.",
+        category: "TALXIS.CLI.Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
+    }
+
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context)
+    {
+        var creation = (IObjectCreationOperation)context.Operation;
+        var type = creation.Type;
+
+        if (type?.Name != "CallToolResult")
+            return;
+
+        // Only target the MCP protocol type
+        if (type.ContainingNamespace?.ToDisplayString() != "ModelContextProtocol.Protocol")
+            return;
+
+        // Allow inside McpToolResultFactory — it IS the factory
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType?.Name == "McpToolResultFactory")
+            return;
+
+        var containingTypeName = containingType?.Name
+            ?? context.ContainingSymbol?.Name
+            ?? "Unknown";
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            creation.Syntax.GetLocation(),
+            containingTypeName));
+    }
+}

--- a/src/TALXIS.CLI.Analyzers/NoDirectProcessStartAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/NoDirectProcessStartAnalyzer.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace TALXIS.CLI.Analyzers;
+
+/// <summary>
+/// TXC026: Command code must not spawn processes directly via <c>Process.Start()</c>,
+/// <c>new Process()</c>, or <c>new ProcessStartInfo()</c>.
+/// Commands should use <c>CliSubprocessRunner</c> for subprocess dispatch with trace
+/// propagation, output capture, and log forwarding. Direct process spawning bypasses
+/// telemetry correlation and the MCP output pipeline.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoDirectProcessStartAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.NoDirectProcessStart,
+        title: "Do not spawn processes directly in command code — use CliSubprocessRunner",
+        messageFormat: "'{0}' directly uses {1}. Use CliSubprocessRunner or dedicated infrastructure instead.",
+        category: "TALXIS.CLI.Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeObjectCreation, OperationKind.ObjectCreation);
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeObjectCreation(OperationAnalysisContext context)
+    {
+        var creation = (IObjectCreationOperation)context.Operation;
+        var type = creation.Type;
+        if (type?.ContainingNamespace?.ToDisplayString() != "System.Diagnostics")
+            return;
+
+        if (type.Name is not ("Process" or "ProcessStartInfo"))
+            return;
+
+        if (!IsInCommandClass(context.ContainingSymbol))
+            return;
+
+        var containingTypeName = context.ContainingSymbol?.ContainingType?.Name ?? "Unknown";
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            creation.Syntax.GetLocation(),
+            containingTypeName,
+            $"new {type.Name}()"));
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var method = invocation.TargetMethod;
+
+        if (method.Name != "Start")
+            return;
+
+        var type = method.ContainingType;
+        if (type?.Name != "Process" || type.ContainingNamespace?.ToDisplayString() != "System.Diagnostics")
+            return;
+
+        if (!IsInCommandClass(context.ContainingSymbol))
+            return;
+
+        var containingTypeName = context.ContainingSymbol?.ContainingType?.Name ?? "Unknown";
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.Syntax.GetLocation(),
+            containingTypeName,
+            "Process.Start()"));
+    }
+
+    private static bool IsInCommandClass(ISymbol? symbol)
+    {
+        var type = symbol?.ContainingType;
+        if (type == null) return false;
+
+        return type.GetAttributes().Any(a => a.AttributeClass?.Name is "CliCommandAttribute")
+            || RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand");
+    }
+}

--- a/src/TALXIS.CLI.Analyzers/NoWriteResultInReadOnlyAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/NoWriteResultInReadOnlyAnalyzer.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace TALXIS.CLI.Analyzers;
 
@@ -11,6 +12,7 @@ namespace TALXIS.CLI.Analyzers;
 /// <c>WriteList</c>, or <c>WriteDynamicTable</c>. Using <c>WriteResult</c> produces a
 /// <c>CommandResultEnvelope</c> with a status message instead of actual data, confusing
 /// both humans and the MCP <c>structuredContent</c> pipeline.
+/// Uses semantic analysis to detect actual <c>OutputFormatter.WriteResult</c> invocations.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class NoWriteResultInReadOnlyAnalyzer : DiagnosticAnalyzer
@@ -30,44 +32,39 @@ public sealed class NoWriteResultInReadOnlyAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+
+        // Detect WriteResult invocations inside [CliReadOnly] command types
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
     }
 
-    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
     {
-        var type = (INamedTypeSymbol)context.Symbol;
-        if (type.IsAbstract || type.TypeKind != TypeKind.Class)
+        var invocation = (IInvocationOperation)context.Operation;
+        if (invocation.TargetMethod.Name != "WriteResult")
             return;
 
-        // Must be a [CliReadOnly] command
-        bool isReadOnly = type.GetAttributes().Any(a =>
+        var receiverType = invocation.TargetMethod.ContainingType;
+        if (receiverType?.Name != "OutputFormatter")
+            return;
+
+        // Walk up to find the containing named type
+        var containingType = context.ContainingSymbol?.ContainingType;
+        if (containingType == null)
+            return;
+
+        // Must be a [CliReadOnly] command inheriting TxcLeafCommand
+        bool isReadOnly = containingType.GetAttributes().Any(a =>
             a.AttributeClass?.Name is "CliReadOnlyAttribute");
         if (!isReadOnly)
             return;
 
-        // Must inherit TxcLeafCommand
-        if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
+        if (!RoslynHelpers.InheritsFrom(containingType, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
             return;
 
-        // Look for WriteResult call in ExecuteAsync method body
-        var executeAsync = type.GetMembers("ExecuteAsync")
-            .OfType<IMethodSymbol>()
-            .FirstOrDefault(m => m.IsOverride || m.DeclaredAccessibility == Accessibility.Protected);
-        if (executeAsync == null)
-            return;
-
-        foreach (var syntaxRef in executeAsync.DeclaringSyntaxReferences)
-        {
-            var syntax = syntaxRef.GetSyntax(context.CancellationToken);
-            var text = syntax.ToFullString();
-            if (text.Contains("WriteResult"))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    Rule,
-                    type.Locations.FirstOrDefault(),
-                    type.Name));
-                return;
-            }
-        }
+        // Report at the invocation site, not the type declaration
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.Syntax.GetLocation(),
+            containingType.Name));
     }
 }

--- a/src/TALXIS.CLI.Analyzers/NoWriteResultInReadOnlyAnalyzer.cs
+++ b/src/TALXIS.CLI.Analyzers/NoWriteResultInReadOnlyAnalyzer.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace TALXIS.CLI.Analyzers;
+
+/// <summary>
+/// TXC028: <c>[CliReadOnly]</c> commands must not call <c>OutputFormatter.WriteResult()</c>.
+/// Read-only commands return data (tables, objects, values) via <c>WriteData</c>,
+/// <c>WriteList</c>, or <c>WriteDynamicTable</c>. Using <c>WriteResult</c> produces a
+/// <c>CommandResultEnvelope</c> with a status message instead of actual data, confusing
+/// both humans and the MCP <c>structuredContent</c> pipeline.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NoWriteResultInReadOnlyAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticIds.NoWriteResultInReadOnly,
+        title: "[CliReadOnly] commands must not call OutputFormatter.WriteResult()",
+        messageFormat: "'{0}' is a [CliReadOnly] command but calls OutputFormatter.WriteResult(). Use WriteData/WriteList/WriteDynamicTable for data output.",
+        category: "TALXIS.CLI.Design",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+    }
+
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
+    {
+        var type = (INamedTypeSymbol)context.Symbol;
+        if (type.IsAbstract || type.TypeKind != TypeKind.Class)
+            return;
+
+        // Must be a [CliReadOnly] command
+        bool isReadOnly = type.GetAttributes().Any(a =>
+            a.AttributeClass?.Name is "CliReadOnlyAttribute");
+        if (!isReadOnly)
+            return;
+
+        // Must inherit TxcLeafCommand
+        if (!RoslynHelpers.InheritsFrom(type, "TALXIS.CLI.Core.Shared.TxcLeafCommand"))
+            return;
+
+        // Look for WriteResult call in ExecuteAsync method body
+        var executeAsync = type.GetMembers("ExecuteAsync")
+            .OfType<IMethodSymbol>()
+            .FirstOrDefault(m => m.IsOverride || m.DeclaredAccessibility == Accessibility.Protected);
+        if (executeAsync == null)
+            return;
+
+        foreach (var syntaxRef in executeAsync.DeclaringSyntaxReferences)
+        {
+            var syntax = syntaxRef.GetSyntax(context.CancellationToken);
+            var text = syntax.ToFullString();
+            if (text.Contains("WriteResult"))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    Rule,
+                    type.Locations.FirstOrDefault(),
+                    type.Name));
+                return;
+            }
+        }
+    }
+}

--- a/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
+++ b/src/TALXIS.CLI.Core/Shared/TxcLeafCommand.cs
@@ -108,10 +108,10 @@ public abstract class TxcLeafCommand
         catch (Exception ex) when (ex is Abstractions.ConfigurationResolutionException or ArgumentException)
         {
             exitCode = ExitValidationError;
-            scope.SetError(exitCode, "validation");
             var root = ExceptionHelpers.GetInnermostException(ex);
             var message = root != ex && !string.Equals(root.Message, ex.Message, StringComparison.Ordinal)
                 ? root.Message : ex.Message;
+            scope.SetError(exitCode, "validation", message);
             Logger.LogError(ex, "{Error}", message);
             LogSupportInfo();
             return exitCode;
@@ -119,18 +119,18 @@ public abstract class TxcLeafCommand
         catch (OperationCanceledException ex)
         {
             exitCode = ExitError;
-            scope.SetError(exitCode, "cancelled");
+            scope.SetError(exitCode, "cancelled", "Operation was cancelled.");
             Logger.LogWarning(ex, "Operation was cancelled.");
             return exitCode;
         }
         catch (Exception ex)
         {
             exitCode = ExitError;
-            scope.SetError(exitCode, "internal");
 
             var root = ExceptionHelpers.GetInnermostException(ex);
             var message = root != ex && !string.Equals(root.Message, ex.Message, StringComparison.Ordinal)
                 ? root.Message : ex.Message;
+            scope.SetError(exitCode, "internal", message);
 
             OutputFormatter.WriteResult("failed", message, exitCode: exitCode);
             Logger.LogError(ex, "Command failed: {Error}", message);

--- a/src/TALXIS.CLI.Core/Telemetry/CommandActivityScope.cs
+++ b/src/TALXIS.CLI.Core/Telemetry/CommandActivityScope.cs
@@ -48,14 +48,18 @@ public sealed class CommandActivityScope : IDisposable
     }
 
     /// <summary>
-    /// Records a classified error on the span (exit code + error kind).
-    /// Called from catch blocks via <see cref="TxcLeafCommand.LogCommandFailure"/>.
+    /// Records a classified error on the span (exit code + error kind + optional message).
+    /// Called from catch blocks in <see cref="TxcLeafCommand"/>.
+    /// The <paramref name="errorMessage"/> appears as <c>txc.error_message</c> in App Insights —
+    /// visible at a glance without drilling into exception events.
     /// </summary>
-    public void SetError(int exitCode, string errorKind)
+    public void SetError(int exitCode, string errorKind, string? errorMessage = null)
     {
         _exitCode = exitCode;
         Activity?.SetTag(TxcTelemetryTags.ExitCode, exitCode);
         Activity?.SetTag(TxcTelemetryTags.ErrorKind, errorKind);
+        if (!string.IsNullOrWhiteSpace(errorMessage))
+            Activity?.SetTag(TxcTelemetryTags.ErrorMessage, errorMessage);
     }
 
     public void Dispose() => Activity?.Dispose();

--- a/src/TALXIS.CLI.Core/Telemetry/CommandActivityScope.cs
+++ b/src/TALXIS.CLI.Core/Telemetry/CommandActivityScope.cs
@@ -37,14 +37,23 @@ public sealed class CommandActivityScope : IDisposable
 
     /// <summary>
     /// Records the exit code on the span. Called once before disposal.
-    /// Non-zero exit codes also set the span error status.
+    /// Non-zero exit codes also set the span error status and default
+    /// <c>txc.error_kind</c> to <c>"validation"</c> when no catch block
+    /// has already classified the error via <see cref="SetError"/>.
     /// </summary>
     public void SetExitCode(int exitCode)
     {
         _exitCode = exitCode;
         Activity?.SetTag(TxcTelemetryTags.ExitCode, exitCode);
         if (exitCode != 0)
+        {
             Activity?.SetStatus(ActivityStatusCode.Error, $"Exit code {exitCode}");
+
+            // Default error kind for non-exception failures (e.g. Logger.LogError + return ExitError).
+            // Exception-based failures always call SetError() first, which already sets ErrorKind.
+            if (Activity?.GetTagItem(TxcTelemetryTags.ErrorKind) is null)
+                Activity?.SetTag(TxcTelemetryTags.ErrorKind, "validation");
+        }
     }
 
     /// <summary>

--- a/src/TALXIS.CLI.Core/Telemetry/TxcTelemetryTags.cs
+++ b/src/TALXIS.CLI.Core/Telemetry/TxcTelemetryTags.cs
@@ -13,6 +13,7 @@ public static class TxcTelemetryTags
     public const string Version = "txc.version";
     public const string ExitCode = "txc.exit_code";
     public const string ErrorKind = "txc.error_kind";
+    public const string ErrorMessage = "txc.error_message";
 
     // MCP-specific
     public const string Tool = "txc.tool";

--- a/src/TALXIS.CLI.Logging/TALXIS.CLI.Logging.csproj
+++ b/src/TALXIS.CLI.Logging/TALXIS.CLI.Logging.csproj
@@ -10,6 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TALXIS.CLI.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
     <!-- OTel + Azure Monitor exporter for telemetry (only active in Release builds).

--- a/src/TALXIS.CLI.Logging/TALXIS.CLI.Logging.csproj
+++ b/src/TALXIS.CLI.Logging/TALXIS.CLI.Logging.csproj
@@ -12,8 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <!-- OTel + Azure Monitor exporter for telemetry (only active in Release builds) -->
+    <!-- OTel + Azure Monitor exporter for telemetry (only active in Release builds).
+         HTTP client instrumentation intentionally not included — command-level spans
+         provide sufficient coverage, and the exporter's own HTTP calls leaked through
+         all attempted filters (see TxcTelemetrySetup.cs). -->
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
   </ItemGroup>
 </Project>

--- a/src/TALXIS.CLI.Logging/TxcTelemetryLogProvider.cs
+++ b/src/TALXIS.CLI.Logging/TxcTelemetryLogProvider.cs
@@ -60,6 +60,19 @@ internal sealed class TxcTelemetryLogger : ILogger
                 }));
         }
 
+        // For Error/Critical log calls WITHOUT an exception object (e.g.,
+        // WorkspaceValidateCliCommand logging per-file validation errors),
+        // stamp the formatted message as txc.error_message on the span.
+        // This provides at-a-glance context in App Insights even when there
+        // is no exception event. Overwrites on each call — the last error
+        // message wins, giving a representative sample.
+        if (exception == null && logLevel >= LogLevel.Error)
+        {
+            var msg = formatter(state, null);
+            if (!string.IsNullOrWhiteSpace(msg))
+                activity.SetTag("txc.error_message", LogRedactionFilter.Redact(msg));
+        }
+
         // Note: span error status is NOT set here — CommandActivityScope.SetExitCode()
         // is the sole authority for span status. This avoids double-SetStatus where the
         // logger's descriptive message gets overwritten by the generic "Exit code N".

--- a/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
+++ b/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
@@ -135,19 +135,14 @@ public static class TxcTelemetrySetup
                         ["txc.session_id"] = sessionResolver.SessionId,
                         ["txc.session_id.source"] = sessionResolver.Source,
                     }))
-            .AddHttpClientInstrumentation(opts =>
-            {
-                // Filter out the Azure Monitor exporter's own telemetry upload calls
-                // to avoid a feedback loop where we log our own logging HTTP requests.
-                // This covers standard HttpClient usage; Azure.Core's HttpPipeline
-                // may bypass this, so TelemetryFilterProcessor provides a second safety net.
-                opts.FilterHttpRequestMessage = req =>
-                {
-                    var host = req.RequestUri?.Host ?? string.Empty;
-                    return !IsAzureMonitorHost(host);
-                };
-            })
-            .AddProcessor(new TelemetryFilterProcessor())
+            // HTTP client instrumentation intentionally omitted. Command-level activity
+            // spans already capture CLI operations end-to-end. HTTP dependency tracking
+            // added noise — Azure Monitor exporter's own POST /v2.1/track calls leaked
+            // through both FilterHttpRequestMessage and TelemetryFilterProcessor (the
+            // Azure.Core HttpPipeline bypasses standard HttpClient instrumentation hooks,
+            // and clearing ActivityTraceFlags.Recorded in OnEnd is too late — the exporter
+            // has already captured the span data). Removing this eliminates the self-tracking
+            // feedback loop without losing useful telemetry.
             .AddProcessor(new SessionIdActivityProcessor(sessionResolver))
             .AddAzureMonitorTraceExporter(opts =>
             {
@@ -165,44 +160,5 @@ public static class TxcTelemetrySetup
         return (OpenTelemetry.Trace.TracerProvider)builder.Build()!;
     }
 
-    /// <summary>
-    /// Returns true for Azure Monitor / App Insights ingestion hosts.
-    /// Used by both the HTTP filter and the fallback processor.
-    /// </summary>
-    internal static bool IsAzureMonitorHost(string host)
-    {
-        return host.Contains(".applicationinsights.azure.com")
-            || host.Contains(".livediagnostics.monitor.azure.com")
-            || host.Contains(".visualstudio.com");
-    }
-
-    /// <summary>
-    /// Safety-net processor that drops HTTP dependency spans targeting Azure Monitor
-    /// endpoints. Covers cases where Azure.Core's HttpPipeline bypasses the
-    /// standard <c>FilterHttpRequestMessage</c> hook.
-    /// </summary>
-    private sealed class TelemetryFilterProcessor : BaseProcessor<System.Diagnostics.Activity>
-    {
-        public override void OnEnd(System.Diagnostics.Activity data)
-        {
-            // HTTP spans set "url.full" or "http.url" or have the host in the display name.
-            // The most reliable tag set by the OTel HTTP instrumentation is "server.address"
-            // or the URL-related tags.
-            var serverAddress = data.GetTagItem("server.address") as string;
-            if (serverAddress != null && IsAzureMonitorHost(serverAddress))
-            {
-                data.ActivityTraceFlags &= ~System.Diagnostics.ActivityTraceFlags.Recorded;
-                return;
-            }
-
-            // Fallback: check the span's display name for the host pattern
-            if (data.DisplayName != null
-                && (data.DisplayName.Contains(".applicationinsights.azure.com")
-                    || data.DisplayName.Contains(".livediagnostics.monitor.azure.com")))
-            {
-                data.ActivityTraceFlags &= ~System.Diagnostics.ActivityTraceFlags.Recorded;
-            }
-        }
-    }
 #endif
 }

--- a/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
+++ b/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
@@ -42,8 +42,8 @@ public static class TxcTelemetrySetup
     /// </summary>
     /// <param name="configConnectionString">Optional connection string from the user's config file
     /// (<c>telemetry.connectionString</c>). Falls back to build-time embedded value if null.</param>
-    /// <param name="entryPoint">Identifies the host: <c>"cli"</c> or <c>"mcp"</c>.
-    /// Used to set the OTel service name (<c>talxis-cli</c> vs <c>talxis-mcp</c>).</param>
+    /// <param name="entryPoint">Identifies how the process was reached: <c>"cli"</c> or <c>"mcp"</c>.
+    /// Emitted as telemetry metadata and used as the default service suffix unless the host overrides it.</param>
     /// <param name="configOptOut">Opt-out flag from the user's config file
     /// (<c>telemetry.optOut</c>). Environment variable <c>TXC_TELEMETRY_OPTOUT</c> takes priority.</param>
     public static void Initialize(string? configConnectionString = null, string entryPoint = "cli", bool configOptOut = false)
@@ -116,6 +116,8 @@ public static class TxcTelemetrySetup
     private static OpenTelemetry.Trace.TracerProvider CreateTracerProvider(
         string connectionString, string entryPoint, SessionIdResolver sessionResolver)
     {
+        var serviceSuffix = ResolveServiceSuffix(entryPoint);
+
         // Use OpenTelemetry SDK to create a TracerProvider with Azure Monitor exporter.
         // This is loaded via reflection-free direct API calls — the NuGet packages
         // are referenced by the entry-point projects (CLI, MCP).
@@ -124,7 +126,7 @@ public static class TxcTelemetrySetup
             .SetResourceBuilder(
                 OpenTelemetry.Resources.ResourceBuilder.CreateDefault()
                     .AddService(
-                        serviceName: $"talxis-{entryPoint}",
+                        serviceName: $"talxis-{serviceSuffix}",
                         serviceVersion: TxcTelemetry.Source.Version,
                         serviceInstanceId: Environment.MachineName)
                     .AddAttributes(new Dictionary<string, object>
@@ -158,6 +160,12 @@ public static class TxcTelemetrySetup
             });
 
         return (OpenTelemetry.Trace.TracerProvider)builder.Build()!;
+    }
+
+    internal static string ResolveServiceSuffix(string entryPoint)
+    {
+        var overrideSuffix = Environment.GetEnvironmentVariable("TXC_SERVICE_SUFFIX");
+        return string.IsNullOrWhiteSpace(overrideSuffix) ? entryPoint : overrideSuffix;
     }
 
 #endif

--- a/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
+++ b/src/TALXIS.CLI.Logging/TxcTelemetrySetup.cs
@@ -162,11 +162,16 @@ public static class TxcTelemetrySetup
         return (OpenTelemetry.Trace.TracerProvider)builder.Build()!;
     }
 
+#endif
+
+    /// <summary>
+    /// Resolves the OTel service name suffix. Defaults to <paramref name="entryPoint"/>
+    /// unless overridden by <c>TXC_SERVICE_SUFFIX</c> (set by the MCP subprocess runner
+    /// so child CLI processes identify as <c>talxis-cli</c> instead of <c>talxis-mcp</c>).
+    /// </summary>
     internal static string ResolveServiceSuffix(string entryPoint)
     {
         var overrideSuffix = Environment.GetEnvironmentVariable("TXC_SERVICE_SUFFIX");
         return string.IsNullOrWhiteSpace(overrideSuffix) ? entryPoint : overrideSuffix;
     }
-
-#endif
 }

--- a/src/TALXIS.CLI.MCP/CliSubprocessRunner.cs
+++ b/src/TALXIS.CLI.MCP/CliSubprocessRunner.cs
@@ -134,9 +134,11 @@ internal static class CliSubprocessRunner
             startInfo.Environment[TALXIS.CLI.Logging.SessionId.ExplicitEnvVarStrategy.SourceEnvVar] = sessionResolver.Source;
         }
 
-        // Tell the child CLI process it was invoked from MCP, not standalone terminal.
-        // This ensures txc.entry_point=mcp on all child spans.
+        // Tell the child CLI process it was invoked from MCP so command spans keep
+        // txc.entry_point=mcp for attribution, but override the OTel service suffix
+        // so App Insights still shows the child process as talxis-cli.
         startInfo.Environment["TXC_ENTRY_POINT"] = "mcp";
+        startInfo.Environment["TXC_SERVICE_SUFFIX"] = "cli";
 
         // Force headless mode for every MCP-spawned tool invocation so that
         // interactive auth flows (browser, device code, masked secret prompts)

--- a/src/TALXIS.CLI.MCP/ExecutionLogService.cs
+++ b/src/TALXIS.CLI.MCP/ExecutionLogService.cs
@@ -55,7 +55,7 @@ internal sealed class ExecutionLogService
 
     /// <summary>
     /// Filters log entries by level, category, and search text.
-    /// Public so <see cref="McpToolResultFactory.BuildExecutionLogResult"/> can reuse the logic.
+    /// Internal so <see cref="McpToolResultFactory.BuildExecutionLogResult"/> can reuse the logic.
     /// </summary>
     internal static IReadOnlyList<RedactedLogEntry> FilterLogEntries(
         IReadOnlyList<RedactedLogEntry> entries, string? level, string? category, string? search)

--- a/src/TALXIS.CLI.MCP/ExecutionLogService.cs
+++ b/src/TALXIS.CLI.MCP/ExecutionLogService.cs
@@ -50,50 +50,14 @@ internal sealed class ExecutionLogService
         };
     }
 
-    /// <summary>
-    /// Builds a filtered, paginated execution log result for the get_execution_log tool.
-    /// </summary>
-    public CallToolResult BuildExecutionLogResult(string uri, string? level = null,
-        string? category = null, string? search = null, int skip = 0, int take = 50)
-    {
-        if (!_toolLogStore.TryGet(uri, out var entry) || entry is null)
-        {
-            return new CallToolResult
-            {
-                IsError = true,
-                Content = [new TextContentBlock { Text = $"Execution log not found for '{uri}'." }]
-            };
-        }
-
-        var allEntries = entry.LogEntries;
-        var filtered = FilterLogEntries(allEntries, level, category, search);
-        var paged = filtered.Skip(skip).Take(take).ToList();
-
-        var result = new
-        {
-            entry.ToolName,
-            entry.ExitCode,
-            entry.Summary,
-            TotalEntries = allEntries.Count,
-            FilteredCount = filtered.Count,
-            Skip = skip,
-            Take = take,
-            LogEntries = paged
-        };
-
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock
-            {
-                Text = JsonSerializer.Serialize(result, TxcOutputJsonOptions.Default)
-            }]
-        };
-    }
-
     private static readonly string[] LogLevelOrder =
         ["Trace", "Debug", "Information", "Warning", "Error", "Critical"];
 
-    private static IReadOnlyList<RedactedLogEntry> FilterLogEntries(
+    /// <summary>
+    /// Filters log entries by level, category, and search text.
+    /// Public so <see cref="McpToolResultFactory.BuildExecutionLogResult"/> can reuse the logic.
+    /// </summary>
+    internal static IReadOnlyList<RedactedLogEntry> FilterLogEntries(
         IReadOnlyList<RedactedLogEntry> entries, string? level, string? category, string? search)
     {
         IEnumerable<RedactedLogEntry> result = entries;

--- a/src/TALXIS.CLI.MCP/GuideHandler.cs
+++ b/src/TALXIS.CLI.MCP/GuideHandler.cs
@@ -54,10 +54,7 @@ public class GuideHandler
                 var toolDefs = workflowEntries.Select(McpToolRegistry.BuildToolDefinition).ToList();
                 _activeToolSet.InjectTools(toolDefs);
                 var compactResponse = BuildCompactListingResponse(workflowEntries, workflow);
-                return new CallToolResult
-                {
-                    Content = [new TextContentBlock { Text = compactResponse }]
-                };
+                return McpToolResultFactory.BuildTextResult(compactResponse);
             }
         }
         else
@@ -71,10 +68,8 @@ public class GuideHandler
         var entries = matchedEntries.ToList();
         if (entries.Count == 0)
         {
-            return new CallToolResult
-            {
-                Content = [new TextContentBlock { Text = $"No matching tools found for: {query}\n\nAvailable workflows: local-development, environment-inspection, environment-mutation, data-operations, deployment, configuration, changeset-management\n\nTry calling with a workflow parameter to see all tools in a domain." }]
-            };
+            return McpToolResultFactory.BuildTextResult(
+                $"No matching tools found for: {query}\n\nAvailable workflows: local-development, environment-inspection, environment-mutation, data-operations, deployment, configuration, changeset-management\n\nTry calling with a workflow parameter to see all tools in a domain.");
         }
 
         // Inject matched tools into ActiveToolSet for direct calling on subsequent turns
@@ -84,10 +79,7 @@ public class GuideHandler
         // Build structured response (includes recipe when available from sampling)
         var response = BuildGuidanceResponse(entries, query, recipeText);
 
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = response }]
-        };
+        return McpToolResultFactory.BuildTextResult(response);
     }
 
     /// <summary>
@@ -106,10 +98,7 @@ public class GuideHandler
             var toolDefs = allEntries.Select(McpToolRegistry.BuildToolDefinition).ToList();
             _activeToolSet.InjectTools(toolDefs);
             var compactResponse = BuildCompactListingResponse(allEntries, workflowScope);
-            return new CallToolResult
-            {
-                Content = [new TextContentBlock { Text = compactResponse }]
-            };
+            return McpToolResultFactory.BuildTextResult(compactResponse);
         }
         else
         {
@@ -127,10 +116,7 @@ public class GuideHandler
 
         var response = BuildGuidanceResponse(entries, query, recipeText);
 
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = response }]
-        };
+        return McpToolResultFactory.BuildTextResult(response);
     }
 
     /// <summary>

--- a/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
+++ b/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
@@ -7,8 +7,13 @@ using TALXIS.CLI.Logging;
 namespace TALXIS.CLI.MCP;
 
 /// <summary>
-/// Builds MCP <see cref="CallToolResult"/> responses from CLI subprocess outcomes.
-/// Log query and resource operations are handled by <see cref="ExecutionLogService"/>.
+/// Single builder for all MCP <see cref="CallToolResult"/> responses.
+/// Enforces the content/structuredContent contract: both surfaces always carry
+/// the same information — <c>content</c> for humans, <c>structuredContent</c> for machines/AI.
+/// <para>
+/// All MCP tool handlers should use this factory instead of constructing
+/// <see cref="CallToolResult"/> directly. See TXC029 analyzer.
+/// </para>
 /// </summary>
 internal sealed class McpToolResultFactory
 {
@@ -24,7 +29,14 @@ internal sealed class McpToolResultFactory
         _sessionIdAccessor = sessionIdAccessor;
     }
 
-    public CallToolResult Build(string toolName, CliSubprocessResult result)
+    // ── CLI subprocess results (data commands, mutative commands) ──────────
+
+    /// <summary>
+    /// Builds a result from a CLI subprocess execution. Handles both success
+    /// and failure, detecting <c>CommandResultEnvelope</c> JSON to produce
+    /// clean human-readable <c>content</c> and typed <c>structuredContent</c>.
+    /// </summary>
+    public CallToolResult BuildDataResult(string toolName, CliSubprocessResult result)
     {
         // Capture operation ID while Activity is still active — by the time
         // BuildFailureResult runs the Activity scope may have ended.
@@ -32,8 +44,6 @@ internal sealed class McpToolResultFactory
 
         // Store execution log for every run — clients may need to troubleshoot
         // unexpected output even from successful executions.
-        // Use the root trace id as execution identity so diagnostics URI, telemetry,
-        // and App Insights operation_Id all share one canonical id.
         string diagnosticsUri = _toolLogStore.Store(
             toolName,
             result.ExitCode,
@@ -42,8 +52,18 @@ internal sealed class McpToolResultFactory
             result.StructuredEntries,
             operationId);
 
+        // ── Success path ──
         if (result.ExitCode == 0)
         {
+            // Detect CommandResultEnvelope on success (mutative commands like create/delete/update).
+            // Extract the human-readable message instead of showing raw JSON in content.
+            var successEnvelope = TryParseCliEnvelope(result.Output?.Trim());
+            if (successEnvelope != null)
+            {
+                return BuildSuccessEnvelopeResult(successEnvelope, diagnosticsUri);
+            }
+
+            // Non-envelope output: data tables, JSON objects, plain text
             string successText = result.Output;
             if (result.StructuredEntries.Count > 0)
             {
@@ -51,7 +71,6 @@ internal sealed class McpToolResultFactory
                     $"Diagnostics URI: {diagnosticsUri}";
             }
 
-            // Try to parse CLI output as JSON for structuredContent
             JsonElement? structuredData = TryParseJson(result.Output?.Trim());
             var callResult = new CallToolResult
             {
@@ -68,10 +87,10 @@ internal sealed class McpToolResultFactory
             return callResult;
         }
 
+        // ── Failure path ──
         // When CLI outputs a CommandResultEnvelope JSON (status/message/exitCode/support),
         // extract the human-readable message and reuse the parsed fields so both MCP
-        // surfaces (content for humans, structuredContent for machines) carry the same
-        // information without double-nesting raw JSON.
+        // surfaces carry the same information without double-nesting raw JSON.
         var envelope = TryParseCliEnvelope(result.Output?.Trim());
         if (envelope != null)
         {
@@ -88,9 +107,11 @@ internal sealed class McpToolResultFactory
         return BuildFailureResult(toolName, summary, diagnosticsUri, result.ExitCode, operationId);
     }
 
+    /// <summary>
+    /// Builds a result from an exception that occurred before or during CLI execution.
+    /// </summary>
     public CallToolResult BuildExceptionResult(string toolName, Exception exception)
     {
-        // Capture operation ID while Activity is still active.
         var operationId = TxcActivitySource.CurrentOperationId;
 
         // Surface the innermost exception message — for wrapped exceptions
@@ -118,6 +139,106 @@ internal sealed class McpToolResultFactory
         return BuildFailureResult(toolName, summary, diagnosticsUri, exitCode: -1, operationId);
     }
 
+    // ── Text-only results (guides, skill content, prose) ──────────────────
+
+    /// <summary>
+    /// Builds a text-only result for prose responses (guide tools, skill content).
+    /// No <c>structuredContent</c> is set — intentionally text-only since
+    /// there is no structured data to represent.
+    /// </summary>
+    public static CallToolResult BuildTextResult(string text)
+    {
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = text }]
+        };
+    }
+
+    // ── Error results (parameter validation, not-found) ───────────────────
+
+    /// <summary>
+    /// Builds an error result for parameter validation, not-found, or other
+    /// non-CLI errors. Both <c>content</c> and <c>structuredContent</c> carry
+    /// the same error message.
+    /// </summary>
+    public static CallToolResult BuildErrorResult(string message)
+    {
+        return new CallToolResult
+        {
+            IsError = true,
+            Content = [new TextContentBlock { Text = message }],
+            StructuredContent = JsonSerializer.SerializeToElement(new
+            {
+                status = "failed",
+                error = new { message }
+            }, TxcOutputJsonOptions.Default)
+        };
+    }
+
+    // ── Execution log results ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a filtered, paginated execution log result.
+    /// Both <c>content</c> (JSON text) and <c>structuredContent</c> carry the same data.
+    /// </summary>
+    public CallToolResult BuildExecutionLogResult(string uri, string? level = null,
+        string? category = null, string? search = null, int skip = 0, int take = 50)
+    {
+        if (!_toolLogStore.TryGet(uri, out var entry) || entry is null)
+        {
+            return BuildErrorResult($"Execution log not found for '{uri}'.");
+        }
+
+        var allEntries = entry.LogEntries;
+        var filtered = ExecutionLogService.FilterLogEntries(allEntries, level, category, search);
+        var paged = filtered.Skip(skip).Take(take).ToList();
+
+        var resultData = new
+        {
+            entry.ToolName,
+            entry.ExitCode,
+            entry.Summary,
+            TotalEntries = allEntries.Count,
+            FilteredCount = filtered.Count,
+            Skip = skip,
+            Take = take,
+            LogEntries = paged
+        };
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock
+            {
+                Text = JsonSerializer.Serialize(resultData, TxcOutputJsonOptions.Default)
+            }],
+            StructuredContent = JsonSerializer.SerializeToElement(resultData, TxcOutputJsonOptions.Default)
+        };
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a success result from a parsed <c>CommandResultEnvelope</c>.
+    /// Extracts the human-readable message for <c>content</c> and uses the
+    /// envelope fields for <c>structuredContent</c> — no double-nesting.
+    /// </summary>
+    private static CallToolResult BuildSuccessEnvelopeResult(CliEnvelopeFields envelope, string diagnosticsUri)
+    {
+        var message = envelope.Message ?? "Operation completed successfully.";
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = message }],
+            StructuredContent = JsonSerializer.SerializeToElement(new
+            {
+                status = "succeeded",
+                message,
+                id = envelope.Id,
+                diagnosticsUri
+            }, TxcOutputJsonOptions.Default)
+        };
+    }
+
     private static JsonElement? TryParseJson(string? text)
     {
         if (string.IsNullOrWhiteSpace(text)) return null;
@@ -134,7 +255,7 @@ internal sealed class McpToolResultFactory
 
     /// <summary>
     /// Tries to parse CLI stdout as a <c>CommandResultEnvelope</c> JSON
-    /// (<c>{"status":"failed","message":"...","exitCode":1,"support":{...}}</c>).
+    /// (<c>{"status":"...","message":"...","exitCode":1,"support":{...}}</c>).
     /// Returns null if the output is not valid JSON or does not match the envelope shape.
     /// </summary>
     private static CliEnvelopeFields? TryParseCliEnvelope(string? text)
@@ -155,13 +276,16 @@ internal sealed class McpToolResultFactory
             int? exitCode = root.TryGetProperty("exitCode", out var ecProp) && ecProp.ValueKind == JsonValueKind.Number
                 ? ecProp.GetInt32() : null;
 
+            string? id = root.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
+                ? idProp.GetString() : null;
+
             SupportContext? support = null;
             if (root.TryGetProperty("support", out var supportProp) && supportProp.ValueKind == JsonValueKind.Object)
             {
                 support = JsonSerializer.Deserialize<SupportContext>(supportProp.GetRawText(), TxcOutputJsonOptions.Default);
             }
 
-            return new CliEnvelopeFields(messageProp.GetString(), exitCode, support);
+            return new CliEnvelopeFields(messageProp.GetString(), exitCode, id, support);
         }
         catch (JsonException)
         {
@@ -169,7 +293,7 @@ internal sealed class McpToolResultFactory
         }
     }
 
-    private sealed record CliEnvelopeFields(string? Message, int? ExitCode, SupportContext? Support);
+    private sealed record CliEnvelopeFields(string? Message, int? ExitCode, string? Id, SupportContext? Support);
 
     private CallToolResult BuildFailureResult(string toolName, string summary,
         string diagnosticsUri, int exitCode = -1, string? operationId = null,

--- a/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
+++ b/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
@@ -68,6 +68,22 @@ internal sealed class McpToolResultFactory
             return callResult;
         }
 
+        // When CLI outputs a CommandResultEnvelope JSON (status/message/exitCode/support),
+        // extract the human-readable message and reuse the parsed fields so both MCP
+        // surfaces (content for humans, structuredContent for machines) carry the same
+        // information without double-nesting raw JSON.
+        var envelope = TryParseCliEnvelope(result.Output?.Trim());
+        if (envelope != null)
+        {
+            return BuildFailureResult(
+                toolName,
+                summary: envelope.Message ?? $"Tool '{toolName}' failed with exit code {result.ExitCode}.",
+                diagnosticsUri,
+                envelope.ExitCode ?? result.ExitCode,
+                operationId,
+                cliSupport: envelope.Support);
+        }
+
         string summary = BuildFailureSummary(toolName, result.Output, result.LastErrors, result.ExitCode);
         return BuildFailureResult(toolName, summary, diagnosticsUri, result.ExitCode, operationId);
     }
@@ -116,14 +132,64 @@ internal sealed class McpToolResultFactory
         }
     }
 
-    private CallToolResult BuildFailureResult(string toolName, string summary,
-        string diagnosticsUri, int exitCode = -1, string? operationId = null)
+    /// <summary>
+    /// Tries to parse CLI stdout as a <c>CommandResultEnvelope</c> JSON
+    /// (<c>{"status":"failed","message":"...","exitCode":1,"support":{...}}</c>).
+    /// Returns null if the output is not valid JSON or does not match the envelope shape.
+    /// </summary>
+    private static CliEnvelopeFields? TryParseCliEnvelope(string? text)
     {
-        var support = new SupportContext
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        try
         {
-            SessionId = _sessionIdAccessor() ?? "unknown",
-            OperationId = operationId ?? "unknown",
-        };
+            using var doc = JsonDocument.Parse(text);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            // Must have "status" and "message" to be recognized as an envelope
+            if (!root.TryGetProperty("status", out var statusProp) || statusProp.ValueKind != JsonValueKind.String)
+                return null;
+            if (!root.TryGetProperty("message", out var messageProp) || messageProp.ValueKind != JsonValueKind.String)
+                return null;
+
+            int? exitCode = root.TryGetProperty("exitCode", out var ecProp) && ecProp.ValueKind == JsonValueKind.Number
+                ? ecProp.GetInt32() : null;
+
+            SupportContext? support = null;
+            if (root.TryGetProperty("support", out var supportProp) && supportProp.ValueKind == JsonValueKind.Object)
+            {
+                support = JsonSerializer.Deserialize<SupportContext>(supportProp.GetRawText(), TxcOutputJsonOptions.Default);
+            }
+
+            return new CliEnvelopeFields(messageProp.GetString(), exitCode, support);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record CliEnvelopeFields(string? Message, int? ExitCode, SupportContext? Support);
+
+    private CallToolResult BuildFailureResult(string toolName, string summary,
+        string diagnosticsUri, int exitCode = -1, string? operationId = null,
+        SupportContext? cliSupport = null)
+    {
+        // Prefer support context from the CLI subprocess envelope (it carries the actual
+        // operation ID from the child process). Fall back to MCP-level context.
+        var sessionId = _sessionIdAccessor() ?? "unknown";
+        var opId = operationId ?? "unknown";
+        var support = cliSupport != null
+            ? new SupportContext
+            {
+                SessionId = !string.IsNullOrEmpty(cliSupport.SessionId) ? cliSupport.SessionId : sessionId,
+                OperationId = !string.IsNullOrEmpty(cliSupport.OperationId) ? cliSupport.OperationId : opId,
+            }
+            : new SupportContext
+            {
+                SessionId = sessionId,
+                OperationId = opId,
+            };
         var supportText = support.FormatAsText();
         var supportBlock = string.IsNullOrEmpty(supportText) ? "" : $"{Environment.NewLine}{supportText}";
 

--- a/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
+++ b/src/TALXIS.CLI.MCP/McpToolResultFactory.cs
@@ -226,9 +226,18 @@ internal sealed class McpToolResultFactory
     {
         var message = envelope.Message ?? "Operation completed successfully.";
 
+        // Both surfaces carry the same information:
+        // content = human-readable text with diagnostics URI appended
+        // structuredContent = typed JSON with the same fields
+        var contentText = $"{message}\n\nDiagnostics URI: {diagnosticsUri}";
+
         return new CallToolResult
         {
-            Content = [new TextContentBlock { Text = message }],
+            Content =
+            [
+                new TextContentBlock { Text = contentText },
+                new ResourceLinkBlock { Name = "Execution log", Uri = diagnosticsUri, Title = "Execution log", MimeType = "application/json" }
+            ],
             StructuredContent = JsonSerializer.SerializeToElement(new
             {
                 status = "succeeded",

--- a/src/TALXIS.CLI.MCP/Program.cs
+++ b/src/TALXIS.CLI.MCP/Program.cs
@@ -214,10 +214,8 @@ async ValueTask<CallToolResult> HandleGuideToolAsync(
             // Return compact listing (no schemas) to avoid token bloat
             var tools = allEnvEntries.Select(McpToolRegistry.BuildToolDefinition).ToList();
             activeToolSet.InjectTools(tools);
-            result = new CallToolResult
-            {
-                Content = [new TextContentBlock { Text = GuideHandler.BuildCompactListingResponse(allEnvEntries, "environment") }]
-            };
+            result = McpToolResultFactory.BuildTextResult(
+                GuideHandler.BuildCompactListingResponse(allEnvEntries, "environment"));
         }
         else
         {
@@ -240,10 +238,7 @@ async ValueTask<CallToolResult> HandleGuideToolAsync(
             if (!string.IsNullOrEmpty(inspText)) parts.Add(inspText);
             if (!string.IsNullOrEmpty(mutText)) parts.Add(mutText);
 
-            result = new CallToolResult
-            {
-                Content = [new TextContentBlock { Text = string.Join("\n\n", parts) }]
-            };
+            result = McpToolResultFactory.BuildTextResult(string.Join("\n\n", parts));
         }
     }
     else if (workflowScope is not null)
@@ -396,18 +391,21 @@ async Task<CallToolResult> ExecuteCliToolAsync(
         if (result.ExitCode != 0)
         {
             mcpActivity?.SetStatus(System.Diagnostics.ActivityStatusCode.Error, $"Exit code {result.ExitCode}");
-            // Log the failure so TxcTelemetryLogProvider records it as an exception
-            // on the MCP Server span (Activity.Current is now the Server span again).
+            // Set error message on MCP server span for at-a-glance context in App Insights
             if (!string.IsNullOrWhiteSpace(result.LastErrors))
+            {
+                var firstError = result.LastErrors.Split('\n')[0];
+                mcpActivity?.SetTag(TALXIS.CLI.Core.Telemetry.TxcTelemetryTags.ErrorMessage, firstError);
                 mcpLogger.LogError("Tool failed: {ToolName} (exit code {ExitCode}): {Error}",
-                    toolName, result.ExitCode, result.LastErrors.Split('\n')[0]);
+                    toolName, result.ExitCode, firstError);
+            }
         }
         else
         {
             mcpLogger.LogInformation("Tool completed: {ToolName} (exit code {ExitCode})", toolName, result.ExitCode);
         }
 
-        return toolResultFactory.Build(toolName, result);
+        return toolResultFactory.BuildDataResult(toolName, result);
     }
     catch (OperationCanceledException) when (ct.IsCancellationRequested)
     {
@@ -494,7 +492,7 @@ async ValueTask<CallToolResult> ExecuteAsTaskAsync(
 
             mcpLogger.LogInformation("Task completed: {ToolName} (exit code {ExitCode}, taskId: {TaskId})", toolName, result.ExitCode, mcpTask.TaskId);
 
-            var callToolResult = toolResultFactory.Build(toolName, result);
+            var callToolResult = toolResultFactory.BuildDataResult(toolName, result);
 
             var finalStatus = result.ExitCode != 0 ? McpTaskStatus.Failed : McpTaskStatus.Completed;
             var resultElement = System.Text.Json.JsonSerializer.SerializeToElement(callToolResult);
@@ -532,8 +530,11 @@ async ValueTask<CallToolResult> ExecuteAsTaskAsync(
         }
     }, CancellationToken.None);
 
-    // Return immediately with task handle
+    // Return immediately with task handle — the actual result is built via
+    // McpToolResultFactory.BuildDataResult when the background task completes.
+#pragma warning disable TXC029 // Task handle is an MCP protocol construct, not a tool result
     return new CallToolResult { Task = mcpTask };
+#pragma warning restore TXC029
 }
 
 // Helper: checks if a tool name is a guide tool
@@ -553,26 +554,17 @@ bool IsMcpSpecificTool(string toolName)
 CallToolResult HandleGetSkillDetails(IDictionary<string, JsonElement>? arguments)
 {
     if (arguments is null || !arguments.TryGetValue("skill_id", out var skillIdEl))
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = $"'skill_id' parameter is required.\n\n{publicSkillLoader.GetSkillsIndexPrompt()}" }],
-            IsError = true
-        };
+        return McpToolResultFactory.BuildErrorResult(
+            $"'skill_id' parameter is required.\n\n{publicSkillLoader.GetSkillsIndexPrompt()}");
 
     var skillId = skillIdEl.GetString() ?? "";
     var content = publicSkillLoader.GetSkillContent(skillId);
 
     if (content is null)
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = $"Skill '{skillId}' not found.\n\n{publicSkillLoader.GetSkillsIndexPrompt()}" }],
-            IsError = true
-        };
+        return McpToolResultFactory.BuildErrorResult(
+            $"Skill '{skillId}' not found.\n\n{publicSkillLoader.GetSkillsIndexPrompt()}");
 
-    return new CallToolResult
-    {
-        Content = [new TextContentBlock { Text = content }]
-    };
+    return McpToolResultFactory.BuildTextResult(content);
 }
 
 // Handler: get_execution_log — returns stored execution log for a previous tool call
@@ -580,21 +572,15 @@ CallToolResult HandleGetExecutionLog(IDictionary<string, JsonElement>? arguments
 {
     if (arguments is null || !arguments.TryGetValue("uri", out var uriElement))
     {
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = "'uri' parameter is required. Pass the diagnostics URI from the tool response." }],
-            IsError = true
-        };
+        return McpToolResultFactory.BuildErrorResult(
+            "'uri' parameter is required. Pass the diagnostics URI from the tool response.");
     }
 
     var uri = uriElement.GetString();
     if (string.IsNullOrWhiteSpace(uri))
     {
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = "'uri' parameter must be a non-empty diagnostics URI." }],
-            IsError = true
-        };
+        return McpToolResultFactory.BuildErrorResult(
+            "'uri' parameter must be a non-empty diagnostics URI.");
     }
 
     // Extract optional filter/paging parameters
@@ -604,7 +590,7 @@ CallToolResult HandleGetExecutionLog(IDictionary<string, JsonElement>? arguments
     var skip = arguments.TryGetValue("skip", out var sk) && sk.TryGetInt32(out var skipVal) ? Math.Max(0, skipVal) : 0;
     var take = arguments.TryGetValue("take", out var tk) && tk.TryGetInt32(out var takeVal) ? Math.Clamp(takeVal, 1, 500) : 50;
 
-    return executionLogService.BuildExecutionLogResult(uri, level, category, search, skip, take);
+    return toolResultFactory.BuildExecutionLogResult(uri, level, category, search, skip, take);
 }
 
 // Registers the always-on tools in the ActiveToolSet
@@ -895,12 +881,17 @@ async Task<CallToolResult> ExecuteMcpSpecificToolWithCapturedOutputAsync(Type co
     {
         var exitCode = await ExecuteMcpSpecificToolAsync(commandType, arguments, ct);
         output.Flush();
+        var captured = output.ToString();
 
-        return new CallToolResult
-        {
-            Content = [new TextContentBlock { Text = output.ToString() }],
-            IsError = exitCode != 0
-        };
+        // Route through the factory for consistent content/structuredContent
+        // and execution log storage. Build a CliSubprocessResult from the
+        // captured in-process output.
+        var subprocessResult = new CliSubprocessResult(
+            exitCode: exitCode,
+            output: captured,
+            lastErrors: string.Empty,
+            structuredEntries: []);
+        return toolResultFactory.BuildDataResult(commandType.Name, subprocessResult);
     }
     catch (Exception ex)
     {

--- a/src/TALXIS.CLI.MCP/Program.cs
+++ b/src/TALXIS.CLI.MCP/Program.cs
@@ -172,7 +172,7 @@ async ValueTask<CallToolResult> CallToolAsync(RequestContext<CallToolRequestPara
         var cmdType = mcpToolRegistry.FindCommandTypeByToolName(toolName);
         if (cmdType == null)
             throw new McpException($"Tool '{toolName}' not found.");
-        return await ExecuteMcpSpecificToolWithCapturedOutputAsync(cmdType, p?.Arguments, ct);
+        return await ExecuteMcpSpecificToolWithCapturedOutputAsync(toolName, cmdType, p?.Arguments, ct);
     }
 
     // --- Route: Active injected tools (direct call) or any known tool ---
@@ -394,7 +394,9 @@ async Task<CallToolResult> ExecuteCliToolAsync(
             // Set error message on MCP server span for at-a-glance context in App Insights
             if (!string.IsNullOrWhiteSpace(result.LastErrors))
             {
-                var firstError = result.LastErrors.Split('\n')[0];
+                var firstError = result.LastErrors
+                    .Split(["\r\n", "\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .FirstOrDefault() ?? result.LastErrors.Trim();
                 mcpActivity?.SetTag(TALXIS.CLI.Core.Telemetry.TxcTelemetryTags.ErrorMessage, firstError);
                 mcpLogger.LogError("Tool failed: {ToolName} (exit code {ExitCode}): {Error}",
                     toolName, result.ExitCode, firstError);
@@ -869,7 +871,7 @@ async Task<int> ExecuteMcpSpecificToolAsync(Type commandType, IDictionary<string
     }
 }
 
-async Task<CallToolResult> ExecuteMcpSpecificToolWithCapturedOutputAsync(Type commandType, IDictionary<string, System.Text.Json.JsonElement>? arguments, CancellationToken ct)
+async Task<CallToolResult> ExecuteMcpSpecificToolWithCapturedOutputAsync(string toolName, Type commandType, IDictionary<string, System.Text.Json.JsonElement>? arguments, CancellationToken ct)
 {
     var output = new StringWriter();
 
@@ -891,12 +893,11 @@ async Task<CallToolResult> ExecuteMcpSpecificToolWithCapturedOutputAsync(Type co
             output: captured,
             lastErrors: string.Empty,
             structuredEntries: []);
-        return toolResultFactory.BuildDataResult(commandType.Name, subprocessResult);
+        return toolResultFactory.BuildDataResult(toolName, subprocessResult);
     }
     catch (Exception ex)
     {
-        return toolResultFactory.BuildExceptionResult(
-            commandType.Name, ex);
+        return toolResultFactory.BuildExceptionResult(toolName, ex);
     }
 }
 

--- a/src/TALXIS.CLI.MCP/Program.cs
+++ b/src/TALXIS.CLI.MCP/Program.cs
@@ -107,6 +107,12 @@ PREFER LOCAL OPERATIONS: Workspace operations are instant and reversible. Enviro
     rootsService = new RootsService(mcpServer, loggerFactory?.CreateLogger<RootsService>());
     var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
     appLifetime = lifetime;
+
+    // Flush pending telemetry spans when the MCP server shuts down.
+    // Without this, short-lived sessions or abrupt exits would silently lose spans
+    // because the OTel batch exporter fires on a timer (default 5s).
+    lifetime.ApplicationStopping.Register(() => TALXIS.CLI.Logging.TxcTelemetrySetup.Shutdown());
+
     await host.RunAsync();
     return 0;
 }

--- a/tests/TALXIS.CLI.IntegrationTests/AppInsightsSmokeTests.cs
+++ b/tests/TALXIS.CLI.IntegrationTests/AppInsightsSmokeTests.cs
@@ -141,6 +141,7 @@ public class AppInsightsSmokeTests
         var entryPoint = row[colIndex["entryPoint"]]?.ToString();
         var command = row[colIndex["command"]]?.ToString();
         var exitCode = row[colIndex["exitCode"]]?.ToString();
+        var errorKind = row[colIndex["errorKind"]]?.ToString();
         var version = row[colIndex["version"]]?.ToString();
         var clientTag = row[colIndex["clientTag"]]?.ToString();
         var success = row[colIndex["success"]]?.ToString();
@@ -153,6 +154,8 @@ public class AppInsightsSmokeTests
         Assert.False(string.IsNullOrWhiteSpace(command), "command dimension should be non-empty");
         Assert.False(string.IsNullOrWhiteSpace(exitCode), "exitCode dimension should be non-empty");
         Assert.NotEqual("0", exitCode);
+        Assert.False(string.IsNullOrWhiteSpace(errorKind), "errorKind dimension should be non-empty");
+        Assert.Equal("validation", errorKind);
         Assert.False(string.IsNullOrWhiteSpace(version), "version dimension should be non-empty");
         Assert.Equal("terminal", clientTag);
         Assert.Equal("False", success, StringComparer.OrdinalIgnoreCase);

--- a/tests/TALXIS.CLI.Tests/Analyzers/TelemetryConsistencyAnalyzerTests.cs
+++ b/tests/TALXIS.CLI.Tests/Analyzers/TelemetryConsistencyAnalyzerTests.cs
@@ -1,0 +1,211 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TALXIS.CLI.Analyzers;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Analyzers;
+
+public class TelemetryConsistencyAnalyzerTests
+{
+    [Fact]
+    public async Task NoDirectActivityTagging_FlagsCommandActivitySetTag()
+    {
+        const string source = """
+            using System.Diagnostics;
+            using DotMake.CommandLine;
+            using TALXIS.CLI.Core.Shared;
+
+            [CliCommand]
+            public sealed class BadCommand : TxcLeafCommand
+            {
+                public void Execute()
+                {
+                    var activity = Activity.Current;
+                    if (activity != null)
+                        activity.SetTag("txc.error_message", "bad");
+                }
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new NoDirectActivityTaggingAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "TXC025");
+    }
+
+    [Fact]
+    public async Task NoDirectProcessStart_FlagsCommandProcessStart()
+    {
+        const string source = """
+            using System.Diagnostics;
+            using DotMake.CommandLine;
+            using TALXIS.CLI.Core.Shared;
+
+            [CliCommand]
+            public sealed class BadCommand : TxcLeafCommand
+            {
+                public void Execute()
+                {
+                    Process.Start("txc");
+                }
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new NoDirectProcessStartAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "TXC026");
+    }
+
+    [Fact]
+    public async Task MustUseWriteResultForMutations_FlagsMutativeCommandWithoutResultEnvelope()
+    {
+        const string source = """
+            using TALXIS.CLI.Core;
+            using TALXIS.CLI.Core.Shared;
+
+            [CliIdempotent]
+            public sealed class BadCommand : TxcLeafCommand
+            {
+                public void Execute()
+                {
+                }
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new MustUseWriteResultForMutationsAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "TXC027");
+    }
+
+    [Fact]
+    public async Task MustUseWriteResultForMutations_AllowsMutativeCommandWithResultEnvelope()
+    {
+        const string source = """
+            using TALXIS.CLI.Core;
+            using TALXIS.CLI.Core.Shared;
+
+            [CliIdempotent]
+            public sealed class GoodCommand : TxcLeafCommand
+            {
+                public void Execute()
+                {
+                    OutputFormatter.WriteResult();
+                }
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new MustUseWriteResultForMutationsAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "TXC027");
+    }
+
+    [Fact]
+    public async Task NoWriteResultInReadOnly_FlagsReadOnlyResultEnvelope()
+    {
+        const string source = """
+            using TALXIS.CLI.Core;
+            using TALXIS.CLI.Core.Shared;
+
+            [CliReadOnly]
+            public sealed class BadCommand : TxcLeafCommand
+            {
+                public void Execute()
+                {
+                    OutputFormatter.WriteResult();
+                }
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new NoWriteResultInReadOnlyAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "TXC028");
+    }
+
+    [Fact]
+    public async Task NoDirectCallToolResult_FlagsObjectCreationOutsideFactory()
+    {
+        const string source = """
+            using ModelContextProtocol.Protocol;
+
+            public sealed class BadHandler
+            {
+                public CallToolResult Execute() => new CallToolResult();
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new NoDirectCallToolResultAnalyzer());
+
+        Assert.Contains(diagnostics, d => d.Id == "TXC029");
+    }
+
+    [Fact]
+    public async Task NoDirectCallToolResult_AllowsObjectCreationInsideFactory()
+    {
+        const string source = """
+            using ModelContextProtocol.Protocol;
+
+            public sealed class McpToolResultFactory
+            {
+                public CallToolResult Execute() => new CallToolResult();
+            }
+            """ + Stubs;
+
+        var diagnostics = await RunAnalyzerAsync(source, new NoDirectCallToolResultAnalyzer());
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "TXC029");
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> RunAnalyzerAsync(string source, DiagnosticAnalyzer analyzer)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview));
+        var references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+
+        var compilation = CSharpCompilation.Create(
+            "AnalyzerTests",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    private const string Stubs = """
+        namespace DotMake.CommandLine
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class CliCommandAttribute : System.Attribute { }
+        }
+
+        namespace TALXIS.CLI.Core
+        {
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class CliDestructiveAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class CliIdempotentAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Class)]
+            public sealed class CliReadOnlyAttribute : System.Attribute { }
+
+            public static class OutputFormatter
+            {
+                public static void WriteResult() { }
+            }
+        }
+
+        namespace TALXIS.CLI.Core.Shared
+        {
+            public abstract class TxcLeafCommand { }
+        }
+
+        namespace ModelContextProtocol.Protocol
+        {
+            public sealed class CallToolResult { }
+        }
+
+        """;
+}

--- a/tests/TALXIS.CLI.Tests/Logging/TxcTelemetryLogProviderTests.cs
+++ b/tests/TALXIS.CLI.Tests/Logging/TxcTelemetryLogProviderTests.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Abstractions;
+using TALXIS.CLI.Core.Telemetry;
+using TALXIS.CLI.Logging;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Logging;
+
+public class TxcTelemetryLogProviderTests
+{
+    [Fact]
+    public void LogError_WithoutException_StampsRedactedErrorMessageOnCurrentActivity()
+    {
+        using var listener = CreateListener();
+        using var activity = TxcActivitySource.Instance.StartActivity("workspace_validate");
+        using var provider = new TxcTelemetryLogProvider();
+        var logger = provider.CreateLogger("test");
+
+        logger.LogError("Validation failed with ClientSecret={Secret}", "super-secret");
+
+        var errorMessage = Assert.IsType<string>(activity?.GetTagItem(TxcTelemetryTags.ErrorMessage));
+        Assert.Contains("***REDACTED***", errorMessage);
+        Assert.DoesNotContain("super-secret", errorMessage);
+    }
+
+    [Fact]
+    public void LogError_WithException_RecordsExceptionEventWithoutOverwritingErrorMessage()
+    {
+        using var listener = CreateListener();
+        using var activity = TxcActivitySource.Instance.StartActivity("workspace_validate");
+        using var provider = new TxcTelemetryLogProvider();
+        var logger = provider.CreateLogger("test");
+
+        logger.LogError(new InvalidOperationException("boom"), "Command failed");
+
+        Assert.Null(activity?.GetTagItem(TxcTelemetryTags.ErrorMessage));
+        Assert.Contains(activity!.Events, e => e.Name == "exception");
+    }
+
+    private static ActivityListener CreateListener()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == TxcActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}

--- a/tests/TALXIS.CLI.Tests/Logging/TxcTelemetrySetupTests.cs
+++ b/tests/TALXIS.CLI.Tests/Logging/TxcTelemetrySetupTests.cs
@@ -1,0 +1,43 @@
+using TALXIS.CLI.Logging;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Logging;
+
+public class TxcTelemetrySetupTests
+{
+    [Fact]
+    public void ResolveServiceSuffix_WithoutOverride_UsesEntryPoint()
+    {
+        var original = System.Environment.GetEnvironmentVariable("TXC_SERVICE_SUFFIX");
+        try
+        {
+            System.Environment.SetEnvironmentVariable("TXC_SERVICE_SUFFIX", null);
+
+            var suffix = TxcTelemetrySetup.ResolveServiceSuffix("mcp");
+
+            Assert.Equal("mcp", suffix);
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("TXC_SERVICE_SUFFIX", original);
+        }
+    }
+
+    [Fact]
+    public void ResolveServiceSuffix_WithOverride_UsesHostServiceSuffix()
+    {
+        var original = System.Environment.GetEnvironmentVariable("TXC_SERVICE_SUFFIX");
+        try
+        {
+            System.Environment.SetEnvironmentVariable("TXC_SERVICE_SUFFIX", "cli");
+
+            var suffix = TxcTelemetrySetup.ResolveServiceSuffix("mcp");
+
+            Assert.Equal("cli", suffix);
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("TXC_SERVICE_SUFFIX", original);
+        }
+    }
+}

--- a/tests/TALXIS.CLI.Tests/MCP/McpToolResultFactoryTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpToolResultFactoryTests.cs
@@ -188,9 +188,13 @@ public class McpToolResultFactoryTests
 
         Assert.True(toolResult.IsError != true);
 
-        // content should be human-readable message, NOT raw JSON
+        // content[0] should be human-readable message with diagnostics URI, NOT raw JSON
         var text = Assert.IsType<TextContentBlock>(toolResult.Content[0]);
-        Assert.Equal("Record deleted successfully.", text.Text);
+        Assert.StartsWith("Record deleted successfully.", text.Text);
+        Assert.Contains("Diagnostics URI:", text.Text);
+
+        // content[1] should be a ResourceLinkBlock for the execution log
+        var resourceLink = Assert.IsType<ResourceLinkBlock>(toolResult.Content[1]);
 
         // structuredContent should have clean envelope fields
         Assert.NotNull(toolResult.StructuredContent);

--- a/tests/TALXIS.CLI.Tests/MCP/McpToolResultFactoryTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpToolResultFactoryTests.cs
@@ -27,7 +27,7 @@ public class McpToolResultFactoryTests
             lastErrors: "file1.xml(1,1): schema error",
             structuredEntries: entries);
 
-        var toolResult = factory.Build("workspace_validate", result);
+        var toolResult = factory.BuildDataResult("workspace_validate", result);
 
         Assert.True(toolResult.IsError);
         var text = Assert.IsType<TextContentBlock>(toolResult.Content[0]);
@@ -78,7 +78,7 @@ public class McpToolResultFactoryTests
     public void BuildExecutionLogResult_ReturnsStructuredLogEntries()
     {
         var store = new ToolLogStore(() => "test-session");
-        var logService = new ExecutionLogService(store);
+        var factory = new McpToolResultFactory(store, () => "test-session");
         var entries = new List<RedactedLogEntry>
         {
             new("2026-05-04T10:00:00Z", "Error", "TestCategory", "schema error"),
@@ -86,7 +86,7 @@ public class McpToolResultFactoryTests
         };
         var uri = store.Store("workspace_validate", 1, "summary", "error", entries);
 
-        var toolResult = logService.BuildExecutionLogResult(uri);
+        var toolResult = factory.BuildExecutionLogResult(uri);
 
         Assert.True(toolResult.IsError != true);
         var text = Assert.IsType<TextContentBlock>(Assert.Single(toolResult.Content));
@@ -109,7 +109,7 @@ public class McpToolResultFactoryTests
     public void BuildExecutionLogResult_FiltersByLevel()
     {
         var store = new ToolLogStore(() => "test-session");
-        var logService = new ExecutionLogService(store);
+        var factory = new McpToolResultFactory(store, () => "test-session");
         var entries = new List<RedactedLogEntry>
         {
             new("2026-05-04T10:00:00Z", "Information", "Cat", "info msg"),
@@ -118,7 +118,7 @@ public class McpToolResultFactoryTests
         };
         var uri = store.Store("tool", 1, "summary", "error", entries);
 
-        var toolResult = logService.BuildExecutionLogResult(uri, level: "Warning");
+        var toolResult = factory.BuildExecutionLogResult(uri, level: "Warning");
 
         var text = Assert.IsType<TextContentBlock>(Assert.Single(toolResult.Content));
         using var document = JsonDocument.Parse(text.Text);
@@ -134,7 +134,7 @@ public class McpToolResultFactoryTests
     public void BuildExecutionLogResult_SearchesMessages()
     {
         var store = new ToolLogStore(() => "test-session");
-        var logService = new ExecutionLogService(store);
+        var factory = new McpToolResultFactory(store, () => "test-session");
         var entries = new List<RedactedLogEntry>
         {
             new("2026-05-04T10:00:00Z", "Error", "Cat", "schema validation failed"),
@@ -143,7 +143,7 @@ public class McpToolResultFactoryTests
         };
         var uri = store.Store("tool", 1, "summary", "error", entries);
 
-        var toolResult = logService.BuildExecutionLogResult(uri, search: "schema");
+        var toolResult = factory.BuildExecutionLogResult(uri, search: "schema");
 
         var text = Assert.IsType<TextContentBlock>(Assert.Single(toolResult.Content));
         using var document = JsonDocument.Parse(text.Text);
@@ -154,13 +154,13 @@ public class McpToolResultFactoryTests
     public void BuildExecutionLogResult_SupportsPaging()
     {
         var store = new ToolLogStore(() => "test-session");
-        var logService = new ExecutionLogService(store);
+        var factory = new McpToolResultFactory(store, () => "test-session");
         var entries = Enumerable.Range(0, 10)
             .Select(i => new RedactedLogEntry($"2026-05-04T10:00:{i:D2}Z", "Error", "Cat", $"msg {i}"))
             .ToList();
         var uri = store.Store("tool", 1, "summary", "error", entries);
 
-        var toolResult = logService.BuildExecutionLogResult(uri, skip: 3, take: 2);
+        var toolResult = factory.BuildExecutionLogResult(uri, skip: 3, take: 2);
 
         var text = Assert.IsType<TextContentBlock>(Assert.Single(toolResult.Content));
         using var document = JsonDocument.Parse(text.Text);
@@ -171,6 +171,51 @@ public class McpToolResultFactoryTests
         Assert.Equal(2, logEntries.GetArrayLength());
         Assert.Equal("msg 3", logEntries[0].GetProperty("message").GetString());
         Assert.Equal("msg 4", logEntries[1].GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void BuildDataResult_SuccessEnvelope_ExtractsMessageForContent()
+    {
+        var store = new ToolLogStore(() => "test-session");
+        var factory = new McpToolResultFactory(store, () => "test-session");
+        var result = new CliSubprocessResult(
+            exitCode: 0,
+            output: "{\"status\":\"succeeded\",\"message\":\"Record deleted successfully.\"}",
+            lastErrors: "",
+            structuredEntries: []);
+
+        var toolResult = factory.BuildDataResult("data_record_delete", result);
+
+        Assert.True(toolResult.IsError != true);
+
+        // content should be human-readable message, NOT raw JSON
+        var text = Assert.IsType<TextContentBlock>(toolResult.Content[0]);
+        Assert.Equal("Record deleted successfully.", text.Text);
+
+        // structuredContent should have clean envelope fields
+        Assert.NotNull(toolResult.StructuredContent);
+        using var doc = JsonDocument.Parse(toolResult.StructuredContent.Value.GetRawText());
+        var root = doc.RootElement;
+        Assert.Equal("succeeded", root.GetProperty("status").GetString());
+        Assert.Equal("Record deleted successfully.", root.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void BuildDataResult_SuccessEnvelopeWithId_IncludesIdInStructuredContent()
+    {
+        var store = new ToolLogStore(() => "test-session");
+        var factory = new McpToolResultFactory(store, () => "test-session");
+        var result = new CliSubprocessResult(
+            exitCode: 0,
+            output: "{\"status\":\"succeeded\",\"message\":\"Record created.\",\"id\":\"abc-123\"}",
+            lastErrors: "",
+            structuredEntries: []);
+
+        var toolResult = factory.BuildDataResult("data_record_create", result);
+
+        Assert.NotNull(toolResult.StructuredContent);
+        using var doc = JsonDocument.Parse(toolResult.StructuredContent.Value.GetRawText());
+        Assert.Equal("abc-123", doc.RootElement.GetProperty("id").GetString());
     }
 
     [Fact]
@@ -188,7 +233,7 @@ public class McpToolResultFactoryTests
             lastErrors: "",
             structuredEntries: entries);
 
-        var toolResult = factory.Build("my_tool", result);
+        var toolResult = factory.BuildDataResult("my_tool", result);
 
         Assert.True(toolResult.IsError != true);
         var text = Assert.IsType<TextContentBlock>(toolResult.Content[0]);

--- a/tests/TALXIS.CLI.Tests/TALXIS.CLI.Tests.csproj
+++ b/tests/TALXIS.CLI.Tests/TALXIS.CLI.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
@@ -26,5 +27,6 @@
     <ProjectReference Include="../../src/TALXIS.CLI.Features.Environment/TALXIS.CLI.Features.Environment.csproj" />
     <ProjectReference Include="../../src/TALXIS.CLI.Features.Config/TALXIS.CLI.Features.Config.csproj" />
     <ProjectReference Include="../../src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj" />
+    <ProjectReference Include="../../src/TALXIS.CLI.Analyzers/TALXIS.CLI.Analyzers.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/TALXIS.CLI.Tests/Telemetry/CommandActivityScopeTests.cs
+++ b/tests/TALXIS.CLI.Tests/Telemetry/CommandActivityScopeTests.cs
@@ -1,0 +1,59 @@
+using System.Diagnostics;
+using TALXIS.CLI.Abstractions;
+using TALXIS.CLI.Core.Telemetry;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Telemetry;
+
+public class CommandActivityScopeTests
+{
+    [Fact]
+    public void SetError_RecordsErrorKindExitCodeAndMessage()
+    {
+        using var listener = CreateListener();
+        using var scope = new CommandActivityScope("workspace_validate", "cli");
+
+        scope.SetError(2, "internal", "Unexpected failure");
+
+        Assert.Equal(2, scope.Activity?.GetTagItem(TxcTelemetryTags.ExitCode));
+        Assert.Equal("internal", scope.Activity?.GetTagItem(TxcTelemetryTags.ErrorKind));
+        Assert.Equal("Unexpected failure", scope.Activity?.GetTagItem(TxcTelemetryTags.ErrorMessage));
+    }
+
+    [Fact]
+    public void SetExitCode_ForNonZeroExitCode_DefaultsErrorKindToValidation()
+    {
+        using var listener = CreateListener();
+        using var scope = new CommandActivityScope("workspace_validate", "cli");
+
+        scope.SetExitCode(1);
+
+        Assert.Equal(1, scope.Activity?.GetTagItem(TxcTelemetryTags.ExitCode));
+        Assert.Equal("validation", scope.Activity?.GetTagItem(TxcTelemetryTags.ErrorKind));
+        Assert.Equal(ActivityStatusCode.Error, scope.Activity?.Status);
+    }
+
+    [Fact]
+    public void SetExitCode_DoesNotOverwriteClassifiedErrorKind()
+    {
+        using var listener = CreateListener();
+        using var scope = new CommandActivityScope("workspace_validate", "cli");
+
+        scope.SetError(130, "cancelled", "The operation was cancelled.");
+        scope.SetExitCode(130);
+
+        Assert.Equal("cancelled", scope.Activity?.GetTagItem(TxcTelemetryTags.ErrorKind));
+        Assert.Equal("The operation was cancelled.", scope.Activity?.GetTagItem(TxcTelemetryTags.ErrorMessage));
+    }
+
+    private static ActivityListener CreateListener()
+    {
+        var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == TxcActivitySource.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes MCP result handling consistency, adds actionable error context to telemetry spans, and introduces 5 new Roslyn analyzers to enforce these patterns going forward.

## Changes

### Telemetry span error context
- Add `txc.error_message` tag to all failed spans — visible at a glance in App Insights instead of just "Exit code 1"
- Extend `CommandActivityScope.SetError()` with optional `errorMessage` parameter
- Bridge non-exception `LogError` calls (e.g., `WorkspaceValidateCliCommand` per-file errors) to `txc.error_message` span tag via `TxcTelemetryLogProvider`
- Set `txc.error_message` on MCP server span from subprocess stderr
- Existing `txc.error_kind` (`internal`/`validation`/`cancelled`) distinguishes our bugs vs customer issues

### MCP result factory consolidation
- **`McpToolResultFactory`** is now the single builder for all MCP `CallToolResult` responses
- Enforces content/structuredContent contract by construction: both surfaces always carry the same information
- `BuildDataResult()` — CLI subprocess results (handles envelope detection for both success and failure)
- `BuildTextResult()` — prose responses (guides, skills) — intentionally text-only
- `BuildErrorResult()` — parameter validation/not-found errors (sets `structuredContent`)
- `BuildExecutionLogResult()` — moved from `ExecutionLogService`, now sets `structuredContent`
- Success envelopes: detects `CommandResultEnvelope` on exit code 0 → extracts `message` for human `content` instead of raw JSON
- In-process tools (`copilot-instructions`) now routed through `BuildDataResult()` for consistent output
- All 15+ `new CallToolResult` sites migrated to factory methods

### MCP error display fix (from initial commit)
- Parse `CommandResultEnvelope` JSON on failure path — extract human-readable message instead of double-nested JSON
- Remove Azure Monitor self-dependency tracking (`AddHttpClientInstrumentation` removed)
- Register telemetry flush on MCP server shutdown

### New Roslyn analyzers (TXC025–TXC029)
| Rule | Severity | What it prevents |
|------|----------|-----------------|
| TXC025 | Warning | Direct `Activity.SetTag/SetStatus/AddEvent` in command code — must use `CommandActivityScope` + `ILogger` |
| TXC026 | Warning | Direct `Process.Start` in command code — must use `CliSubprocessRunner` (catches `SolutionImportCliCommand`) |
| TXC027 | Warning | Mutative commands missing `WriteResult()` — breaks MCP envelope detection |
| TXC028 | Warning | Read-only commands calling `WriteResult()` — should return data, not envelopes |
| TXC029 | Warning | Direct `new CallToolResult` outside `McpToolResultFactory` — breaks content/structuredContent consistency |

TXC010 (description min length) promoted to build error.

## App Insights query examples

```kusto
// Our bugs — must fix
requests | where customDimensions["txc.error_kind"] == "internal"
| project timestamp, name, customDimensions["txc.error_message"]

// What customers struggle with — roadmap intelligence
requests | where customDimensions["txc.error_kind"] == "validation"
| summarize count() by tostring(customDimensions["txc.command"]), tostring(customDimensions["txc.error_message"])
```