### PR TITLE
fix: normalize MCP home-relative paths on all platforms

### DIFF
--- a/src/TALXIS.CLI.MCP/CliSubprocessRunner.cs
+++ b/src/TALXIS.CLI.MCP/CliSubprocessRunner.cs
@@ -105,7 +105,7 @@ internal static class CliSubprocessRunner
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             CreateNoWindow = true,
-            WorkingDirectory = workingDirectory ?? System.Environment.CurrentDirectory
+            WorkingDirectory = McpPathNormalizer.NormalizeOperationalPath(workingDirectory ?? System.Environment.CurrentDirectory)
         };
 
         // Enable structured JSON logging for MCP consumption
@@ -171,11 +171,12 @@ internal static class CliSubprocessRunner
             throw new InvalidOperationException("Could not resolve the TALXIS CLI assembly path.");
         }
 
+        cliAssemblyPath = McpPathNormalizer.NormalizeOperationalPath(cliAssemblyPath);
         string cliDirectory = Path.GetDirectoryName(cliAssemblyPath)
             ?? throw new InvalidOperationException("Could not resolve the TALXIS CLI directory.");
 
         string cliExecutableName = OperatingSystem.IsWindows() ? "TALXIS.CLI.exe" : "TALXIS.CLI";
-        string cliExecutablePath = Path.Combine(cliDirectory, cliExecutableName);
+        string cliExecutablePath = McpPathNormalizer.NormalizeOperationalPath(Path.Combine(cliDirectory, cliExecutableName));
         if (File.Exists(cliExecutablePath))
         {
             return (cliExecutablePath, null);

--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -1,0 +1,60 @@
+namespace TALXIS.CLI.MCP;
+
+internal static class McpPathNormalizer
+{
+    public static string NormalizeOperationalPath(string path, bool allowFileUriLocalPathHome = false)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("Path must not be empty.", nameof(path));
+
+        return Path.GetFullPath(ExpandHomeRelativePath(path, allowFileUriLocalPathHome));
+    }
+
+    internal static string ExpandHomeRelativePath(string path, bool allowFileUriLocalPathHome = false)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return path;
+
+        var suffixStart = GetHomeRelativeSuffixStart(path, allowFileUriLocalPathHome);
+        if (suffixStart < 0)
+            return path;
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            return path;
+
+        var remainder = path[suffixStart..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\', '/');
+        if (string.IsNullOrEmpty(remainder))
+            return home;
+
+        var segments = remainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
+    }
+
+    private static int GetHomeRelativeSuffixStart(string path, bool allowFileUriLocalPathHome)
+    {
+        if (path == "~")
+            return 1;
+
+        if (path.Length >= 2 && path[0] == '~' && IsDirectorySeparator(path[1]))
+            return 2;
+
+        if (!allowFileUriLocalPathHome)
+            return -1;
+
+        if (path.Length == 2 && IsDirectorySeparator(path[0]) && path[1] == '~')
+            return 2;
+
+        // Uri.LocalPath for file:///~/project retains a leading separator, so
+        // accept /~/... here without changing ordinary absolute paths.
+        if (path.Length >= 3 && IsDirectorySeparator(path[0]) && path[1] == '~' && IsDirectorySeparator(path[2]))
+            return 3;
+
+        return -1;
+    }
+
+    private static bool IsDirectorySeparator(char value)
+        => value == Path.DirectorySeparatorChar
+        || value == Path.AltDirectorySeparatorChar
+        || value is '\\' or '/';
+}

--- a/src/TALXIS.CLI.MCP/RootsService.cs
+++ b/src/TALXIS.CLI.MCP/RootsService.cs
@@ -87,7 +87,7 @@ internal sealed class RootsService
         // Windows, converting '/' → '\\', etc.).
         try
         {
-            return Path.GetFullPath(parsed.LocalPath);
+            return McpPathNormalizer.NormalizeOperationalPath(parsed.LocalPath, allowFileUriLocalPathHome: true);
         }
         catch (Exception)
         {

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -12,13 +12,14 @@ public class McpPathNormalizerTests
     public void NormalizeOperationalPath_HomeRelativeInput_ResolvesAgainstUserProfile(string input)
     {
         var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-        Assert.False(string.IsNullOrWhiteSpace(home));
 
         var result = McpPathNormalizer.NormalizeOperationalPath(input);
 
-        var expected = input == "~"
-            ? Path.GetFullPath(home)
-            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        var expected = string.IsNullOrWhiteSpace(home)
+            ? Path.GetFullPath(input)
+            : input == "~"
+                ? Path.GetFullPath(home)
+                : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
         Assert.Equal(expected, result);
     }
 
@@ -28,13 +29,13 @@ public class McpPathNormalizerTests
     public void NormalizeOperationalPath_FileUriLocalHomePath_ResolvesAgainstUserProfile(string input)
     {
         var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-        Assert.False(string.IsNullOrWhiteSpace(home));
 
         var result = McpPathNormalizer.NormalizeOperationalPath(input, allowFileUriLocalPathHome: true);
 
-        Assert.Equal(
-            Path.GetFullPath(Path.Combine(home, "Sources", "project")),
-            result);
+        var expected = string.IsNullOrWhiteSpace(home)
+            ? Path.GetFullPath(input)
+            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        Assert.Equal(expected, result);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -1,0 +1,56 @@
+using TALXIS.CLI.MCP;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.MCP;
+
+public class McpPathNormalizerTests
+{
+    [Theory]
+    [InlineData("~")]
+    [InlineData("~/Sources/project")]
+    [InlineData("~\\Sources\\project")]
+    public void NormalizeOperationalPath_HomeRelativeInput_ResolvesAgainstUserProfile(string input)
+    {
+        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        Assert.False(string.IsNullOrWhiteSpace(home));
+
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+
+        var expected = input == "~"
+            ? Path.GetFullPath(home)
+            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("/~/Sources/project")]
+    [InlineData("\\~\\Sources\\project")]
+    public void NormalizeOperationalPath_FileUriLocalHomePath_ResolvesAgainstUserProfile(string input)
+    {
+        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        Assert.False(string.IsNullOrWhiteSpace(home));
+
+        var result = McpPathNormalizer.NormalizeOperationalPath(input, allowFileUriLocalPathHome: true);
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(home, "Sources", "project")),
+            result);
+    }
+
+    [Fact]
+    public void NormalizeOperationalPath_AbsoluteUnixPath_RemainsAbsolute()
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath("/tmp/project");
+        Assert.Equal(Path.GetFullPath("/tmp/project"), result);
+    }
+
+    [Fact]
+    public void ExpandHomeRelativePath_WithoutFileUriFlag_LeavesSlashTildePathUnchanged()
+    {
+        const string input = "/~/Sources/project";
+
+        var result = McpPathNormalizer.ExpandHomeRelativePath(input);
+
+        Assert.Equal(input, result);
+    }
+}

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -70,14 +70,13 @@ public class RootsServiceTests
     public void ConvertFileUri_HomeRelativePath_ResolvesAgainstUserProfile()
     {
         var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
-        Assert.False(string.IsNullOrWhiteSpace(home));
-
         var result = RootsService.ConvertFileUriToPath("file:///~/Sources/project");
 
         Assert.NotNull(result);
-        Assert.Equal(
-            Path.GetFullPath(Path.Combine(home, "Sources", "project")),
-            result);
+        var expected = string.IsNullOrWhiteSpace(home)
+            ? Path.GetFullPath("/~/Sources/project")
+            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        Assert.Equal(expected, result);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -67,6 +67,20 @@ public class RootsServiceTests
     }
 
     [Fact]
+    public void ConvertFileUri_HomeRelativePath_ResolvesAgainstUserProfile()
+    {
+        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        Assert.False(string.IsNullOrWhiteSpace(home));
+
+        var result = RootsService.ConvertFileUriToPath("file:///~/Sources/project");
+
+        Assert.NotNull(result);
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(home, "Sources", "project")),
+            result);
+    }
+
+    [Fact]
     public void ConvertFileUri_ResultIsFullPath()
     {
         // Path.GetFullPath always returns an absolute path


### PR DESCRIPTION
## Summary
- normalize MCP operational paths before using them as workspace roots or subprocess paths
- handle home-relative inputs like `~`, `~/...`, `~\\...`, and `file:///~/...` against the current user profile
- add regression tests for MCP root conversion and path normalization

## Details
This fixes #125 by keeping `~` handling inside the MCP host's execution boundary instead of relying on shell expansion behavior.

The fix is applied in:
- `RootsService.ConvertFileUriToPath`
- `CliSubprocessRunner`
- new `McpPathNormalizer` helper

## Validation
- `dotnet build TALXIS.CLI.sln --configuration Debug`
- `dotnet test tests/TALXIS.CLI.Tests/TALXIS.CLI.Tests.csproj --configuration Debug --filter "FullyQualifiedName~RootsServiceTests|FullyQualifiedName~McpPathNormalizerTests|FullyQualifiedName~LogRedactionFilterTests"`
- `dotnet test TALXIS.CLI.sln --configuration Debug --no-build`

## Repo scan
I scanned the repo for similar cross-platform path-boundary issues around:
- `Uri.LocalPath` / file URI conversion
- `Assembly.Location` / process startup paths
- `ProcessStartInfo.WorkingDirectory`
- home-directory rewriting / `%USERPROFILE%`

I did not find another same-shape internal bug beyond the MCP root + subprocess path boundary fixed here.
