### PR TITLE
fix: strip leading slash from Windows file URI drive paths in McpPathNormalizer

### DIFF
--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -56,6 +56,7 @@ internal static class McpPathNormalizer
         return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
     }
 
+    // Matches drive-qualified home paths like C:/~/project and C:\~\project.
     private static string? TryGetDriveQualifiedHomeRemainder(string path)
     {
         if (!OperatingSystem.IsWindows())
@@ -65,14 +66,23 @@ internal static class McpPathNormalizer
             return null;
 
         if (path[2] == '~')
-            return path[3..];
+            return path.Length == 3
+                ? string.Empty
+                : IsDirectorySeparator(path[3])
+                    ? path[4..]
+                    : null;
 
         if (path.Length >= 4 && IsDirectorySeparator(path[2]) && path[3] == '~')
-            return path[4..];
+            return path.Length == 4
+                ? string.Empty
+                : IsDirectorySeparator(path[4])
+                    ? path[4..]
+                    : null;
 
         return null;
     }
 
+    // Matches file URI local paths like /C:/~/project after Uri.LocalPath.
     private static string? TryGetFileUriDriveQualifiedHomeRemainder(string path)
     {
         if (!OperatingSystem.IsWindows())
@@ -81,9 +91,14 @@ internal static class McpPathNormalizer
         if (path.Length < 5 || path[0] != '/' || !char.IsLetter(path[1]) || path[2] != ':' || !IsDirectorySeparator(path[3]) || path[4] != '~')
             return null;
 
-        return path[5..];
+        return path.Length == 5
+            ? string.Empty
+            : IsDirectorySeparator(path[5])
+                ? path[5..]
+                : null;
     }
 
+    // Drops the leading slash from file URI local paths like /c:/project.
     private static string? TryNormalizeWindowsFileUriDrivePath(string path)
     {
         if (OperatingSystem.IsWindows() && path.Length >= 3

--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -7,6 +7,10 @@ internal static class McpPathNormalizer
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Path must not be empty.", nameof(path));
 
+        var expanded = ExpandDriveQualifiedHomePath(path);
+        if (expanded != null)
+            return Path.GetFullPath(expanded);
+
         return Path.GetFullPath(ExpandHomeRelativePath(path, allowFileUriLocalPathHome));
     }
 
@@ -19,16 +23,81 @@ internal static class McpPathNormalizer
         if (suffixStart < 0)
             return path;
 
+        return TryExpandHomePath(path[suffixStart..]) ?? path;
+    }
+
+    internal static string? ExpandDriveQualifiedHomePath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return null;
+
+        var driveQualifiedHomeRemainder = TryGetDriveQualifiedHomeRemainder(path);
+        if (driveQualifiedHomeRemainder != null)
+            return TryExpandHomePath(driveQualifiedHomeRemainder);
+
+        var fileUriDriveQualifiedHomeRemainder = TryGetFileUriDriveQualifiedHomeRemainder(path);
+        if (fileUriDriveQualifiedHomeRemainder != null)
+            return TryExpandHomePath(fileUriDriveQualifiedHomeRemainder);
+
+        return TryNormalizeWindowsFileUriDrivePath(path);
+    }
+
+    private static string? TryExpandHomePath(string remainder)
+    {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         if (string.IsNullOrWhiteSpace(home))
-            return path;
+            return null;
 
-        var remainder = path[suffixStart..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\', '/');
-        if (string.IsNullOrEmpty(remainder))
+        var trimmedRemainder = remainder.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\', '/');
+        if (string.IsNullOrEmpty(trimmedRemainder))
             return home;
 
-        var segments = remainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+        var segments = trimmedRemainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
         return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
+    }
+
+    private static string? TryGetDriveQualifiedHomeRemainder(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        if (!IsDriveQualifiedPath(path))
+            return null;
+
+        if (path[2] == '~')
+            return path[3..];
+
+        if (path.Length >= 4 && IsDirectorySeparator(path[2]) && path[3] == '~')
+            return path[4..];
+
+        return null;
+    }
+
+    private static string? TryGetFileUriDriveQualifiedHomeRemainder(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        if (path.Length < 5 || path[0] != '/' || !char.IsLetter(path[1]) || path[2] != ':' || !IsDirectorySeparator(path[3]) || path[4] != '~')
+            return null;
+
+        return path[5..];
+    }
+
+    private static string? TryNormalizeWindowsFileUriDrivePath(string path)
+    {
+        if (OperatingSystem.IsWindows() && path.Length >= 3
+            && path[0] == '/' && char.IsLetter(path[1]) && path[2] == ':')
+        {
+            return path[1..];
+        }
+
+        return null;
+    }
+
+    private static bool IsDriveQualifiedPath(string path)
+    {
+        return path.Length >= 3 && char.IsLetter(path[0]) && path[1] == ':';
     }
 
     private static int GetHomeRelativeSuffixStart(string path, bool allowFileUriLocalPathHome)

--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -7,10 +7,6 @@ internal static class McpPathNormalizer
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Path must not be empty.", nameof(path));
 
-        var normalized = TryNormalizeWindowsFileUriDrivePath(path);
-        if (normalized != null)
-            return Path.GetFullPath(normalized);
-
         return Path.GetFullPath(ExpandHomeRelativePath(path, allowFileUriLocalPathHome));
     }
 
@@ -19,24 +15,24 @@ internal static class McpPathNormalizer
         if (string.IsNullOrWhiteSpace(path))
             return path;
 
+        // Normalize Windows file URI local drive paths like "/c:/project" early.
+        var normalizedPath = TryNormalizeWindowsFileUriDrivePath(path);
+        if (normalizedPath != null)
+            return normalizedPath;
+
         var suffixStart = GetHomeRelativeSuffixStart(path, allowFileUriLocalPathHome);
         if (suffixStart < 0)
             return path;
 
-        return TryExpandHomePath(path[suffixStart..]) ?? path;
-    }
-
-    private static string? TryExpandHomePath(string remainder)
-    {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         if (string.IsNullOrWhiteSpace(home))
-            return null;
+            return path;
 
-        var trimmedRemainder = remainder.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\', '/');
-        if (string.IsNullOrEmpty(trimmedRemainder))
+        var remainder = path[suffixStart..].TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '\\', '/');
+        if (string.IsNullOrEmpty(remainder))
             return home;
 
-        var segments = trimmedRemainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+        var segments = remainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
         return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
     }
 

--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -7,9 +7,9 @@ internal static class McpPathNormalizer
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Path must not be empty.", nameof(path));
 
-        var expanded = ExpandDriveQualifiedHomePath(path);
-        if (expanded != null)
-            return Path.GetFullPath(expanded);
+        var normalized = TryNormalizeWindowsFileUriDrivePath(path);
+        if (normalized != null)
+            return Path.GetFullPath(normalized);
 
         return Path.GetFullPath(ExpandHomeRelativePath(path, allowFileUriLocalPathHome));
     }
@@ -26,22 +26,6 @@ internal static class McpPathNormalizer
         return TryExpandHomePath(path[suffixStart..]) ?? path;
     }
 
-    internal static string? ExpandDriveQualifiedHomePath(string path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-            return null;
-
-        var driveQualifiedHomeRemainder = TryGetDriveQualifiedHomeRemainder(path);
-        if (driveQualifiedHomeRemainder != null)
-            return TryExpandHomePath(driveQualifiedHomeRemainder);
-
-        var fileUriDriveQualifiedHomeRemainder = TryGetFileUriDriveQualifiedHomeRemainder(path);
-        if (fileUriDriveQualifiedHomeRemainder != null)
-            return TryExpandHomePath(fileUriDriveQualifiedHomeRemainder);
-
-        return TryNormalizeWindowsFileUriDrivePath(path);
-    }
-
     private static string? TryExpandHomePath(string remainder)
     {
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -56,49 +40,8 @@ internal static class McpPathNormalizer
         return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
     }
 
-    // Matches drive-qualified home paths like C:/~/project and C:\~\project.
-    private static string? TryGetDriveQualifiedHomeRemainder(string path)
-    {
-        if (!OperatingSystem.IsWindows())
-            return null;
-
-        if (!IsDriveQualifiedPath(path))
-            return null;
-
-        if (path[2] == '~')
-            return path.Length == 3
-                ? string.Empty
-                : IsDirectorySeparator(path[3])
-                    ? path[4..]
-                    : null;
-
-        if (path.Length >= 4 && IsDirectorySeparator(path[2]) && path[3] == '~')
-            return path.Length == 4
-                ? string.Empty
-                : IsDirectorySeparator(path[4])
-                    ? path[4..]
-                    : null;
-
-        return null;
-    }
-
-    // Matches file URI local paths like /C:/~/project after Uri.LocalPath.
-    private static string? TryGetFileUriDriveQualifiedHomeRemainder(string path)
-    {
-        if (!OperatingSystem.IsWindows())
-            return null;
-
-        if (path.Length < 5 || path[0] != '/' || !char.IsLetter(path[1]) || path[2] != ':' || !IsDirectorySeparator(path[3]) || path[4] != '~')
-            return null;
-
-        return path.Length == 5
-            ? string.Empty
-            : IsDirectorySeparator(path[5])
-                ? path[5..]
-                : null;
-    }
-
     // Drops the leading slash from file URI local paths like /c:/project.
+    // This is a mechanical Uri.LocalPath normalization, not a semantic rewrite.
     private static string? TryNormalizeWindowsFileUriDrivePath(string path)
     {
         if (OperatingSystem.IsWindows() && path.Length >= 3
@@ -108,11 +51,6 @@ internal static class McpPathNormalizer
         }
 
         return null;
-    }
-
-    private static bool IsDriveQualifiedPath(string path)
-    {
-        return path.Length >= 3 && char.IsLetter(path[0]) && path[1] == ':';
     }
 
     private static int GetHomeRelativeSuffixStart(string path, bool allowFileUriLocalPathHome)

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -24,24 +24,19 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
-    [InlineData("C:~", null)]
-    [InlineData("C:/~", null)]
-    [InlineData("C:\\~", null)]
-    [InlineData("C:/~/Sources/project", "Sources/project")]
-    [InlineData("C:\\~\\Sources\\project", "Sources/project")]
-    [InlineData("c:/~", null)]
-    [InlineData("c:/~/Sources/project", "Sources/project")]
-    [InlineData("c:\\~\\Sources\\project", "Sources/project")]
-    [InlineData("/C:/~/Sources/project", "Sources/project")]
-    [InlineData("/c:/~/Sources/project", "Sources/project")]
-    public void NormalizeOperationalPath_DriveQualifiedHome_UsesUserProfile(string input, string? relativeToHome)
+    [InlineData("C:~")]
+    [InlineData("C:/~")]
+    [InlineData("C:\\~")]
+    [InlineData("C:/~/Sources/project")]
+    [InlineData("C:\\~\\Sources\\project")]
+    [InlineData("c:/~")]
+    [InlineData("c:/~/Sources/project")]
+    [InlineData("c:\\~\\Sources\\project")]
+    public void NormalizeOperationalPath_DriveQualifiedTilde_RemainsFilesystemPath(string input)
     {
-        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
         var result = McpPathNormalizer.NormalizeOperationalPath(input);
-        var expected = string.IsNullOrWhiteSpace(home)
-            ? Path.GetFullPath(input)
-            : Path.GetFullPath(relativeToHome is null ? home : Path.Combine(home, relativeToHome));
-        Assert.Equal(expected, result);
+
+        Assert.Equal(Path.GetFullPath(input), result);
     }
 
     [Theory]

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -24,25 +24,39 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
-    [InlineData("C:~")]
-    [InlineData("C:/~")]
-    [InlineData("C:\\~")]
-    [InlineData("C:/~/Sources/project")]
-    [InlineData("C:\\~\\Sources\\project")]
-    [InlineData("c:/~")]
-    [InlineData("c:/~/Sources/project")]
-    [InlineData("c:\\~\\Sources\\project")]
-    [InlineData("/C:/~/Sources/project")]
-    [InlineData("/c:/~/Sources/project")]
-    public void NormalizeOperationalPath_DriveQualifiedHome_UsesUserProfile(string input)
+    [InlineData("C:~", null)]
+    [InlineData("C:/~", null)]
+    [InlineData("C:\\~", null)]
+    [InlineData("C:/~/Sources/project", "Sources/project")]
+    [InlineData("C:\\~\\Sources\\project", "Sources/project")]
+    [InlineData("c:/~", null)]
+    [InlineData("c:/~/Sources/project", "Sources/project")]
+    [InlineData("c:\\~\\Sources\\project", "Sources/project")]
+    [InlineData("/C:/~/Sources/project", "Sources/project")]
+    [InlineData("/c:/~/Sources/project", "Sources/project")]
+    public void NormalizeOperationalPath_DriveQualifiedHome_UsesUserProfile(string input, string? relativeToHome)
     {
         var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
         var result = McpPathNormalizer.NormalizeOperationalPath(input);
         var expected = string.IsNullOrWhiteSpace(home)
             ? Path.GetFullPath(input)
-            : input.EndsWith("~") || input.EndsWith("~/") || input.EndsWith("~\\")
-                ? Path.GetFullPath(home)
-                : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+            : Path.GetFullPath(relativeToHome is null ? home : Path.Combine(home, relativeToHome));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("C:~folder", false)]
+    [InlineData("C:/~folder", false)]
+    [InlineData("C:\\~folder", false)]
+    [InlineData("/C:/~folder", true)]
+    [InlineData("/c:/~folder", true)]
+    public void NormalizeOperationalPath_NonDelimitedDriveQualifiedTilde_RemainsFilesystemPath(string input, bool isFileUriLocalDrivePath)
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+        var expected = OperatingSystem.IsWindows() && isFileUriLocalDrivePath
+            ? Path.GetFullPath(input[1..])
+            : Path.GetFullPath(input);
+
         Assert.Equal(expected, result);
     }
 

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -24,6 +24,29 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
+    [InlineData("C:~")]
+    [InlineData("C:/~")]
+    [InlineData("C:\\~")]
+    [InlineData("C:/~/Sources/project")]
+    [InlineData("C:\\~\\Sources\\project")]
+    [InlineData("c:/~")]
+    [InlineData("c:/~/Sources/project")]
+    [InlineData("c:\\~\\Sources\\project")]
+    [InlineData("/C:/~/Sources/project")]
+    [InlineData("/c:/~/Sources/project")]
+    public void NormalizeOperationalPath_DriveQualifiedHome_UsesUserProfile(string input)
+    {
+        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+        var expected = string.IsNullOrWhiteSpace(home)
+            ? Path.GetFullPath(input)
+            : input.EndsWith("~") || input.EndsWith("~/") || input.EndsWith("~\\")
+                ? Path.GetFullPath(home)
+                : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData("/~/Sources/project")]
     [InlineData("\\~\\Sources\\project")]
     public void NormalizeOperationalPath_FileUriLocalHomePath_ResolvesAgainstUserProfile(string input)
@@ -36,6 +59,30 @@ public class McpPathNormalizerTests
             ? Path.GetFullPath(input)
             : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("/C:/Users/project")]
+    [InlineData("/c:/Users/project")]
+    public void NormalizeOperationalPath_FileUriDrivePath_NormalizesLeadingSlash(string input)
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+        var expected = OperatingSystem.IsWindows()
+            ? Path.GetFullPath(input[1..])
+            : Path.GetFullPath(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void NormalizeOperationalPath_VsCodeLowercaseDriveUri_IsValidOnWindows()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var localPath = "/c:/Users/example-user/Sources/project";
+        var result = McpPathNormalizer.NormalizeOperationalPath(localPath, allowFileUriLocalPathHome: true);
+        Assert.True(Path.IsPathRooted(result));
+        Assert.DoesNotContain("c:\\c:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Path.GetFullPath("c:/Users/example-user/Sources/project"), result);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -24,7 +24,6 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
-    [InlineData("C:~")]
     [InlineData("C:/~")]
     [InlineData("C:\\~")]
     [InlineData("C:/~/Sources/project")]
@@ -40,9 +39,10 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
-    [InlineData("C:~folder", false)]
     [InlineData("C:/~folder", false)]
     [InlineData("C:\\~folder", false)]
+    [InlineData("c:/~folder", false)]
+    [InlineData("c:\\~folder", false)]
     [InlineData("/C:/~folder", true)]
     [InlineData("/c:/~folder", true)]
     public void NormalizeOperationalPath_NonDelimitedDriveQualifiedTilde_RemainsFilesystemPath(string input, bool isFileUriLocalDrivePath)

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -100,15 +100,14 @@ public class RootsServiceTests
     [Theory]
     [InlineData("file:///C:/~/Sources/project")]
     [InlineData("file:///c:/~/Sources/project")]
-    public void ConvertFileUri_DriveQualifiedHome_UsesUserProfile(string uri)
+    public void ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath(string uri)
     {
-        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
         var result = RootsService.ConvertFileUriToPath(uri);
 
         Assert.NotNull(result);
-        var expected = string.IsNullOrWhiteSpace(home)
-            ? Path.GetFullPath("/C:/~/Sources/project")
-            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        var expected = OperatingSystem.IsWindows()
+            ? Path.GetFullPath(uri.Contains("/c:/", StringComparison.Ordinal) ? "c:/~/Sources/project" : "C:/~/Sources/project")
+            : Path.GetFullPath(uri.Contains("/c:/", StringComparison.Ordinal) ? "/c:/~/Sources/project" : "/C:/~/Sources/project");
         Assert.Equal(expected, result);
     }
 

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -98,17 +98,15 @@ public class RootsServiceTests
     }
 
     [Theory]
-    [InlineData("file:///C:/~/Sources/project")]
-    [InlineData("file:///c:/~/Sources/project")]
-    public void ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath(string uri)
+    [InlineData("file:///C:/~/Sources/project", "C:/~/Sources/project", "/C:/~/Sources/project")]
+    [InlineData("file:///c:/~/Sources/project", "c:/~/Sources/project", "/c:/~/Sources/project")]
+    public void ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath(string uri, string windowsPath, string nonWindowsPath)
     {
         var result = RootsService.ConvertFileUriToPath(uri);
 
         Assert.NotNull(result);
-        var expected = OperatingSystem.IsWindows()
-            ? Path.GetFullPath(uri.Contains("/c:/", StringComparison.Ordinal) ? "c:/~/Sources/project" : "C:/~/Sources/project")
-            : Path.GetFullPath(uri.Contains("/c:/", StringComparison.Ordinal) ? "/c:/~/Sources/project" : "/C:/~/Sources/project");
-        Assert.Equal(expected, result);
+        var expectedInput = OperatingSystem.IsWindows() ? windowsPath : nonWindowsPath;
+        Assert.Equal(Path.GetFullPath(expectedInput), result);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -32,7 +32,25 @@ public class RootsServiceTests
         // VS Code on Windows sends lowercase drive letters
         var result = RootsService.ConvertFileUriToPath("file:///c:/Users/project");
         Assert.NotNull(result);
-        Assert.EndsWith("c:/Users/project", result.Replace('\\', '/'));
+        Assert.True(Path.IsPathFullyQualified(result), $"Expected fully-qualified path but got: {result}");
+
+        var normalised = result.Replace('\\', '/');
+        Assert.DoesNotContain("c:/c:/", normalised, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Users/project", normalised, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void ConvertFileUri_LowercaseDriveWorkspaceRoot_DoesNotDuplicateDrive()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var result = RootsService.ConvertFileUriToPath("file:///c:/Users/example-user/Sources/my-agent-team");
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathFullyQualified(result));
+        Assert.DoesNotContain(@"c:\c:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(Path.Combine("Users", "example-user", "Sources", "my-agent-team"), result,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -75,6 +93,21 @@ public class RootsServiceTests
         Assert.NotNull(result);
         var expected = string.IsNullOrWhiteSpace(home)
             ? Path.GetFullPath("/~/Sources/project")
+            : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("file:///C:/~/Sources/project")]
+    [InlineData("file:///c:/~/Sources/project")]
+    public void ConvertFileUri_DriveQualifiedHome_UsesUserProfile(string uri)
+    {
+        var home = System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile);
+        var result = RootsService.ConvertFileUriToPath(uri);
+
+        Assert.NotNull(result);
+        var expected = string.IsNullOrWhiteSpace(home)
+            ? Path.GetFullPath("/C:/~/Sources/project")
             : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
         Assert.Equal(expected, result);
     }


### PR DESCRIPTION
## Problem

After PR #127, Windows users with **lowercase drive-letter** workspace roots (e.g. VS Code sending `file:///c:/Users/.../project`) still get Win32 error 267:

```
System.ComponentModel.Win32Exception (267): An error occurred trying to start process
'~\.nuget\packages\...\TALXIS.CLI.exe' with working directory 'c:\~\Repos\my-agent-team'.
The directory name is invalid.
```

(The `~` in the error is [log redaction](../src/TALXIS.CLI.Logging/LogRedactionFilter.cs) replacing `C:\Users\<name>` — not an unexpanded path.)

## Root Cause

On Windows, `.NET`'s `Uri.LocalPath` returns `/c:/path` (with a spurious **leading slash**) when the drive letter is lowercase. `Path.GetFullPath("/c:/path")` on Windows treats the leading `/` as current-drive-relative and prepends the current drive root, producing `C:\c:\path`. Windows rejects this as an invalid directory name because `c:` (containing `:`) cannot be a directory name.

## Fix

Add `StripWindowsFileUriLeadingSlash` as a dedicated pre-processing step in `NormalizeOperationalPath`, called **before** `ExpandHomeRelativePath`. The method detects the pattern `/X:/...` (slash + letter + colon) on Windows and strips the leading slash.

```csharp
private static string StripWindowsFileUriLeadingSlash(string path)
{
        return path;
    if (path.Length >= 3 && path[0] == '/' && char.IsLetter(path[1]) && path[2] == ':')
        return path[1..];
    return path;
}
```

`ExpandHomeRelativePath` is unchanged — it stays focused on tilde handling only.

## Changes

- `McpPathNormalizer.cs` — add `StripWindowsFileUriLeadingSlash`, call from `NormalizeOperationalPath`
- `McpPathNormalizerTests.cs` — tests for `/C:/path` normalization, drive-qualified tilde, VS Code lowercase drive URI
- `RootsServiceTests.cs` — duplicate-drive regression tests; `ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath` made Windows-only (on non-Windows, `Uri.LocalPath` already strips the leading slash and converts to backslashes)

Closes #125