### PR TITLE
fix: strip leading slash from Windows file URI drive paths in McpPathNormalizer

### DIFF
--- a/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
+++ b/src/TALXIS.CLI.MCP/McpPathNormalizer.cs
@@ -7,6 +7,11 @@ internal static class McpPathNormalizer
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Path must not be empty.", nameof(path));
 
+        // Strip the spurious leading '/' that Uri.LocalPath prepends to Windows
+        // drive-letter paths (e.g. /c:/path → c:/path). Path.GetFullPath would
+        // otherwise treat it as current-drive-relative and produce c:\c:\path.
+        path = StripWindowsFileUriLeadingSlash(path);
+
         return Path.GetFullPath(ExpandHomeRelativePath(path, allowFileUriLocalPathHome));
     }
 
@@ -29,6 +34,18 @@ internal static class McpPathNormalizer
 
         var segments = remainder.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
         return segments.Length == 0 ? home : Path.Combine([home, .. segments]);
+    }
+
+    // Strips the leading '/' from Windows file URI drive paths (e.g. /c:/path → c:/path).
+    // Uri.LocalPath always prepends a slash on Windows; Path.GetFullPath would otherwise
+    // treat it as current-drive-relative and produce a duplicate c:\c:\ prefix.
+    private static string StripWindowsFileUriLeadingSlash(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            return path;
+        if (path.Length >= 3 && path[0] == '/' && char.IsLetter(path[1]) && path[2] == ':')
+            return path[1..];
+        return path;
     }
 
     private static int GetHomeRelativeSuffixStart(string path, bool allowFileUriLocalPathHome)

--- a/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/McpPathNormalizerTests.cs
@@ -24,6 +24,38 @@ public class McpPathNormalizerTests
     }
 
     [Theory]
+    [InlineData("C:/~")]
+    [InlineData("C:\\~")]
+    [InlineData("C:/~/Sources/project")]
+    [InlineData("C:\\~\\Sources\\project")]
+    [InlineData("c:/~")]
+    [InlineData("c:/~/Sources/project")]
+    [InlineData("c:\\~\\Sources\\project")]
+    public void NormalizeOperationalPath_DriveQualifiedTilde_RemainsFilesystemPath(string input)
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+
+        Assert.Equal(Path.GetFullPath(input), result);
+    }
+
+    [Theory]
+    [InlineData("C:/~folder", false)]
+    [InlineData("C:\\~folder", false)]
+    [InlineData("c:/~folder", false)]
+    [InlineData("c:\\~folder", false)]
+    [InlineData("/C:/~folder", true)]
+    [InlineData("/c:/~folder", true)]
+    public void NormalizeOperationalPath_NonDelimitedDriveQualifiedTilde_RemainsFilesystemPath(string input, bool isFileUriLocalDrivePath)
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+        var expected = OperatingSystem.IsWindows() && isFileUriLocalDrivePath
+            ? Path.GetFullPath(input[1..])
+            : Path.GetFullPath(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData("/~/Sources/project")]
     [InlineData("\\~\\Sources\\project")]
     public void NormalizeOperationalPath_FileUriLocalHomePath_ResolvesAgainstUserProfile(string input)
@@ -36,6 +68,30 @@ public class McpPathNormalizerTests
             ? Path.GetFullPath(input)
             : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("/C:/Users/project")]
+    [InlineData("/c:/Users/project")]
+    public void NormalizeOperationalPath_FileUriDrivePath_NormalizesLeadingSlash(string input)
+    {
+        var result = McpPathNormalizer.NormalizeOperationalPath(input);
+        var expected = OperatingSystem.IsWindows()
+            ? Path.GetFullPath(input[1..])
+            : Path.GetFullPath(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void NormalizeOperationalPath_VsCodeLowercaseDriveUri_IsValidOnWindows()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        var localPath = "/c:/Users/example-user/Sources/project";
+        var result = McpPathNormalizer.NormalizeOperationalPath(localPath, allowFileUriLocalPathHome: true);
+        Assert.True(Path.IsPathRooted(result));
+        Assert.DoesNotContain("c:\\c:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Path.GetFullPath("c:/Users/example-user/Sources/project"), result);
     }
 
     [Fact]

--- a/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/RootsServiceTests.cs
@@ -32,7 +32,25 @@ public class RootsServiceTests
         // VS Code on Windows sends lowercase drive letters
         var result = RootsService.ConvertFileUriToPath("file:///c:/Users/project");
         Assert.NotNull(result);
-        Assert.EndsWith("c:/Users/project", result.Replace('\\', '/'));
+        Assert.True(Path.IsPathFullyQualified(result), $"Expected fully-qualified path but got: {result}");
+
+        var normalised = result.Replace('\\', '/');
+        Assert.DoesNotContain("c:/c:/", normalised, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Users/project", normalised, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void ConvertFileUri_LowercaseDriveWorkspaceRoot_DoesNotDuplicateDrive()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var result = RootsService.ConvertFileUriToPath("file:///c:/Users/example-user/Sources/my-agent-team");
+        Assert.NotNull(result);
+        Assert.True(Path.IsPathFullyQualified(result));
+        Assert.DoesNotContain(@"c:\c:", result, StringComparison.OrdinalIgnoreCase);
+        Assert.EndsWith(Path.Combine("Users", "example-user", "Sources", "my-agent-team"), result,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -77,6 +95,23 @@ public class RootsServiceTests
             ? Path.GetFullPath("/~/Sources/project")
             : Path.GetFullPath(Path.Combine(home, "Sources", "project"));
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("file:///C:/~/Sources/project", "C:/~/Sources/project")]
+    [InlineData("file:///c:/~/Sources/project", "c:/~/Sources/project")]
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    public void ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath(string uri, string windowsPath)
+    {
+        // Windows drive-letter URIs (file:///C:/...) are Windows-only;
+        // on non-Windows, Uri.LocalPath already returns a backslash-separated
+        // relative path (C:\...) which Path.GetFullPath resolves against cwd.
+        if (!OperatingSystem.IsWindows()) return;
+
+        var result = RootsService.ConvertFileUriToPath(uri);
+
+        Assert.NotNull(result);
+        Assert.Equal(Path.GetFullPath(windowsPath), result);
     }
 
     [Fact]


### PR DESCRIPTION
Supersedes #132 (refactored before merge — see comment there for explanation).

## Problem

After PR #127, Windows users with **lowercase drive-letter** workspace roots (e.g. VS Code sending `file:///c:/Users/.../project`) still get Win32 error 267:

```
System.ComponentModel.Win32Exception (267): An error occurred trying to start process
'~\.nuget\packages\...\TALXIS.CLI.exe' with working directory 'c:\~\Repos\my-agent-team'.
The directory name is invalid.
```

(The `~` in the error is [log redaction](src/TALXIS.CLI.Logging/LogRedactionFilter.cs) replacing `C:\Users\<name>` — not an unexpanded path.)

## Root Cause

On Windows, `.NET`'s `Uri.LocalPath` returns `/c:/path` (with a spurious **leading slash**) when the drive letter is lowercase. `Path.GetFullPath("/c:/path")` on Windows treats the leading `/` as current-drive-relative and prepends the current drive root, producing `C:\c:\path`. Windows rejects this as an invalid directory name because `c:` (containing `:`) cannot be a directory name.

## Fix

Add `StripWindowsFileUriLeadingSlash` as a dedicated pre-processing step in `NormalizeOperationalPath`, called **before** `ExpandHomeRelativePath`. The method detects the pattern `/X:/...` (slash + letter + colon) on Windows and strips the leading slash.

```csharp
private static string StripWindowsFileUriLeadingSlash(string path)
{
        return path;
    if (path.Length >= 3 && path[0] == '/' && char.IsLetter(path[1]) && path[2] == ':')
        return path[1..];
    return path;
}
```

`ExpandHomeRelativePath` is unchanged — it stays focused on tilde handling only.

## Changes

- `McpPathNormalizer.cs` — add `StripWindowsFileUriLeadingSlash`, call from `NormalizeOperationalPath`
- `McpPathNormalizerTests.cs` — tests for `/C:/path` normalization, drive-qualified tilde, VS Code lowercase drive URI
- `RootsServiceTests.cs` — duplicate-drive regression tests; `ConvertFileUri_DriveQualifiedHome_RemainsFilesystemPath` made Windows-only (on non-Windows, `Uri.LocalPath` already strips the leading slash and converts to backslashes)

Closes #125