### PR TITLE
Add: support for formula definition in attribute creation options and…

### DIFF
--- a/src/TALXIS.CLI.Core/Contracts/Dataverse/CreateAttributeOptions.cs
+++ b/src/TALXIS.CLI.Core/Contracts/Dataverse/CreateAttributeOptions.cs
@@ -82,4 +82,9 @@ public sealed record CreateAttributeOptions
     public bool IsAuditable { get; init; }
     public bool IsSearchable { get; init; } = true;
     public bool IsSecured { get; init; }
+
+    // === Formula ===
+
+    /// <summary>Power Fx formula expression. When set, SourceType is set to 3 (Formula). Supported base types: string, number, decimal, float, money, bool, datetime, choice, multichoice.</summary>
+    public string? FormulaDefinition { get; init; }
 }

--- a/src/TALXIS.CLI.Features.Environment/Entity/AttributeTypeRegistry.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/AttributeTypeRegistry.cs
@@ -22,7 +22,7 @@ public static class AttributeTypeRegistry
     public static IReadOnlyList<string> SharedParameterNames { get; } = new[]
     {
         "entity", "name", "display-name", "description", "required", "solution",
-        "is-auditable", "is-searchable", "is-secured"
+        "is-auditable", "is-searchable", "is-secured", "formula-definition"
     };
 
     private static ReadOnlyCollection<AttributeTypeInfo> BuildAllTypes()

--- a/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Entity/EntityAttributeCreateCliCommand.cs
@@ -32,7 +32,7 @@ public class EntityAttributeCreateCliCommand : StagedCliCommand
     [CliOption(Name = "--name", Description = "Schema name for the new column.", Required = true)]
     public string Name { get; set; } = null!;
 
-    [CliOption(Name = "--type", Description = "Column type: string, memo, number, decimal, float, money, bool, datetime, choice, multichoice, lookup, polymorphic-lookup, customer, image, file, bigint.", Required = true)]
+    [CliOption(Name = "--type", Description = "Column type: string, memo, number, decimal, float, money, bool, datetime, choice, multichoice, lookup, polymorphic-lookup, customer, image, file, bigint. Add --formula-definition to make any supported type a formula column.", Required = true)]
     public AttributeTypeArg Type { get; set; }
 
     // === Optional for all types ===
@@ -134,6 +134,11 @@ public class EntityAttributeCreateCliCommand : StagedCliCommand
     [DefaultValue(true)]
     public bool CanStoreFullImage { get; set; } = true;
 
+    // === Formula ===
+
+    [CliOption(Name = "--formula-definition", Description = "Power Fx formula expression. When provided, creates the column as a formula field (SourceType=3). Supported types: string, number, decimal, float, money, bool, datetime, choice, multichoice.", Required = false)]
+    public string? FormulaDefinition { get; set; }
+
     protected override async Task<int> ExecuteAsync()
     {
         ValidateExecutionMode();
@@ -177,6 +182,7 @@ public class EntityAttributeCreateCliCommand : StagedCliCommand
                     ["cascadeDelete"] = options.CascadeDelete,
                     ["maxSizeKb"] = options.MaxSizeKb,
                     ["canStoreFullImage"] = options.CanStoreFullImage,
+                    ["formulaDefinition"] = options.FormulaDefinition,
                     ["isAuditable"] = options.IsAuditable,
                     ["isSearchable"] = options.IsSearchable,
                     ["isSecured"] = options.IsSecured
@@ -272,6 +278,9 @@ public class EntityAttributeCreateCliCommand : StagedCliCommand
             // Image/File
             MaxSizeKb = MaxSizeKb,
             CanStoreFullImage = CanStoreFullImage,
+
+            // Formula
+            FormulaDefinition = FormulaDefinition,
 
             // Shared metadata properties
             IsAuditable = IsAuditable,

--- a/src/TALXIS.CLI.Platform.Dataverse.Application/Services/DataverseEntityMetadataService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Application/Services/DataverseEntityMetadataService.cs
@@ -145,7 +145,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
         switch (options.Type)
         {
             case "string":
-                await ExecuteCreateAttribute(conn, options, new StringAttributeMetadata
+                var strMeta = new StringAttributeMetadata
                 {
                     SchemaName = options.SchemaName,
                     DisplayName = displayLabel,
@@ -153,7 +153,9 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                     RequiredLevel = requiredLevel,
                     MaxLength = options.MaxLength ?? 200,
                     FormatName = options.StringFormat is not null ? MapStringFormat(options.StringFormat) : StringFormatName.Text
-                }, ct).ConfigureAwait(false);
+                };
+                if (options.FormulaDefinition is not null) { strMeta.SourceType = 3; strMeta.FormulaDefinition = options.FormulaDefinition; }
+                await ExecuteCreateAttribute(conn, options, strMeta, ct).ConfigureAwait(false);
                 break;
 
             case "memo":
@@ -178,6 +180,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                 if (options.MinValue.HasValue) intMeta.MinValue = (int)options.MinValue.Value;
                 if (options.MaxValue.HasValue) intMeta.MaxValue = (int)options.MaxValue.Value;
                 if (options.NumberFormat.HasValue()) intMeta.Format = MapIntegerFormat(options.NumberFormat!);
+                if (options.FormulaDefinition is not null) { intMeta.SourceType = 3; intMeta.FormulaDefinition = options.FormulaDefinition; }
                 await ExecuteCreateAttribute(conn, options, intMeta, ct).ConfigureAwait(false);
                 break;
 
@@ -192,6 +195,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                 if (options.MinValue.HasValue) decMeta.MinValue = (decimal)options.MinValue.Value;
                 if (options.MaxValue.HasValue) decMeta.MaxValue = (decimal)options.MaxValue.Value;
                 if (options.Precision.HasValue) decMeta.Precision = options.Precision.Value;
+                if (options.FormulaDefinition is not null) { decMeta.SourceType = 3; decMeta.FormulaDefinition = options.FormulaDefinition; }
                 await ExecuteCreateAttribute(conn, options, decMeta, ct).ConfigureAwait(false);
                 break;
 
@@ -206,6 +210,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                 if (options.MinValue.HasValue) dblMeta.MinValue = options.MinValue.Value;
                 if (options.MaxValue.HasValue) dblMeta.MaxValue = options.MaxValue.Value;
                 if (options.Precision.HasValue) dblMeta.Precision = options.Precision.Value;
+                if (options.FormulaDefinition is not null) { dblMeta.SourceType = 3; dblMeta.FormulaDefinition = options.FormulaDefinition; }
                 await ExecuteCreateAttribute(conn, options, dblMeta, ct).ConfigureAwait(false);
                 break;
 
@@ -221,11 +226,12 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                 if (options.MaxValue.HasValue) moneyMeta.MaxValue = options.MaxValue.Value;
                 if (options.Precision.HasValue) moneyMeta.Precision = options.Precision.Value;
                 if (options.PrecisionSource.HasValue) moneyMeta.PrecisionSource = options.PrecisionSource.Value;
+                if (options.FormulaDefinition is not null) { moneyMeta.SourceType = 3; moneyMeta.FormulaDefinition = options.FormulaDefinition; }
                 await ExecuteCreateAttribute(conn, options, moneyMeta, ct).ConfigureAwait(false);
                 break;
 
             case "bool":
-                await ExecuteCreateAttribute(conn, options, new BooleanAttributeMetadata
+                var boolMeta = new BooleanAttributeMetadata
                 {
                     SchemaName = options.SchemaName,
                     DisplayName = displayLabel,
@@ -234,7 +240,9 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                     OptionSet = new BooleanOptionSetMetadata(
                         new OptionMetadata(new Label(options.TrueLabel, 1033), 1),
                         new OptionMetadata(new Label(options.FalseLabel, 1033), 0))
-                }, ct).ConfigureAwait(false);
+                };
+                if (options.FormulaDefinition is not null) { boolMeta.SourceType = 3; boolMeta.FormulaDefinition = options.FormulaDefinition; }
+                await ExecuteCreateAttribute(conn, options, boolMeta, ct).ConfigureAwait(false);
                 break;
 
             case "datetime":
@@ -248,6 +256,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
                 };
                 if (options.DateTimeBehavior is not null)
                     dtMeta.DateTimeBehavior = MapDateTimeBehavior(options.DateTimeBehavior);
+                if (options.FormulaDefinition is not null) { dtMeta.SourceType = 3; dtMeta.FormulaDefinition = options.FormulaDefinition; }
                 await ExecuteCreateAttribute(conn, options, dtMeta, ct).ConfigureAwait(false);
                 break;
 
@@ -919,6 +928,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
             picklistMeta.OptionSet = BuildLocalOptionSet(options);
         }
 
+        if (options.FormulaDefinition is not null) { picklistMeta.SourceType = 3; picklistMeta.FormulaDefinition = options.FormulaDefinition; }
         await ExecuteCreateAttribute(conn, options, picklistMeta, ct).ConfigureAwait(false);
     }
 
@@ -944,6 +954,7 @@ internal sealed class DataverseEntityMetadataService : IDataverseEntityMetadataS
             multiMeta.OptionSet = BuildLocalOptionSet(options);
         }
 
+        if (options.FormulaDefinition is not null) { multiMeta.SourceType = 3; multiMeta.FormulaDefinition = options.FormulaDefinition; }
         await ExecuteCreateAttribute(conn, options, multiMeta, ct).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
This pull request introduces support for creating formula columns using Power Fx expressions in the CLI for Dataverse entity attributes. It adds a new `--formula-definition` option, updates the relevant data structures and command-line interface, and ensures that the formula is applied to all supported attribute types during attribute creation.

**Formula column support:**

* Added a new `FormulaDefinition` property to `CreateAttributeOptions`, allowing users to specify a Power Fx formula when creating an attribute.
* Updated the CLI command (`EntityAttributeCreateCliCommand`) to include a `--formula-definition` option, and documented its usage in the `--type` option description. [[1]](diffhunk://#diff-6617d620088b2da9f70ef9ad70332d566b308dc535df3a9bfbef6ac4802c1d7fL35-R35) [[2]](diffhunk://#diff-6617d620088b2da9f70ef9ad70332d566b308dc535df3a9bfbef6ac4802c1d7fR137-R141)
* Included `formula-definition` in the list of shared parameter names in `AttributeTypeRegistry`.

**Attribute creation logic:**

* Modified the attribute creation logic in `DataverseEntityMetadataService` to set the `SourceType` to 3 (Formula) and assign the formula definition for all supported types (string, number, decimal, float, money, bool, datetime, choice, multichoice) when the formula is provided. [[1]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbL148-R158) [[2]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR183) [[3]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR198) [[4]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR213) [[5]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR229-R234) [[6]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbL237-R245) [[7]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR259) [[8]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR931) [[9]](diffhunk://#diff-b9b8a17b326fc68785cd3b4d810ade70b445404a3255a151dd4a3ffed3c142dbR957)
* Passed the formula definition through the CLI command execution and attribute creation pipeline, ensuring it is available wherever needed. [[1]](diffhunk://#diff-6617d620088b2da9f70ef9ad70332d566b308dc535df3a9bfbef6ac4802c1d7fR185) [[2]](diffhunk://#diff-6617d620088b2da9f70ef9ad70332d566b308dc535df3a9bfbef6ac4802c1d7fR282-R284)

These changes enable users to create formula columns directly from the CLI, enhancing the flexibility and power of the Dataverse attribute creation workflow.… registry