### PR TITLE
fix: default PublishWorkflows to true; fix SmartDiff for Update path

### DIFF
--- a/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Solution/SolutionImportCliCommand.cs
@@ -32,8 +32,9 @@ public class SolutionImportCliCommand : ProfiledCliCommand
     [CliOption(Name = "--force-overwrite", Description = "Overwrite unmanaged customizations (disables SmartDiff).", Required = false)]
     public bool ForceOverwrite { get; set; }
 
-    [CliOption(Name = "--publish-workflows", Description = "Activate workflows after import.", Required = false)]
-    public bool PublishWorkflows { get; set; }
+    [CliOption(Name = "--publish-workflows", Description = "Activate plugin steps and classic workflows during import (PublishWorkflows). Defaults to true.", Required = false)]
+    [DefaultValue(true)]
+    public bool PublishWorkflows { get; set; } = true;
 
     [CliOption(Name = "--skip-dependency-check", Description = "Skip product-update dependency checks.", Required = false)]
     public bool SkipDependencyCheck { get; set; }

--- a/src/TALXIS.CLI.Platform.Dataverse.Application/Sdk/SolutionImporter.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Application/Sdk/SolutionImporter.cs
@@ -99,11 +99,11 @@ public sealed class SolutionImporter
     }
 
     /// <summary>
-    /// Whether SmartDiff is expected to apply for the chosen path + options. SmartDiff only
-    /// applies on the upgrade path when force-overwrite is off.
+    /// Whether SmartDiff is expected to apply for the chosen path + options. SmartDiff applies
+    /// on both Update and single-step Upgrade paths when force-overwrite is off.
     /// </summary>
     public static bool SmartDiffExpected(SolutionImportPath path, bool forceOverwrite)
-        => path == SolutionImportPath.Upgrade && !forceOverwrite;
+        => (path == SolutionImportPath.Upgrade || path == SolutionImportPath.Update) && !forceOverwrite;
 
     public async Task<SolutionInfo?> GetExistingSolutionAsync(string uniqueName, CancellationToken cancellationToken = default)
     {

--- a/tests/TALXIS.CLI.Tests/Environment/Platforms/Dataverse/SolutionImporterPathSelectionTests.cs
+++ b/tests/TALXIS.CLI.Tests/Environment/Platforms/Dataverse/SolutionImporterPathSelectionTests.cs
@@ -48,11 +48,12 @@ public class SolutionImporterPathSelectionTests
     }
 
     [Fact]
-    public void SmartDiffExpected_IsTrue_OnlyForUpgradeWithoutForceOverwrite()
+    public void SmartDiffExpected_IsTrue_ForUpgradeAndUpdateWithoutForceOverwrite()
     {
         Assert.True(SolutionImporter.SmartDiffExpected(SolutionImportPath.Upgrade, forceOverwrite: false));
         Assert.False(SolutionImporter.SmartDiffExpected(SolutionImportPath.Upgrade, forceOverwrite: true));
-        Assert.False(SolutionImporter.SmartDiffExpected(SolutionImportPath.Update, forceOverwrite: false));
+        Assert.True(SolutionImporter.SmartDiffExpected(SolutionImportPath.Update, forceOverwrite: false));
+        Assert.False(SolutionImporter.SmartDiffExpected(SolutionImportPath.Update, forceOverwrite: true));
         Assert.False(SolutionImporter.SmartDiffExpected(SolutionImportPath.Install, forceOverwrite: false));
     }
 


### PR DESCRIPTION
## Summary

Analysed the PAC CLI to understand what `--activate-plugins` actually does under the hood.

### Findings

- `--activate-plugins` in PAC maps directly to `PublishWorkflows` in the Dataverse API (`ImportSolutionRequest` / `StageAndUpgradeRequest`). There is **no separate API switch** for plugin steps vs classic workflow processes — `PublishWorkflows` controls both.
- Our `--publish-workflows` flag was already wired correctly, but defaulted to `false`, silently leaving all plugin steps and workflows deactivated after every import.
- SmartDiff applies to **both Update and single-step Upgrade** paths (confirmed by PAC source and the [making-solution-imports-fast](https://blog.networg.com/making-solution-imports-fast/) post). Our `SmartDiffExpected()` helper was incorrectly reporting `false` for the Update path.

### Changes

| File | Change |
|------|--------|
| `SolutionImportCliCommand.cs` | Default `--publish-workflows` to `true`; clarify description to mention both plugin steps and classic workflows |
| `SolutionImporter.cs` | `SmartDiffExpected()` now returns `true` for Update and Upgrade (not just Upgrade) |
| `SolutionImporterPathSelectionTests.cs` | Updated test to assert Update path also expects SmartDiff |