### PR TITLE
feat: add device code auth and vault auto-fallback for Codespaces / browser-isolated Linux

### DIFF
--- a/src/TALXIS.CLI.Core/Abstractions/IBrowserAvailabilityProbe.cs
+++ b/src/TALXIS.CLI.Core/Abstractions/IBrowserAvailabilityProbe.cs
@@ -1,0 +1,25 @@
+namespace TALXIS.CLI.Core.Abstractions;
+
+/// <summary>
+/// Reports whether the current environment can launch a local browser that
+/// receives OAuth <c>http://localhost</c> redirects. Environments like
+/// browser-based GitHub Codespaces, SSH sessions, and headless Linux containers
+/// are interactive (TTY present) but "browser-isolated" — the user must use
+/// device code flow instead of interactive browser login.
+/// </summary>
+/// <remarks>
+/// This is distinct from <see cref="IHeadlessDetector"/> which determines
+/// whether a human is present at all. A process can be non-headless (TTY
+/// available, human present) yet still browser-isolated.
+/// </remarks>
+public interface IBrowserAvailabilityProbe
+{
+    /// <summary>
+    /// <c>true</c> when the environment can open a browser that successfully
+    /// receives the <c>http://localhost</c> redirect after Entra sign-in.
+    /// </summary>
+    bool IsBrowserAvailable { get; }
+
+    /// <summary>Human-readable reason when <see cref="IsBrowserAvailable"/> is false.</summary>
+    string? UnavailableReason { get; }
+}

--- a/src/TALXIS.CLI.Core/Abstractions/IDeviceCodeLoginService.cs
+++ b/src/TALXIS.CLI.Core/Abstractions/IDeviceCodeLoginService.cs
@@ -1,0 +1,29 @@
+using TALXIS.CLI.Core.Model;
+
+namespace TALXIS.CLI.Core.Abstractions;
+
+/// <summary>
+/// Performs a device code sign-in against Entra. The user is presented with
+/// a URL and a code to enter on another device (or browser tab), making this
+/// suitable for browser-isolated environments like GitHub Codespaces, SSH
+/// sessions, or containers without a desktop.
+/// </summary>
+/// <remarks>
+/// Semantically equivalent to <see cref="IInteractiveLoginService"/> but
+/// does not require a local browser or <c>http://localhost</c> redirect.
+/// The resulting token is persisted identically to an interactive browser
+/// credential (same MSAL token cache, same silent renewal path).
+/// </remarks>
+public interface IDeviceCodeLoginService
+{
+    /// <param name="tenantId">
+    /// Optional Entra tenant id or domain. When <c>null</c>, the
+    /// <c>organizations</c> endpoint is used and the tenant is inferred
+    /// from whichever account the user picks.
+    /// </param>
+    /// <param name="cloud">Sovereign cloud for the authority URL.</param>
+    Task<InteractiveLoginResult> LoginAsync(
+        string? tenantId,
+        CloudInstance cloud,
+        CancellationToken ct);
+}

--- a/src/TALXIS.CLI.Core/Bootstrapping/CredentialCandidatePicker.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/CredentialCandidatePicker.cs
@@ -1,0 +1,45 @@
+using TALXIS.CLI.Core.Model;
+
+namespace TALXIS.CLI.Core.Bootstrapping;
+
+/// <summary>
+/// Shared deterministic credential-selection logic used by both
+/// <see cref="InteractiveCredentialBootstrapper"/> and
+/// <see cref="DeviceCodeCredentialBootstrapper"/> to pick the best
+/// existing credential from a candidate set.
+/// </summary>
+internal static class CredentialCandidatePicker
+{
+    /// <summary>
+    /// Selects the best credential from <paramref name="candidates"/> by
+    /// applying the following preference ordering:
+    /// <list type="number">
+    ///   <item>Credential whose <c>Id</c> matches <paramref name="explicitAlias"/> (if provided).</item>
+    ///   <item>Credential whose <c>Id</c> matches <paramref name="upn"/>.</item>
+    ///   <item>Alphabetically first by <c>Id</c>.</item>
+    /// </list>
+    /// Returns <c>null</c> when the set is empty.
+    /// </summary>
+    public static Credential? PickPreferred(
+        IEnumerable<Credential> candidates,
+        string? explicitAlias,
+        string upn)
+    {
+        var list = candidates.ToList();
+        if (list.Count == 0)
+            return null;
+
+        if (!string.IsNullOrWhiteSpace(explicitAlias))
+        {
+            var explicitMatch = list.FirstOrDefault(c =>
+                string.Equals(c.Id, explicitAlias.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (explicitMatch is not null)
+                return explicitMatch;
+        }
+
+        return list
+            .OrderBy(c => string.Equals(c.Id, upn, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
+            .First();
+    }
+}

--- a/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
@@ -97,31 +97,25 @@ public static class DeviceCodeCredentialBootstrapper
 
         if (!string.IsNullOrWhiteSpace(result.AccountId))
         {
-            var exact = candidates.FirstOrDefault(c =>
-                string.Equals(c.InteractiveAccountId, result.AccountId, StringComparison.OrdinalIgnoreCase));
+            // Route through PickPreferredCandidate to honour --alias and apply
+            // deterministic ordering even when multiple credentials share the
+            // same InteractiveAccountId (e.g., a DeviceCode and an InteractiveBrowser
+            // credential from the same account).
+            var exact = CredentialCandidatePicker.PickPreferred(
+                candidates.Where(c =>
+                    string.Equals(c.InteractiveAccountId, result.AccountId, StringComparison.OrdinalIgnoreCase)),
+                explicitAlias,
+                result.Upn);
             if (exact is not null)
                 return exact;
         }
 
-        // Fall back to UPN or legacy id-based matching, using the same
-        // deterministic preference ordering as InteractiveCredentialBootstrapper:
-        // prefer the credential whose id matches the explicit alias, then the UPN,
-        // then fall back to alphabetical order.
-        var upnCandidates = candidates.Where(c =>
-            string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase));
-
-        if (!string.IsNullOrWhiteSpace(explicitAlias))
-        {
-            var explicitMatch = upnCandidates.FirstOrDefault(c =>
-                string.Equals(c.Id, explicitAlias.Trim(), StringComparison.OrdinalIgnoreCase));
-            if (explicitMatch is not null)
-                return explicitMatch;
-        }
-
-        return upnCandidates
-            .OrderBy(c => string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
-            .ThenBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
-            .FirstOrDefault();
+        // Fall back to UPN or legacy id-based matching with deterministic ordering.
+        return CredentialCandidatePicker.PickPreferred(
+            candidates.Where(c =>
+                string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase)),
+            explicitAlias,
+            result.Upn);
     }
 }

--- a/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
@@ -1,0 +1,119 @@
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Headless;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Core.Storage;
+
+namespace TALXIS.CLI.Core.Bootstrapping;
+
+/// <summary>
+/// Single path that performs a device code sign-in and persists the resulting
+/// <see cref="Credential"/>. Mirrors <see cref="InteractiveCredentialBootstrapper"/>
+/// but uses <see cref="IDeviceCodeLoginService"/> and stores the credential as
+/// <see cref="CredentialKind.DeviceCode"/>.
+/// </summary>
+/// <remarks>
+/// Device code credentials share the same silent-renewal path as interactive
+/// browser credentials — MSAL's token cache holds both refresh token types
+/// identically. The credential kind is tracked so the CLI knows which
+/// re-authentication flow to use when <c>MsalUiRequiredException</c> fires.
+/// </remarks>
+public static class DeviceCodeCredentialBootstrapper
+{
+    /// <summary>
+    /// Enforces the headless policy for device code sign-in, runs the
+    /// login, resolves an alias (explicit override or UPN-derived), and
+    /// upserts the credential.
+    /// </summary>
+    public static async Task<InteractiveCredentialResult> AcquireAndPersistAsync(
+        IDeviceCodeLoginService login,
+        ICredentialStore store,
+        IHeadlessDetector headless,
+        string? tenantId,
+        CloudInstance cloud,
+        string? explicitAlias,
+        CancellationToken ct)
+    {
+        if (login is null) throw new ArgumentNullException(nameof(login));
+        if (store is null) throw new ArgumentNullException(nameof(store));
+        if (headless is null) throw new ArgumentNullException(nameof(headless));
+
+        // Device code still requires a TTY for the user to see the code
+        // and confirm — it is not permitted in fully headless (no-TTY) mode.
+        headless.EnsureKindAllowed(CredentialKind.DeviceCode);
+
+        var result = await login.LoginAsync(tenantId, cloud, ct).ConfigureAwait(false);
+
+        var existing = await FindExistingDeviceCodeCredentialAsync(
+            store, result, cloud, explicitAlias, ct).ConfigureAwait(false);
+
+        var alias = existing?.Id;
+        if (string.IsNullOrWhiteSpace(alias))
+        {
+            alias = string.IsNullOrWhiteSpace(explicitAlias)
+                ? await CredentialAliasResolver.ResolveForUpnAsync(store, result.Upn, ct).ConfigureAwait(false)
+                : explicitAlias!.Trim();
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var credential = existing ?? new Credential { CreatedAt = now };
+        credential.Id = alias;
+        credential.Kind = CredentialKind.DeviceCode;
+        credential.TenantId = result.TenantId;
+        credential.Cloud = cloud;
+        credential.ApplicationId = string.IsNullOrWhiteSpace(result.ApplicationId)
+            ? credential.ApplicationId
+            : result.ApplicationId;
+        credential.InteractiveAccountId = string.IsNullOrWhiteSpace(result.AccountId)
+            ? credential.InteractiveAccountId
+            : result.AccountId;
+        credential.InteractiveUpn = result.Upn;
+        credential.Description = $"Device code sign-in ({result.Upn})";
+        credential.UpdatedAt = now;
+
+        await store.UpsertAsync(credential, ct).ConfigureAwait(false);
+        return new InteractiveCredentialResult(credential, result.Upn, result.TenantId);
+    }
+
+    private static async Task<Credential?> FindExistingDeviceCodeCredentialAsync(
+        ICredentialStore store,
+        InteractiveLoginResult result,
+        CloudInstance cloud,
+        string? explicitAlias,
+        CancellationToken ct)
+    {
+        var credentials = await store.ListAsync(ct).ConfigureAwait(false);
+        // Match existing credentials of either DeviceCode or InteractiveBrowser
+        // kind — a user re-logging from Codespaces should reuse their existing
+        // credential entry rather than creating a duplicate.
+        var candidates = credentials
+            .Where(c => c.Kind is CredentialKind.DeviceCode or CredentialKind.InteractiveBrowser)
+            .Where(c => string.Equals(c.TenantId, result.TenantId, StringComparison.OrdinalIgnoreCase))
+            .Where(c => c.Cloud == cloud)
+            .Where(c =>
+                string.IsNullOrWhiteSpace(result.ApplicationId)
+                || string.IsNullOrWhiteSpace(c.ApplicationId)
+                || string.Equals(c.ApplicationId, result.ApplicationId, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(result.AccountId))
+        {
+            var exact = candidates.FirstOrDefault(c =>
+                string.Equals(c.InteractiveAccountId, result.AccountId, StringComparison.OrdinalIgnoreCase));
+            if (exact is not null)
+                return exact;
+        }
+
+        // Fall back to UPN or legacy id-based matching.
+        if (!string.IsNullOrWhiteSpace(explicitAlias))
+        {
+            var explicitMatch = candidates.FirstOrDefault(c =>
+                string.Equals(c.Id, explicitAlias.Trim(), StringComparison.OrdinalIgnoreCase));
+            if (explicitMatch is not null)
+                return explicitMatch;
+        }
+
+        return candidates.FirstOrDefault(c =>
+            string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/DeviceCodeCredentialBootstrapper.cs
@@ -103,17 +103,25 @@ public static class DeviceCodeCredentialBootstrapper
                 return exact;
         }
 
-        // Fall back to UPN or legacy id-based matching.
+        // Fall back to UPN or legacy id-based matching, using the same
+        // deterministic preference ordering as InteractiveCredentialBootstrapper:
+        // prefer the credential whose id matches the explicit alias, then the UPN,
+        // then fall back to alphabetical order.
+        var upnCandidates = candidates.Where(c =>
+            string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase));
+
         if (!string.IsNullOrWhiteSpace(explicitAlias))
         {
-            var explicitMatch = candidates.FirstOrDefault(c =>
+            var explicitMatch = upnCandidates.FirstOrDefault(c =>
                 string.Equals(c.Id, explicitAlias.Trim(), StringComparison.OrdinalIgnoreCase));
             if (explicitMatch is not null)
                 return explicitMatch;
         }
 
-        return candidates.FirstOrDefault(c =>
-            string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase));
+        return upnCandidates
+            .OrderBy(c => string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+            .ThenBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
     }
 }

--- a/src/TALXIS.CLI.Core/Bootstrapping/InteractiveCredentialBootstrapper.cs
+++ b/src/TALXIS.CLI.Core/Bootstrapping/InteractiveCredentialBootstrapper.cs
@@ -96,7 +96,7 @@ public static class InteractiveCredentialBootstrapper
 
         if (!string.IsNullOrWhiteSpace(result.AccountId))
         {
-            var exact = PickPreferredCandidate(
+            var exact = CredentialCandidatePicker.PickPreferred(
                 candidates.Where(c =>
                     string.Equals(c.InteractiveAccountId, result.AccountId, StringComparison.OrdinalIgnoreCase)),
                 explicitAlias,
@@ -107,34 +107,11 @@ public static class InteractiveCredentialBootstrapper
 
         // Backward compatibility for older credentials that predate persisted
         // account ids: prefer stored interactive UPN, then legacy "UPN as id".
-        return PickPreferredCandidate(
+        return CredentialCandidatePicker.PickPreferred(
             candidates.Where(c =>
                 string.Equals(c.InteractiveUpn, result.Upn, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(c.Id, result.Upn, StringComparison.OrdinalIgnoreCase)),
             explicitAlias,
             result.Upn);
-    }
-
-    private static Credential? PickPreferredCandidate(
-        IEnumerable<Credential> candidates,
-        string? explicitAlias,
-        string upn)
-    {
-        var list = candidates.ToList();
-        if (list.Count == 0)
-            return null;
-
-        if (!string.IsNullOrWhiteSpace(explicitAlias))
-        {
-            var explicitMatch = list.FirstOrDefault(c =>
-                string.Equals(c.Id, explicitAlias.Trim(), StringComparison.OrdinalIgnoreCase));
-            if (explicitMatch is not null)
-                return explicitMatch;
-        }
-
-        return list
-            .OrderBy(c => string.Equals(c.Id, upn, StringComparison.OrdinalIgnoreCase) ? 0 : 1)
-            .ThenBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
-            .First();
     }
 }

--- a/src/TALXIS.CLI.Core/DependencyInjection/ConfigServiceCollectionExtensions.cs
+++ b/src/TALXIS.CLI.Core/DependencyInjection/ConfigServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ConfigServiceCollectionExtensions
 
         services.AddSingleton<IConfigurationResolver, ConfigurationResolver>();
         services.AddSingleton<IHeadlessDetector, HeadlessDetector>();
+        services.AddSingleton<IBrowserAvailabilityProbe, BrowserAvailabilityProbe>();
         services.AddSingleton<IConfirmationPrompter, ConsoleConfirmationPrompter>();
         services.AddSingleton<TALXIS.CLI.Core.Bootstrapping.ConnectionUpsertService>();
 

--- a/src/TALXIS.CLI.Core/Headless/BrowserAvailabilityProbe.cs
+++ b/src/TALXIS.CLI.Core/Headless/BrowserAvailabilityProbe.cs
@@ -1,0 +1,82 @@
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Resolution;
+
+namespace TALXIS.CLI.Core.Headless;
+
+/// <summary>
+/// Determines whether a local browser can open and receive
+/// <c>http://localhost</c> OAuth redirects. Returns <c>false</c> in
+/// browser-isolated environments such as:
+/// <list type="bullet">
+///   <item><c>TXC_TTY_ONLY=1</c> — explicit opt-in to device code flow.</item>
+///   <item><c>CODESPACES=true</c> — browser-based GitHub Codespaces cannot tunnel localhost.</item>
+///   <item>Linux without <c>DISPLAY</c> or <c>WAYLAND_DISPLAY</c> — no desktop session.</item>
+///   <item>Linux where <c>xdg-open</c> is not on <c>PATH</c>.</item>
+/// </list>
+/// </summary>
+public sealed class BrowserAvailabilityProbe : IBrowserAvailabilityProbe
+{
+    public const string TxcTtyOnlyEnvVar = "TXC_TTY_ONLY";
+
+    public BrowserAvailabilityProbe() : this(ProcessEnvironmentReader.Instance) { }
+
+    internal BrowserAvailabilityProbe(IEnvironmentReader env)
+    {
+        ArgumentNullException.ThrowIfNull(env);
+        UnavailableReason = Evaluate(env);
+        IsBrowserAvailable = UnavailableReason is null;
+    }
+
+    public bool IsBrowserAvailable { get; }
+    public string? UnavailableReason { get; }
+
+    private static string? Evaluate(IEnvironmentReader env)
+    {
+        // Explicit opt-in to TTY-only mode (device code).
+        if (IsTruthy(env.Get(TxcTtyOnlyEnvVar)))
+            return $"{TxcTtyOnlyEnvVar}=1";
+
+        // GitHub Codespaces browser-based: localhost redirects cannot reach
+        // the container from the user's browser tab.
+        if (IsTruthy(env.Get("CODESPACES")))
+            return "CODESPACES=true (localhost redirect unreachable)";
+
+        // On non-Linux platforms, assume a browser is available (Windows/macOS
+        // desktop or VS Code Desktop with tunnel — both handle localhost fine).
+        if (!OperatingSystem.IsLinux())
+            return null;
+
+        // Linux: need a display server for the browser to render in.
+        var display = env.Get("DISPLAY");
+        var wayland = env.Get("WAYLAND_DISPLAY");
+        if (string.IsNullOrWhiteSpace(display) && string.IsNullOrWhiteSpace(wayland))
+            return "No DISPLAY or WAYLAND_DISPLAY set (no desktop session)";
+
+        // Linux with a display: check xdg-open is on PATH.
+        if (!IsXdgOpenOnPath())
+            return "xdg-open not found on PATH";
+
+        return null;
+    }
+
+    private static bool IsXdgOpenOnPath()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var dirs = path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+        foreach (var dir in dirs)
+        {
+            var candidate = Path.Combine(dir, "xdg-open");
+            if (File.Exists(candidate))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsTruthy(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && (value.Equals("1", StringComparison.Ordinal)
+            || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/TALXIS.CLI.Core/Headless/BrowserAvailabilityProbe.cs
+++ b/src/TALXIS.CLI.Core/Headless/BrowserAvailabilityProbe.cs
@@ -53,15 +53,15 @@ public sealed class BrowserAvailabilityProbe : IBrowserAvailabilityProbe
             return "No DISPLAY or WAYLAND_DISPLAY set (no desktop session)";
 
         // Linux with a display: check xdg-open is on PATH.
-        if (!IsXdgOpenOnPath())
+        // Read PATH via the injected reader so tests can control it deterministically.
+        if (!IsXdgOpenOnPath(env.Get("PATH")))
             return "xdg-open not found on PATH";
 
         return null;
     }
 
-    private static bool IsXdgOpenOnPath()
+    private static bool IsXdgOpenOnPath(string? path)
     {
-        var path = Environment.GetEnvironmentVariable("PATH");
         if (string.IsNullOrWhiteSpace(path))
             return false;
 

--- a/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
+++ b/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
@@ -13,11 +13,12 @@ namespace TALXIS.CLI.Core.Vault;
 internal static class MsalCacheHelperFactory
 {
     /// <summary>
-    /// Creates and verifies an <see cref="MsalCacheHelper"/>. On
-    /// <see cref="MsalCachePersistenceException"/> throws
-    /// <see cref="VaultUnavailableException"/> with a platform-specific remedy
-    /// hint. Set <c>TXC_PLAINTEXT_FALLBACK=1</c> on any platform to use an
-    /// unencrypted file fallback.
+    /// Creates and verifies an <see cref="MsalCacheHelper"/>. When the OS
+    /// credential vault is unavailable (e.g. no libsecret/D-Bus on Linux,
+    /// no DPAPI in a container), automatically falls back to a plaintext
+    /// file-based cache with a warning — matching the pac CLI behaviour.
+    /// Set <c>TXC_PLAINTEXT_FALLBACK=1</c> to skip the keyring attempt
+    /// entirely and go straight to plaintext.
     /// </summary>
     public static async Task<MsalCacheHelper> CreateAsync(
         VaultOptions options,
@@ -43,12 +44,16 @@ internal static class MsalCacheHelperFactory
         }
         catch (MsalCachePersistenceException ex)
         {
+            // OS vault is unavailable (missing libsecret, no D-Bus session,
+            // container without DPAPI, etc.). Auto-fallback to plaintext with
+            // a warning rather than hard-failing — the user can still work.
             string hint = GetPlatformHint();
             logger.LogWarning(ex,
-                "OS credential vault is unavailable. {Hint} " +
-                "Set {EnvVar}=1 to use a plaintext file fallback.",
+                "OS credential vault is unavailable — falling back to plaintext file cache. " +
+                "{Hint} To suppress this warning, set {EnvVar}=1 explicitly.",
                 hint, VaultOptions.PlaintextFallbackEnvVar);
-            throw new VaultUnavailableException(ex);
+
+            return await CreatePlaintextAsync(options, paths, logger).ConfigureAwait(false);
         }
     }
 

--- a/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
+++ b/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
@@ -53,7 +53,11 @@ internal static class MsalCacheHelperFactory
                 "{Hint} To suppress this warning, set {EnvVar}=1 explicitly.",
                 hint, VaultOptions.PlaintextFallbackEnvVar);
 
-            return await CreatePlaintextAsync(options, paths, logger).ConfigureAwait(false);
+            // Clone options with an explicit reason so the downstream plaintext
+            // warning log accurately reflects automatic fallback rather than
+            // an explicit opt-in.
+            var fallbackOptions = options with { UsePlaintextFallback = true, PlaintextReason = "auto-fallback (OS vault unavailable)" };
+            return await CreatePlaintextAsync(fallbackOptions, paths, logger).ConfigureAwait(false);
         }
     }
 

--- a/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
+++ b/src/TALXIS.CLI.Core/Vault/MsalCacheHelperFactory.cs
@@ -85,13 +85,19 @@ internal static class MsalCacheHelperFactory
             "Vault using PLAINTEXT file-based storage at {Path} (opt-in: {Reason}). {PermissionNote}",
             fallbackPath, options.PlaintextReason ?? "explicit", permissionNote);
 
+        // Pre-create the file and restrict permissions before MSAL registers its
+        // cache callbacks. MsalCacheHelper.CreateAsync does not create the file
+        // immediately — it only registers AfterAccess/BeforeAccess delegates that
+        // write on demand. If we call TrySetOwnerOnlyPermissions after CreateAsync
+        // the file doesn't exist yet, the chmod is skipped, and MSAL later creates
+        // the file with the process umask (typically 0644, group+world readable).
+        EnsureOwnerOnlyFile(fallbackPath, logger);
+
         var props = new StorageCreationPropertiesBuilder(options.FallbackCacheFileName, paths.AuthDirectory)
             .WithUnprotectedFile()
             .Build();
 
-        var helper = await MsalCacheHelper.CreateAsync(props).ConfigureAwait(false);
-        TrySetOwnerOnlyPermissions(fallbackPath, logger);
-        return helper;
+        return await MsalCacheHelper.CreateAsync(props).ConfigureAwait(false);
     }
 
     private static StorageCreationProperties BuildProtectedProperties(VaultOptions options, ConfigPaths paths)
@@ -107,19 +113,33 @@ internal static class MsalCacheHelperFactory
         return builder.Build();
     }
 
-    private static void TrySetOwnerOnlyPermissions(string path, ILogger logger)
+    /// <summary>
+    /// Creates the plaintext cache file (if absent) and immediately restricts
+    /// it to owner read/write. Must be called <em>before</em>
+    /// <see cref="MsalCacheHelper.CreateAsync"/> so that MSAL's first write
+    /// lands into an already-restricted file rather than creating it with the
+    /// process umask (typically 0644, group+world readable).
+    /// </summary>
+    private static void EnsureOwnerOnlyFile(string path, ILogger logger)
     {
-        if (OperatingSystem.IsWindows() || !File.Exists(path))
+        if (OperatingSystem.IsWindows())
             return;
 
         try
         {
+            // Open-or-create with exclusive owner permissions from the start.
+            using var fs = new FileStream(
+                path,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None);
+
             File.SetUnixFileMode(path,
                 UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Failed to chmod 600 plaintext vault at {Path}.", path);
+            logger.LogDebug(ex, "Failed to pre-create or chmod 600 plaintext vault at {Path}.", path);
         }
     }
 }

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
@@ -53,7 +53,7 @@ public class AuthLoginCliCommand : TxcLeafCommand
         var browserProbe = TxcServices.Get<IBrowserAvailabilityProbe>();
         var cloud = Cloud ?? CloudInstance.Public;
 
-        // Determine whether to use device code flow: explicit flag, env var,
+        // Determine whether to use device code flow: explicit flag or
         // or automatic detection of browser-isolated environments.
         var useDeviceCode = DeviceCode || !browserProbe.IsBrowserAvailable;
 

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthLoginCliCommand.cs
@@ -11,20 +11,24 @@ using TALXIS.CLI.Logging;
 namespace TALXIS.CLI.Features.Config.Auth;
 
 /// <summary>
-/// <c>txc config auth login</c> — eager interactive browser sign-in.
-/// Persists an <see cref="CredentialKind.InteractiveBrowser"/>
-/// credential whose refresh token sits in the shared MSAL cache; no
-/// secret material is written to the txc credential-vault file.
+/// <c>txc config auth login</c> — eager interactive sign-in.
+/// Persists an <see cref="CredentialKind.InteractiveBrowser"/> or
+/// <see cref="CredentialKind.DeviceCode"/> credential whose refresh token
+/// sits in the shared MSAL cache; no secret material is written to the
+/// txc credential-vault file.
 /// </summary>
 /// <remarks>
 /// Fails fast with exit 1 in headless contexts — interactive browser is
 /// never a permitted headless kind. See <see cref="HeadlessAuthRequiredException"/>.
+/// When a local browser is not available (Codespaces, SSH, no DISPLAY),
+/// the command automatically falls back to device code flow unless
+/// <c>--device-code</c> was already specified.
 /// </remarks>
 [CliIdempotent]
 [McpIgnore]
 [CliCommand(
     Name = "login",
-    Description = "Interactive browser sign-in. Persists a credential named after the UPN (override with --alias)."
+    Description = "Interactive sign-in. Uses browser login by default; falls back to device code in browser-isolated environments (Codespaces, SSH)."
 )]
 public class AuthLoginCliCommand : TxcLeafCommand
 {
@@ -39,21 +43,48 @@ public class AuthLoginCliCommand : TxcLeafCommand
     [CliOption(Name = "--cloud", Description = "Sovereign cloud. Default: public.", Required = false)]
     public CloudInstance? Cloud { get; set; }
 
+    [CliOption(Name = "--device-code", Description = "Use device code flow instead of browser login. Required when no local browser can reach localhost (Codespaces, SSH, containers).", Required = false)]
+    public bool DeviceCode { get; set; }
+
     protected override async Task<int> ExecuteAsync()
     {
-        var login = TxcServices.Get<IInteractiveLoginService>();
         var store = TxcServices.Get<ICredentialStore>();
         var headless = TxcServices.Get<IHeadlessDetector>();
+        var browserProbe = TxcServices.Get<IBrowserAvailabilityProbe>();
         var cloud = Cloud ?? CloudInstance.Public;
 
-        Logger.LogInformation("Starting interactive sign-in...");
-        var result = await InteractiveCredentialBootstrapper.AcquireAndPersistAsync(
-            login, store, headless, Tenant, cloud, Alias, CancellationToken.None).ConfigureAwait(false);
+        // Determine whether to use device code flow: explicit flag, env var,
+        // or automatic detection of browser-isolated environments.
+        var useDeviceCode = DeviceCode || !browserProbe.IsBrowserAvailable;
 
-        Logger.LogInformation("Signed in as {Upn} (tenant {Tenant}). Credential '{Alias}' saved.",
-            result.Upn, result.TenantId, result.Credential.Id);
+        if (useDeviceCode)
+        {
+            var deviceCodeLogin = TxcServices.Get<IDeviceCodeLoginService>();
+            Logger.LogInformation("Starting device code sign-in (browser unavailable: {Reason})...",
+                browserProbe.UnavailableReason ?? "--device-code flag");
 
-        OutputFormatter.WriteData(new { id = result.Credential.Id, upn = result.Upn, tenantId = result.TenantId, cloud });
-        return ExitSuccess;
+            var result = await DeviceCodeCredentialBootstrapper.AcquireAndPersistAsync(
+                deviceCodeLogin, store, headless, Tenant, cloud, Alias, CancellationToken.None).ConfigureAwait(false);
+
+            Logger.LogInformation("Signed in as {Upn} (tenant {Tenant}). Credential '{Alias}' saved.",
+                result.Upn, result.TenantId, result.Credential.Id);
+
+            OutputFormatter.WriteData(new { id = result.Credential.Id, upn = result.Upn, tenantId = result.TenantId, cloud, flow = "device-code" });
+            return ExitSuccess;
+        }
+        else
+        {
+            var login = TxcServices.Get<IInteractiveLoginService>();
+            Logger.LogInformation("Starting interactive sign-in...");
+
+            var result = await InteractiveCredentialBootstrapper.AcquireAndPersistAsync(
+                login, store, headless, Tenant, cloud, Alias, CancellationToken.None).ConfigureAwait(false);
+
+            Logger.LogInformation("Signed in as {Upn} (tenant {Tenant}). Credential '{Alias}' saved.",
+                result.Upn, result.TenantId, result.Credential.Id);
+
+            OutputFormatter.WriteData(new { id = result.Credential.Id, upn = result.Upn, tenantId = result.TenantId, cloud, flow = "interactive-browser" });
+            return ExitSuccess;
+        }
     }
 }

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/DependencyInjection/DataverseProviderServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ public static class DataverseProviderServiceCollectionExtensions
         services.AddSingleton<IDataverseLiveChecker, DataverseLiveChecker>();
         services.AddSingleton<IEnvironmentTypeResolver, DataverseEnvironmentTypeResolver>();
         services.AddSingleton<IInteractiveLoginService, DataverseInteractiveLoginService>();
+        services.AddSingleton<IDeviceCodeLoginService, DataverseDeviceCodeLoginService>();
         services.AddSingleton<TALXIS.CLI.Core.Bootstrapping.IConnectionProviderBootstrapper,
             TALXIS.CLI.Platform.Dataverse.Runtime.Bootstrapping.DataverseConnectionProviderBootstrapper>();
         return services;

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseDeviceCodeLoginService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseDeviceCodeLoginService.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Identity.Client;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Identity;
+using TALXIS.CLI.Core.Model;
+
+namespace TALXIS.CLI.Platform.Dataverse.Runtime.Msal;
+
+/// <summary>
+/// MSAL-backed <see cref="IDeviceCodeLoginService"/>. Uses the device code
+/// flow (<c>AcquireTokenWithDeviceCode</c>) so the user authenticates in an
+/// external browser by visiting <c>https://microsoft.com/devicelogin</c>.
+/// </summary>
+/// <remarks>
+/// This is the correct flow for browser-isolated environments — GitHub
+/// Codespaces (browser-based), SSH sessions, containers without a display.
+/// The localhost redirect used by interactive browser login is not reachable
+/// in these environments; device code needs no redirect at all.
+///
+/// Scopes: <c>openid profile offline_access</c> only — same identity-warming
+/// strategy as <see cref="DataverseInteractiveLoginService"/>.
+/// </remarks>
+public sealed class DataverseDeviceCodeLoginService : IDeviceCodeLoginService
+{
+    private static readonly string[] SignInScopes = ["openid", "profile", "offline_access"];
+
+    private readonly MsalClientFactory _factory;
+    private readonly MsalTokenCacheBinder _cacheBinder;
+    private readonly ILogger _logger;
+
+    public DataverseDeviceCodeLoginService(
+        MsalClientFactory factory,
+        MsalTokenCacheBinder cacheBinder,
+        ILogger<DataverseDeviceCodeLoginService>? logger = null)
+    {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _cacheBinder = cacheBinder ?? throw new ArgumentNullException(nameof(cacheBinder));
+        _logger = logger ?? NullLogger<DataverseDeviceCodeLoginService>.Instance;
+    }
+
+    public async Task<InteractiveLoginResult> LoginAsync(
+        string? tenantId,
+        CloudInstance cloud,
+        CancellationToken ct)
+    {
+        var app = _factory.BuildPublicClientForLogin(tenantId, cloud);
+        _cacheBinder.Attach(app.UserTokenCache);
+
+        _logger.LogInformation(
+            "Starting device code sign-in (tenant={Tenant}, cloud={Cloud}).",
+            tenantId ?? "organizations", cloud);
+
+        AuthenticationResult result = await app
+            .AcquireTokenWithDeviceCode(SignInScopes, deviceCodeResult =>
+            {
+                // MSAL composes a full user-facing message like:
+                // "To sign in, use a web browser to open the page
+                //  https://microsoft.com/devicelogin and enter the code ABCDEFG"
+                _logger.LogWarning("{DeviceCodeMessage}", deviceCodeResult.Message);
+                return Task.CompletedTask;
+            })
+            .ExecuteAsync(ct)
+            .ConfigureAwait(false);
+
+        var upn = result.Account?.Username;
+        if (string.IsNullOrWhiteSpace(upn))
+            throw new InvalidOperationException(
+                "Device code sign-in succeeded but MSAL did not return a UPN. " +
+                "Try again with --alias to provide one explicitly.");
+
+        return new InteractiveLoginResult(
+            upn,
+            result.TenantId,
+            result.Account?.HomeAccountId?.Identifier,
+            MsalClientFactory.PublicClientId);
+    }
+}

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
@@ -20,6 +20,12 @@ namespace TALXIS.CLI.Platform.Dataverse.Runtime.Msal;
 /// access tokens silently. Running the Dataverse <c>//.default</c> scope
 /// at this point would force the user to name an env that may not exist
 /// yet in their config.
+///
+/// A custom <see cref="SystemWebViewOptions.OpenBrowserAsync"/> prints
+/// the auth URL to the terminal on platforms where <c>xdg-open</c> may
+/// not be available (SSH, containers). This makes VS Code Desktop tunnel
+/// scenarios work — the user clicks the printed URL and VS Code forwards
+/// the localhost redirect back into the container.
 /// </remarks>
 public sealed class DataverseInteractiveLoginService : IInteractiveLoginService
 {
@@ -51,9 +57,24 @@ public sealed class DataverseInteractiveLoginService : IInteractiveLoginService
             "Launching browser for interactive sign-in (tenant={Tenant}, cloud={Cloud}).",
             tenantId ?? "organizations", cloud);
 
+        var systemWebViewOptions = new SystemWebViewOptions
+        {
+            // Custom browser launcher that prints the URL to the terminal.
+            // On Linux without xdg-open (SSH, containers) the default MSAL
+            // behaviour would throw — this ensures the user always sees the URL
+            // and can click it (VS Code Desktop tunnels localhost back).
+            OpenBrowserAsync = uri =>
+            {
+                _logger.LogWarning("Open this URL in your browser to sign in:\n  {AuthUrl}", uri);
+                TryLaunchBrowser(uri.ToString());
+                return Task.CompletedTask;
+            }
+        };
+
         AuthenticationResult result = await app
             .AcquireTokenInteractive(SignInScopes)
             .WithUseEmbeddedWebView(false)
+            .WithSystemWebViewOptions(systemWebViewOptions)
             .ExecuteAsync(ct)
             .ConfigureAwait(false);
 
@@ -67,5 +88,26 @@ public sealed class DataverseInteractiveLoginService : IInteractiveLoginService
             result.TenantId,
             result.Account?.HomeAccountId?.Identifier,
             MsalClientFactory.PublicClientId);
+    }
+
+    /// <summary>
+    /// Best-effort browser launch. Failures are silently swallowed — the URL
+    /// is already printed to the terminal for manual use.
+    /// </summary>
+    private void TryLaunchBrowser(string url)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+            else if (OperatingSystem.IsMacOS())
+                System.Diagnostics.Process.Start("open", url);
+            else
+                System.Diagnostics.Process.Start("xdg-open", url);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Browser launch failed (expected in headless/container environments).");
+        }
     }
 }

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
@@ -30,6 +30,7 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
     private readonly ICredentialVault _vault;
     private readonly IEnvironmentReader _env;
     private readonly IHeadlessDetector _headless;
+    private readonly IBrowserAvailabilityProbe _browserProbe;
     private readonly ILogger<DataverseAccessTokenService> _logger;
     private readonly InMemoryTokenCache _tokenCache = new();
 
@@ -39,6 +40,7 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         ICredentialVault vault,
         IEnvironmentReader env,
         IHeadlessDetector headless,
+        IBrowserAvailabilityProbe browserProbe,
         ILogger<DataverseAccessTokenService>? logger = null)
     {
         _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
@@ -46,6 +48,7 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         _vault = vault ?? throw new ArgumentNullException(nameof(vault));
         _env = env ?? throw new ArgumentNullException(nameof(env));
         _headless = headless ?? throw new ArgumentNullException(nameof(headless));
+        _browserProbe = browserProbe ?? throw new ArgumentNullException(nameof(browserProbe));
         _logger = logger ?? NullLogger<DataverseAccessTokenService>.Instance;
     }
 
@@ -99,14 +102,15 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
 
             return credential.Kind switch
             {
-                CredentialKind.InteractiveBrowser => await AcquirePublicClientSilentAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
+                CredentialKind.InteractiveBrowser or CredentialKind.DeviceCode =>
+                    await AcquirePublicClientSilentAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
                 CredentialKind.ClientSecret => await AcquireClientSecretAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
                 CredentialKind.ClientCertificate => await AcquireClientCertificateAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
                 CredentialKind.WorkloadIdentityFederation => await AcquireFederatedAsync(connection, credential, scope, cacheKey, ct).ConfigureAwait(false),
-                CredentialKind.DeviceCode or CredentialKind.ManagedIdentity or CredentialKind.AzureCli or CredentialKind.Pat =>
+                CredentialKind.ManagedIdentity or CredentialKind.AzureCli or CredentialKind.Pat =>
                     throw new NotSupportedException(
                         $"Credential kind {credential.Kind} is reserved but not yet wired for Dataverse token acquisition in this release. " +
-                        "Use InteractiveBrowser, ClientSecret, ClientCertificate, or WorkloadIdentityFederation."),
+                        "Use InteractiveBrowser, DeviceCode, ClientSecret, ClientCertificate, or WorkloadIdentityFederation."),
                 _ => throw new NotSupportedException($"Unknown credential kind: {credential.Kind}"),
             };
         }
@@ -153,26 +157,50 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
         }
         catch (MsalUiRequiredException ex)
         {
-            // In interactive sessions, attempt automatic re-authentication
-            // using AcquireTokenInteractive with the actual Dataverse scope
-            // that failed — not just identity scopes. This ensures consent
-            // is obtained for the correct resource.
+            // In interactive sessions, attempt automatic re-authentication.
+            // The strategy depends on whether a local browser is reachable:
+            // - Browser available: AcquireTokenInteractive with Dataverse scope
+            // - Browser isolated (Codespaces/SSH): device code flow
             if (!_headless.IsHeadless)
             {
                 _logger.LogWarning(
-                    "Token for credential '{CredentialId}' expired or requires consent — launching interactive re-authentication with Dataverse scope.",
+                    "Token for credential '{CredentialId}' expired or requires consent — attempting re-authentication.",
                     credential.Id);
 
                 try
                 {
-                    var interactiveResult = await app
-                        .AcquireTokenInteractive(new[] { scope })
-                        .WithAccount(account)
-                        .WithUseEmbeddedWebView(false)
-                        .ExecuteAsync(ct)
-                        .ConfigureAwait(false);
-                    _tokenCache.Set(cacheKey, interactiveResult);
-                    return interactiveResult.AccessToken;
+                    if (_browserProbe.IsBrowserAvailable)
+                    {
+                        // Browser is reachable — use interactive flow with the
+                        // actual Dataverse scope that needs consent.
+                        var interactiveResult = await app
+                            .AcquireTokenInteractive(new[] { scope })
+                            .WithAccount(account)
+                            .WithUseEmbeddedWebView(false)
+                            .ExecuteAsync(ct)
+                            .ConfigureAwait(false);
+                        _tokenCache.Set(cacheKey, interactiveResult);
+                        return interactiveResult.AccessToken;
+                    }
+                    else
+                    {
+                        // Browser-isolated environment (Codespaces, SSH, etc.)
+                        // — use device code flow for re-authentication.
+                        _logger.LogWarning(
+                            "No local browser available ({Reason}). Using device code for re-authentication.",
+                            _browserProbe.UnavailableReason);
+
+                        var deviceCodeResult = await app
+                            .AcquireTokenWithDeviceCode(new[] { scope }, dcr =>
+                            {
+                                _logger.LogWarning("{DeviceCodeMessage}", dcr.Message);
+                                return Task.CompletedTask;
+                            })
+                            .ExecuteAsync(ct)
+                            .ConfigureAwait(false);
+                        _tokenCache.Set(cacheKey, deviceCodeResult);
+                        return deviceCodeResult.AccessToken;
+                    }
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseAccessTokenService.cs
@@ -190,6 +190,13 @@ public sealed class DataverseAccessTokenService : IDataverseAccessTokenService
                             "No local browser available ({Reason}). Using device code for re-authentication.",
                             _browserProbe.UnavailableReason);
 
+                        // Note: AcquireTokenWithDeviceCode does not support WithLoginHint
+                        // (no account pre-selection in device code flow). We log the expected
+                        // account so the user can verify they are signing in as the right identity.
+                        _logger.LogWarning(
+                            "Please sign in as {ExpectedUpn} when completing device code authentication.",
+                            account.Username);
+
                         var deviceCodeResult = await app
                             .AcquireTokenWithDeviceCode(new[] { scope }, dcr =>
                             {

--- a/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthLoginCommandTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthLoginCommandTests.cs
@@ -205,6 +205,54 @@ public sealed class AuthLoginCommandTests
     }
 
     [Fact]
+    public async Task Login_DeviceCode_PersistsCredential_WhenFlagExplicit()
+    {
+        using var host = new CommandTestHost(
+            browserAvailable: false,
+            loginResult: new InteractiveLoginResult(
+                "tomas@contoso.com",
+                "t-guid",
+                "account-guid",
+                MsalClientFactory.PublicClientId));
+        var store = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
+
+        var sw = new StringWriter();
+        int exit;
+        using (OutputWriter.RedirectTo(sw))
+            exit = await new AuthLoginCliCommand { DeviceCode = true }.RunAsync();
+
+        Assert.Equal(0, exit);
+        Assert.Equal(1, host.Login.Calls);
+
+        var creds = await store.ListAsync(default);
+        var cred = Assert.Single(creds);
+        Assert.Equal("tomas@contoso.com", cred.Id);
+        Assert.Equal(CredentialKind.DeviceCode, cred.Kind);
+
+        using var doc = JsonDocument.Parse(sw.ToString());
+        Assert.Equal("device-code", doc.RootElement.GetProperty("flow").GetString());
+    }
+
+    [Fact]
+    public async Task Login_DeviceCode_TriggeredAutomatically_WhenBrowserUnavailable()
+    {
+        using var host = new CommandTestHost(
+            browserAvailable: false,
+            loginResult: new InteractiveLoginResult("tomas@contoso.com", "t-guid"));
+        var store = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
+
+        // No --device-code flag; auto-detection via FakeBrowserProbe should trigger device code
+        var exit = await new AuthLoginCliCommand().RunAsync();
+
+        Assert.Equal(0, exit);
+        Assert.Equal(1, host.Login.Calls);
+
+        var creds = await store.ListAsync(default);
+        var cred = Assert.Single(creds);
+        Assert.Equal(CredentialKind.DeviceCode, cred.Kind);
+    }
+
+    [Fact]
     public async Task Login_FailsFast_InHeadlessEnvironment()
     {
         using var host = new CommandTestHost(headless: true);

--- a/tests/TALXIS.CLI.Tests/Config/Commands/CommandTestHost.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Commands/CommandTestHost.cs
@@ -28,6 +28,7 @@ internal sealed class CommandTestHost : IDisposable
 
     public CommandTestHost(
         bool headless = false,
+        bool? browserAvailable = null,
         InteractiveLoginResult? loginResult = null,
         string? currentDirectory = null,
         FakeConnectionProvider? dataverseProvider = null,
@@ -61,7 +62,7 @@ internal sealed class CommandTestHost : IDisposable
         services.AddSingleton<IWorkspaceDiscovery, WorkspaceDiscovery>();
         services.AddSingleton<IConfigurationResolver, ConfigurationResolver>();
         services.AddSingleton<IInteractiveLoginService>(Login);
-        services.AddSingleton<IBrowserAvailabilityProbe>(new FakeBrowserProbe(browserAvailable: !headless));
+        services.AddSingleton<IBrowserAvailabilityProbe>(new FakeBrowserProbe(browserAvailable: browserAvailable ?? !headless));
         services.AddSingleton<IDeviceCodeLoginService>(Login);
         services.AddSingleton<IPowerPlatformEnvironmentCatalog>(EnvironmentCatalog);
         services.AddSingleton(_ =>

--- a/tests/TALXIS.CLI.Tests/Config/Commands/CommandTestHost.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Commands/CommandTestHost.cs
@@ -61,6 +61,8 @@ internal sealed class CommandTestHost : IDisposable
         services.AddSingleton<IWorkspaceDiscovery, WorkspaceDiscovery>();
         services.AddSingleton<IConfigurationResolver, ConfigurationResolver>();
         services.AddSingleton<IInteractiveLoginService>(Login);
+        services.AddSingleton<IBrowserAvailabilityProbe>(new FakeBrowserProbe(browserAvailable: !headless));
+        services.AddSingleton<IDeviceCodeLoginService>(Login);
         services.AddSingleton<IPowerPlatformEnvironmentCatalog>(EnvironmentCatalog);
         services.AddSingleton(_ =>
             MsalTokenCacheBinder
@@ -167,7 +169,7 @@ internal sealed class CommandTestHost : IDisposable
             => Task.FromResult(true);
     }
 
-    internal sealed class FakeInteractiveLogin : IInteractiveLoginService
+    internal sealed class FakeInteractiveLogin : IInteractiveLoginService, IDeviceCodeLoginService
     {
         private readonly InteractiveLoginResult _result;
         public int Calls { get; private set; }
@@ -183,6 +185,17 @@ internal sealed class CommandTestHost : IDisposable
             LastCloud = cloud;
             return Task.FromResult(_result);
         }
+    }
+
+    internal sealed class FakeBrowserProbe : IBrowserAvailabilityProbe
+    {
+        public FakeBrowserProbe(bool browserAvailable)
+        {
+            IsBrowserAvailable = browserAvailable;
+            UnavailableReason = browserAvailable ? null : "test harness: browser unavailable";
+        }
+        public bool IsBrowserAvailable { get; }
+        public string? UnavailableReason { get; }
     }
 
     internal sealed class FakePowerPlatformEnvironmentCatalog : IPowerPlatformEnvironmentCatalog

--- a/tests/TALXIS.CLI.Tests/Config/Headless/BrowserAvailabilityProbeTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Headless/BrowserAvailabilityProbeTests.cs
@@ -1,0 +1,71 @@
+using TALXIS.CLI.Core.Headless;
+using TALXIS.CLI.Core.Resolution;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Config.Headless;
+
+public class BrowserAvailabilityProbeTests
+{
+    [Fact]
+    public void BrowserAvailable_ByDefault_OnNonLinux()
+    {
+        // When nothing signals browser isolation, the default is "available"
+        // (this test runs on CI which may be Linux — it validates the env-var path).
+        var probe = new BrowserAvailabilityProbe(new FakeEnv());
+        if (!OperatingSystem.IsLinux())
+        {
+            Assert.True(probe.IsBrowserAvailable);
+            Assert.Null(probe.UnavailableReason);
+        }
+    }
+
+    [Theory]
+    [InlineData("TXC_TTY_ONLY", "1")]
+    [InlineData("TXC_TTY_ONLY", "true")]
+    public void TxcTtyOnly_ForcesBrowserUnavailable(string envName, string value)
+    {
+        var probe = new BrowserAvailabilityProbe(new FakeEnv((envName, value)));
+        Assert.False(probe.IsBrowserAvailable);
+        Assert.Contains("TXC_TTY_ONLY", probe.UnavailableReason);
+    }
+
+    [Fact]
+    public void Codespaces_ForcesBrowserUnavailable()
+    {
+        var probe = new BrowserAvailabilityProbe(new FakeEnv(("CODESPACES", "true")));
+        Assert.False(probe.IsBrowserAvailable);
+        Assert.Contains("CODESPACES", probe.UnavailableReason);
+    }
+
+    [Fact]
+    public void Codespaces_FalsyValue_DoesNotForce()
+    {
+        var probe = new BrowserAvailabilityProbe(new FakeEnv(("CODESPACES", "false")));
+        // On non-Linux, should be available. On Linux, depends on DISPLAY.
+        if (!OperatingSystem.IsLinux())
+            Assert.True(probe.IsBrowserAvailable);
+    }
+
+    [Fact]
+    public void Linux_NoDisplay_BrowserUnavailable()
+    {
+        if (!OperatingSystem.IsLinux())
+            return; // Test only meaningful on Linux
+
+        var probe = new BrowserAvailabilityProbe(new FakeEnv());
+        // On Linux CI without DISPLAY, the probe should detect browser isolation.
+        Assert.False(probe.IsBrowserAvailable);
+        Assert.Contains("DISPLAY", probe.UnavailableReason!);
+    }
+
+    private sealed class FakeEnv : IEnvironmentReader
+    {
+        private readonly Dictionary<string, string> _map;
+        public FakeEnv(params (string Key, string Value)[] entries)
+        {
+            _map = entries.ToDictionary(e => e.Key, e => e.Value, StringComparer.Ordinal);
+        }
+        public string? Get(string name) => _map.TryGetValue(name, out var v) ? v : null;
+        public string GetCurrentDirectory() => Directory.GetCurrentDirectory();
+    }
+}


### PR DESCRIPTION
## Problem

`txc config auth login` fails in GitHub Codespaces and other browser-isolated Linux environments (Alpine containers, SSH sessions) with two separate root causes:

1. **Vault hard-crash** — `MsalCacheHelperFactory` throws `VaultUnavailableException` when libsecret/D-Bus is absent (no auto-fallback to plaintext).
2. **No device code flow** — `CredentialKind.DeviceCode` was defined but threw `NotSupportedException` everywhere. The interactive browser flow requires a local `http://localhost` redirect that Codespaces containers cannot receive.

## Key design insight

Codespaces is **not headless** — a human is at the terminal. The correct distinction is _browser-isolated_: interactive TTY present, but no local browser can receive the OAuth redirect. This is handled by the new `IBrowserAvailabilityProbe` abstraction, orthogonal to `IHeadlessDetector`.

## Changes

### Vault auto-fallback (`MsalCacheHelperFactory`)
- Catches `MsalCachePersistenceException` and retries with plaintext file storage + warning log — matching pac CLI behaviour. No more hard crash; `TXC_PLAINTEXT_FALLBACK=1` still works as before to skip the keyring attempt entirely.

### `IBrowserAvailabilityProbe` (new)
- `BrowserAvailabilityProbe` returns `IsBrowserAvailable = false` when:
  - `TXC_TTY_ONLY=1` — explicit opt-in
  - `CODESPACES=true` — browser-based Codespaces
  - Linux without `DISPLAY` / `WAYLAND_DISPLAY`
  - Linux where `xdg-open` is not on PATH

### Device code login (new)
- `IDeviceCodeLoginService` / `DataverseDeviceCodeLoginService` — `AcquireTokenWithDeviceCode` prints MSAL's full message to the terminal.
- `DeviceCodeCredentialBootstrapper` — persists as `CredentialKind.DeviceCode`; matches existing interactive browser credentials for same account on re-login.

### `txc config auth login --device-code`
- New flag, **auto-triggered** when `IBrowserAvailabilityProbe` detects no browser.
- In Codespaces: `txc config auth login` just works — no flag needed.

### `DataverseAccessTokenService`
- `DeviceCode` handled identically to `InteractiveBrowser` for silent renewal.
- On `MsalUiRequiredException` in browser-isolated environments, falls back to device code instead of `AcquireTokenInteractive`.

### `DataverseInteractiveLoginService`
- Custom `SystemWebViewOptions.OpenBrowserAsync` always prints the auth URL to the terminal, then attempts `xdg-open` best-effort. Makes VS Code Desktop + Codespaces tunnel work.

## Environment variable reference

| Var | Effect |
|-----|--------|
| `TXC_TTY_ONLY=1` | Force device code flow (browser-isolated opt-in) |
| `TXC_PLAINTEXT_FALLBACK=1` | Skip keyring entirely (existing) |
| `CODESPACES=true` | Auto-detected; triggers device code |