### PR TITLE
fix: use ArgumentList to prevent URL spaces splitting open args on macOS/Linux

### DIFF
--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
@@ -98,12 +98,20 @@ public sealed class DataverseInteractiveLoginService : IInteractiveLoginService
     {
         try
         {
+            System.Diagnostics.ProcessStartInfo psi;
             if (OperatingSystem.IsWindows())
-                System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
-            else if (OperatingSystem.IsMacOS())
-                System.Diagnostics.Process.Start("open", url);
+            {
+                psi = new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true };
+            }
             else
-                System.Diagnostics.Process.Start("xdg-open", url);
+            {
+                // Pass the URL as a single element in ArgumentList so that spaces
+                // in query-string values (e.g. "scope=openid profile offline_access")
+                // are not split into separate arguments by the shell.
+                psi = new System.Diagnostics.ProcessStartInfo(OperatingSystem.IsMacOS() ? "open" : "xdg-open");
+                psi.ArgumentList.Add(url);
+            }
+            System.Diagnostics.Process.Start(psi);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem

`txc config auth login` prints a warning and fails to open the browser on macOS (and Linux). The error is:

```
[WARN] Open this URL in your browser to sign in:
  https://...?scope=openid profile offline_access&...
The files .../profile and .../offline_access&... do not exist.
```

## Root cause

Introduced in #153. `TryLaunchBrowser` called:

```csharp
System.Diagnostics.Process.Start("open", url);
```

The second parameter is treated as a **raw argument string**. The OAuth authorization URL contains spaces in the scope parameter (`scope=openid profile offline_access`). Those spaces are word-split by the shell into separate `open` arguments, so macOS `open` receives `profile` and `offline_access&...` as relative paths from the CWD.

## Fix

Replace with `ProcessStartInfo.ArgumentList.Add(url)` for non-Windows platforms so the full URL is always passed as a single quoted argument. Windows already uses `UseShellExecute = true` which is correct.