### PR TITLE
fix: use AbsoluteUri to prevent double-encoding in browser launch URL

### DIFF
--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Msal/DataverseInteractiveLoginService.cs
@@ -65,8 +65,13 @@ public sealed class DataverseInteractiveLoginService : IInteractiveLoginService
             // and can click it (VS Code Desktop tunnels localhost back).
             OpenBrowserAsync = uri =>
             {
-                _logger.LogWarning("Open this URL in your browser to sign in:\n  {AuthUrl}", uri);
-                TryLaunchBrowser(uri.ToString());
+                // Use AbsoluteUri (fully percent-encoded) so the URL is valid when
+                // logged (copyable into a browser) and when passed to the OS launcher.
+                // Uri.ToString() decodes %20 to spaces, which makes the URL invalid;
+                // macOS open then re-encodes everything, double-encoding %3A → %253A.
+                var absoluteUrl = uri.AbsoluteUri;
+                _logger.LogWarning("Open this URL in your browser to sign in:\n  {AuthUrl}", absoluteUrl);
+                TryLaunchBrowser(absoluteUrl);
                 return Task.CompletedTask;
             }
         };


### PR DESCRIPTION
## Problem

After #154, `txc config auth login` opens the browser but AAD rejects with:

> AADSTS90102: 'redirect_uri' value must be a valid absolute URI.

The redirect_uri in the URL that reaches AAD is double-encoded: `http%253A%252F%252Flocalhost` instead of `http%3A%2F%2Flocalhost`.

## Root cause

`Uri.ToString()` decodes `%20` back to literal spaces, producing a URL with `scope=openid profile offline_access` (unencoded spaces). This is not a valid URL string. When macOS `open` receives an invalid URL it attempts to normalise it — re-encoding everything including `%` signs already present in encoded sequences like `%3A`, turning them into `%253A`.

## Fix

Use `uri.AbsoluteUri` (fully percent-encoded, no decoded characters) for both the log message and the `TryLaunchBrowser` call. `open` then receives a well-formed URL and passes it to the browser unchanged.