### PR TITLE
Fix env bootstrap from auth credentials

### DIFF
--- a/docs/environment-lifecycle.md
+++ b/docs/environment-lifecycle.md
@@ -1,6 +1,6 @@
 # Environment Lifecycle
 
-`txc env list`, `txc env create`, `txc env update`, and `txc env delete` manage Power Platform environments at the **tenant level** — they use the active profile's credential and cloud for admin authority, not a target environment URL.
+`txc env list`, `txc env create`, `txc env update`, and `txc env delete` manage Power Platform environments at the **tenant level** — they use the selected profile's credential and cloud for admin authority, not a target environment URL. `list` and `create` can also run before any environment/profile exists by using `--auth` (or the single stored auth credential) plus optional `--cloud`.
 
 ## Listing environments
 
@@ -15,6 +15,8 @@ Returns every Dataverse-backed environment visible to the caller. Results includ
 | `--filter` | Case-insensitive substring match against display name, unique name, or URL. |
 | `--type`, `-t` | Filter to a single lifecycle type: `Production`, `Sandbox`, `Trial`, `Developer`, `Default`, `Teams`, `SubscriptionBasedTrial`. |
 | `--profile`, `-p` | Profile supplying the admin identity and cloud. Falls back to the active profile. |
+| `--auth` | Auth credential id to use directly when no target profile exists. If omitted and no profile resolves, the only stored auth credential is used. |
+| `--cloud` | Power Platform cloud to use with `--auth` or the default auth credential. |
 | `--format`, `-f` | `json` or `text` (auto-detected when omitted). |
 
 ### Examples
@@ -22,6 +24,9 @@ Returns every Dataverse-backed environment visible to the caller. Results includ
 ```sh
 # List all environments
 txc env list
+
+# Bootstrap a tenant with no profiles/environments yet
+txc env list --auth admin@contoso.com
 
 # Only sandboxes, as JSON
 txc env list --type Sandbox -f json
@@ -51,6 +56,8 @@ Provisions a new Power Platform environment. By default the command returns imme
 | `--user` | `-u` | No | — | Owning user's Entra object id. Only valid for `Developer` environments. |
 | `--wait` | — | No | `false` | Block until provisioning completes. |
 | `--profile` | `-p` | No | active | Profile supplying the admin identity and cloud. |
+| `--auth` | — | No | single credential | Auth credential id to use directly when no target profile exists. |
+| `--cloud` | — | No | credential/public | Power Platform cloud to use with `--auth` or the default auth credential. |
 
 > \* `--name` is ignored for `Teams` environments (the name derives from the linked group).
 
@@ -59,6 +66,9 @@ Provisions a new Power Platform environment. By default the command returns imme
 ```sh
 # Quick sandbox — returns immediately
 txc env create --type Sandbox --name "Feature Branch 42" --region europe
+
+# Create the first environment in a tenant before any profile exists
+txc env create --auth admin@contoso.com --type Developer --name "First Dev"
 
 # Developer environment owned by a specific user, wait for completion
 txc env create --type Developer --name "Jan's Dev Box" --user 00000000-0000-0000-0000-000000000001 --wait

--- a/src/TALXIS.CLI.Core/Abstractions/IConfigurationResolver.cs
+++ b/src/TALXIS.CLI.Core/Abstractions/IConfigurationResolver.cs
@@ -24,5 +24,17 @@ public sealed class ConfigurationResolutionException : Exception
 {
     public ConfigurationResolutionException(string message) : base(message) { }
     public ConfigurationResolutionException(string message, Exception inner) : base(message, inner) { }
+    public ConfigurationResolutionException(string message, ConfigurationResolutionFailureReason reason) : base(message)
+        => Reason = reason;
+    public ConfigurationResolutionException(string message, Exception inner, ConfigurationResolutionFailureReason reason) : base(message, inner)
+        => Reason = reason;
+
+    public ConfigurationResolutionFailureReason Reason { get; } = ConfigurationResolutionFailureReason.Unspecified;
 }
 #pragma warning restore RS0030
+
+public enum ConfigurationResolutionFailureReason
+{
+    Unspecified = 0,
+    NoProfile = 1,
+}

--- a/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementService.cs
+++ b/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementService.cs
@@ -22,6 +22,8 @@ public sealed record EnvironmentInfo(
 /// </summary>
 public sealed record EnvironmentCreateOptions
 {
+    public string? CredentialId { get; init; }
+    public CloudInstance? Cloud { get; init; }
     public string? DisplayName { get; init; }
     public required EnvironmentType EnvironmentType { get; init; }
     public string Region { get; init; } = "unitedstates";
@@ -96,6 +98,8 @@ public interface IEnvironmentManagementService
     /// </summary>
     Task<IReadOnlyList<EnvironmentInfo>> ListAsync(
         string? profileName,
+        string? credentialId,
+        CloudInstance? cloud,
         CancellationToken ct);
 
     /// <summary>

--- a/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementService.cs
+++ b/src/TALXIS.CLI.Core/Platforms/PowerPlatform/IEnvironmentManagementService.cs
@@ -93,8 +93,9 @@ public sealed record EnvironmentDeleteOutcome(
 public interface IEnvironmentManagementService
 {
     /// <summary>
-    /// Lists the Dataverse-backed environments in the tenant visible to the
-    /// resolved profile's identity.
+    /// Lists the Dataverse-backed environments visible to the resolved profile's
+    /// identity, or to a selected/stored auth credential during bootstrap when
+    /// no profile is available.
     /// </summary>
     Task<IReadOnlyList<EnvironmentInfo>> ListAsync(
         string? profileName,
@@ -104,7 +105,8 @@ public interface IEnvironmentManagementService
 
     /// <summary>
     /// Creates a new environment using the resolved profile's credential and
-    /// cloud for admin authority.
+    /// cloud for admin authority, or a selected/stored auth credential during
+    /// bootstrap when no profile is available.
     /// </summary>
     Task<EnvironmentCreateOutcome> CreateAsync(
         string? profileName,

--- a/src/TALXIS.CLI.Core/Resolution/ConfigurationResolver.cs
+++ b/src/TALXIS.CLI.Core/Resolution/ConfigurationResolver.cs
@@ -51,7 +51,8 @@ public sealed class ConfigurationResolver : IConfigurationResolver
         {
             throw new ConfigurationResolutionException(
                 "No txc profile could be resolved. Pass --profile <name>, set TXC_PROFILE, "
-                + "pin a workspace default with 'txc config profile pin', or select a global default with 'txc config profile select'.");
+                + "pin a workspace default with 'txc config profile pin', or select a global default with 'txc config profile select'.",
+                ConfigurationResolutionFailureReason.NoProfile);
         }
 
         var profile = await _profiles.GetAsync(name, ct).ConfigureAwait(false)

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentCreateCliCommand.cs
@@ -24,11 +24,17 @@ namespace TALXIS.CLI.Features.Environment;
 [CliLongRunning]
 [CliCommand(
     Name = "create",
-    Description = "Create a new Power Platform environment in the tenant. Requires an active profile (used for admin identity and cloud). Returns after queueing unless --wait is passed."
+    Description = "Create a new Power Platform environment in the tenant using a selected profile or auth credential. Returns after queueing unless --wait is passed."
 )]
 public class EnvironmentCreateCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EnvironmentCreateCliCommand));
+
+    [CliOption(Name = "--auth", Description = "Auth credential id to use directly when no target profile exists.", Required = false)]
+    public string? Auth { get; set; }
+
+    [CliOption(Name = "--cloud", Description = "Power Platform cloud to use with --auth or the default auth credential.", Required = false)]
+    public CloudInstance? Cloud { get; set; }
 
     [CliOption(Name = "--name", Aliases = ["-n"], Description = "Display name for the new environment. Required for every type except Teams.", Required = false)]
     public string? Name { get; set; }
@@ -68,6 +74,8 @@ public class EnvironmentCreateCliCommand : ProfiledCliCommand
 
         var options = new EnvironmentCreateOptions
         {
+            CredentialId = Auth,
+            Cloud = Cloud,
             DisplayName = Name,
             EnvironmentType = Type,
             Region = Region,

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentDeleteCliCommand.cs
@@ -51,7 +51,7 @@ public class EnvironmentDeleteCliCommand : ProfiledCliCommand, IDestructiveComma
         try
         {
             var service = TxcServices.Get<IEnvironmentManagementService>();
-            var environments = await service.ListAsync(Profile, CancellationToken.None).ConfigureAwait(false);
+            var environments = await service.ListAsync(Profile, credentialId: null, cloud: null, CancellationToken.None).ConfigureAwait(false);
             var target = environments.FirstOrDefault(e => e.EnvironmentId == EnvironmentId);
 
             if (target is null)

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentDeleteCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentDeleteCliCommand.cs
@@ -50,6 +50,9 @@ public class EnvironmentDeleteCliCommand : ProfiledCliCommand, IDestructiveComma
 
         try
         {
+            var resolver = TxcServices.Get<IConfigurationResolver>();
+            await resolver.ResolveAsync(Profile, CancellationToken.None).ConfigureAwait(false);
+
             var service = TxcServices.Get<IEnvironmentManagementService>();
             var environments = await service.ListAsync(Profile, credentialId: null, cloud: null, CancellationToken.None).ConfigureAwait(false);
             var target = environments.FirstOrDefault(e => e.EnvironmentId == EnvironmentId);

--- a/src/TALXIS.CLI.Features.Environment/EnvironmentListCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/EnvironmentListCliCommand.cs
@@ -17,11 +17,17 @@ namespace TALXIS.CLI.Features.Environment;
 [CliReadOnly]
 [CliCommand(
     Name = "list",
-    Description = "List the Power Platform environments in the tenant visible to the active profile's credential. Requires an active profile (used only for identity and cloud, not as a target)."
+    Description = "List the Power Platform environments in the tenant visible to the selected profile or auth credential."
 )]
 public class EnvironmentListCliCommand : ProfiledCliCommand
 {
     protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(EnvironmentListCliCommand));
+
+    [CliOption(Name = "--auth", Description = "Auth credential id to use directly when no target profile exists.", Required = false)]
+    public string? Auth { get; set; }
+
+    [CliOption(Name = "--cloud", Description = "Power Platform cloud to use with --auth or the default auth credential.", Required = false)]
+    public CloudInstance? Cloud { get; set; }
 
     [CliOption(Name = "--filter", Description = "Show only environments whose display name, unique name, or URL contains this substring.", Required = false)]
     public string? Filter { get; set; }
@@ -32,7 +38,7 @@ public class EnvironmentListCliCommand : ProfiledCliCommand
     protected override async Task<int> ExecuteAsync()
     {
         var service = TxcServices.Get<IEnvironmentManagementService>();
-        IReadOnlyList<EnvironmentInfo> environments = await service.ListAsync(Profile, CancellationToken.None)
+        IReadOnlyList<EnvironmentInfo> environments = await service.ListAsync(Profile, Auth, Cloud, CancellationToken.None)
             .ConfigureAwait(false);
 
         if (!string.IsNullOrWhiteSpace(Filter))

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementService.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementService.cs
@@ -137,7 +137,7 @@ public sealed class EnvironmentManagementService : IEnvironmentManagementService
         CloudInstance? cloud,
         CancellationToken ct)
     {
-        if (!string.IsNullOrWhiteSpace(credentialId) || cloud is not null)
+        if (!string.IsNullOrWhiteSpace(credentialId))
         {
             var credential = await ResolveCredentialAsync(credentialId, cloud, ct).ConfigureAwait(false);
             return (CreateTenantConnection(credential, cloud), credential);
@@ -150,10 +150,10 @@ public sealed class EnvironmentManagementService : IEnvironmentManagementService
         }
         catch (ConfigurationResolutionException ex) when (
             string.IsNullOrWhiteSpace(profileName)
-            && ex.Message.StartsWith("No txc profile could be resolved", StringComparison.Ordinal))
+            && ex.Reason == ConfigurationResolutionFailureReason.NoProfile)
         {
-            var credential = await ResolveCredentialAsync(null, null, ct).ConfigureAwait(false);
-            return (CreateTenantConnection(credential, null), credential);
+            var credential = await ResolveCredentialAsync(null, cloud, ct).ConfigureAwait(false);
+            return (CreateTenantConnection(credential, cloud), credential);
         }
     }
 

--- a/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementService.cs
+++ b/src/TALXIS.CLI.Platform.PowerPlatform.Control/EnvironmentManagementService.cs
@@ -1,4 +1,5 @@
 using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
 using TALXIS.CLI.Core.Platforms.PowerPlatform;
 
 namespace TALXIS.CLI.Platform.PowerPlatform.Control;
@@ -14,23 +15,30 @@ namespace TALXIS.CLI.Platform.PowerPlatform.Control;
 public sealed class EnvironmentManagementService : IEnvironmentManagementService
 {
     private readonly IConfigurationResolver _resolver;
+    private readonly ICredentialStore _credentials;
     private readonly IPowerPlatformEnvironmentCatalog _catalog;
     private readonly IPowerPlatformEnvironmentProvisioner _provisioner;
 
     public EnvironmentManagementService(
         IConfigurationResolver resolver,
+        ICredentialStore credentials,
         IPowerPlatformEnvironmentCatalog catalog,
         IPowerPlatformEnvironmentProvisioner provisioner)
     {
         _resolver = resolver ?? throw new ArgumentNullException(nameof(resolver));
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
         _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
         _provisioner = provisioner ?? throw new ArgumentNullException(nameof(provisioner));
     }
 
-    public async Task<IReadOnlyList<EnvironmentInfo>> ListAsync(string? profileName, CancellationToken ct)
+    public async Task<IReadOnlyList<EnvironmentInfo>> ListAsync(
+        string? profileName,
+        string? credentialId,
+        CloudInstance? cloud,
+        CancellationToken ct)
     {
-        var ctx = await _resolver.ResolveAsync(profileName, ct).ConfigureAwait(false);
-        var environments = await _catalog.ListAsync(ctx.Connection, ctx.Credential, ct).ConfigureAwait(false);
+        var (connection, credential) = await ResolveAuthorityAsync(profileName, credentialId, cloud, ct).ConfigureAwait(false);
+        var environments = await _catalog.ListAsync(connection, credential, ct).ConfigureAwait(false);
 
         return environments
             .Select(e => new EnvironmentInfo(
@@ -50,7 +58,8 @@ public sealed class EnvironmentManagementService : IEnvironmentManagementService
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        var ctx = await _resolver.ResolveAsync(profileName, ct).ConfigureAwait(false);
+        var (connection, credential) = await ResolveAuthorityAsync(
+            profileName, options.CredentialId, options.Cloud, ct).ConfigureAwait(false);
 
         var request = new EnvironmentCreateRequest
         {
@@ -67,7 +76,7 @@ public sealed class EnvironmentManagementService : IEnvironmentManagementService
             MaxWait = options.MaxWait,
         };
 
-        var result = await _provisioner.CreateAsync(ctx.Connection, ctx.Credential, request, ct).ConfigureAwait(false);
+        var result = await _provisioner.CreateAsync(connection, credential, request, ct).ConfigureAwait(false);
 
         return new EnvironmentCreateOutcome(
             result.EnvironmentId,
@@ -121,4 +130,82 @@ public sealed class EnvironmentManagementService : IEnvironmentManagementService
             result.Completed,
             result.OperationLocation);
     }
+
+    private async Task<(Connection Connection, Credential Credential)> ResolveAuthorityAsync(
+        string? profileName,
+        string? credentialId,
+        CloudInstance? cloud,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(credentialId) || cloud is not null)
+        {
+            var credential = await ResolveCredentialAsync(credentialId, cloud, ct).ConfigureAwait(false);
+            return (CreateTenantConnection(credential, cloud), credential);
+        }
+
+        try
+        {
+            var ctx = await _resolver.ResolveAsync(profileName, ct).ConfigureAwait(false);
+            return (ctx.Connection, ctx.Credential);
+        }
+        catch (ConfigurationResolutionException ex) when (
+            string.IsNullOrWhiteSpace(profileName)
+            && ex.Message.StartsWith("No txc profile could be resolved", StringComparison.Ordinal))
+        {
+            var credential = await ResolveCredentialAsync(null, null, ct).ConfigureAwait(false);
+            return (CreateTenantConnection(credential, null), credential);
+        }
+    }
+
+    private async Task<Credential> ResolveCredentialAsync(
+        string? credentialId,
+        CloudInstance? cloud,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(credentialId))
+        {
+            var credential = await _credentials.GetAsync(credentialId.Trim(), ct).ConfigureAwait(false);
+            if (credential is null)
+                throw new ConfigurationResolutionException(
+                    $"Credential '{credentialId}' was not found. Run 'txc config auth list' to see available credentials.");
+
+            if (cloud is not null && credential.Cloud is not null && credential.Cloud != cloud)
+                throw new ConfigurationResolutionException(
+                    $"Credential '{credential.Id}' is for cloud '{credential.Cloud}', not '{cloud}'. Omit --cloud or choose a matching credential.");
+
+            return credential;
+        }
+
+        var candidates = (await _credentials.ListAsync(ct).ConfigureAwait(false))
+            .Where(IsSupportedTenantCredential)
+            .Where(c => cloud is null || c.Cloud is null || c.Cloud == cloud)
+            .OrderBy(c => c.Id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return candidates.Count switch
+        {
+            1 => candidates[0],
+            0 => throw new ConfigurationResolutionException(
+                "No txc profile could be resolved and no auth credential is available. Run 'txc config auth login' first, or pass --profile."),
+            _ => throw new ConfigurationResolutionException(
+                "No txc profile could be resolved and multiple auth credentials are available. Pass --auth <credential> to select one."),
+        };
+    }
+
+    private static Connection CreateTenantConnection(Credential credential, CloudInstance? cloud)
+        => new()
+        {
+            Id = $"auth:{credential.Id}",
+            Provider = ProviderKind.Dataverse,
+            Cloud = cloud ?? credential.Cloud ?? CloudInstance.Public,
+            TenantId = credential.TenantId,
+            Description = "Tenant-level Power Platform admin authority",
+        };
+
+    private static bool IsSupportedTenantCredential(Credential credential)
+        => credential.Kind is CredentialKind.InteractiveBrowser
+            or CredentialKind.DeviceCode
+            or CredentialKind.ClientSecret
+            or CredentialKind.ClientCertificate
+            or CredentialKind.WorkloadIdentityFederation;
 }

--- a/tests/TALXIS.CLI.Tests/Environment/EnvironmentManagementServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/Environment/EnvironmentManagementServiceTests.cs
@@ -1,0 +1,203 @@
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Core.Platforms.PowerPlatform;
+using TALXIS.CLI.Core.Resolution;
+using TALXIS.CLI.Platform.PowerPlatform.Control;
+using Xunit;
+using ConnectionModel = TALXIS.CLI.Core.Model.Connection;
+
+namespace TALXIS.CLI.Tests.Environment;
+
+public sealed class EnvironmentManagementServiceTests
+{
+    [Fact]
+    public async Task List_FallsBackToSingleAuthCredential_WhenNoProfileResolves()
+    {
+        var credentials = new InMemoryCredentialStore(new Credential
+        {
+            Id = "admin",
+            Kind = CredentialKind.DeviceCode,
+            TenantId = "tenant-id",
+            Cloud = CloudInstance.Gcc,
+        });
+        var catalog = new CapturingCatalog();
+        catalog.Add(new PowerPlatformEnvironmentSummary(
+            Guid.NewGuid(),
+            "Dev",
+            new Uri("https://dev.crm.dynamics.com/"),
+            "org",
+            "dev",
+            null,
+            EnvironmentType.Developer));
+        var sut = new EnvironmentManagementService(
+            new ThrowingResolver(), credentials, catalog, new CapturingProvisioner());
+
+        var result = await sut.ListAsync(null, credentialId: null, cloud: null, CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal("auth:admin", catalog.LastConnection!.Id);
+        Assert.Null(catalog.LastConnection.EnvironmentUrl);
+        Assert.Equal("tenant-id", catalog.LastConnection.TenantId);
+        Assert.Equal(CloudInstance.Gcc, catalog.LastConnection.Cloud);
+        Assert.Equal("admin", catalog.LastCredential!.Id);
+    }
+
+    [Fact]
+    public async Task List_WithAuthAndCloud_UsesSelectedCredentialDirectly()
+    {
+        var credentials = new InMemoryCredentialStore(
+            new Credential { Id = "other", Kind = CredentialKind.DeviceCode, Cloud = CloudInstance.Public },
+            new Credential { Id = "ops", Kind = CredentialKind.DeviceCode, TenantId = "tenant-id" });
+        var catalog = new CapturingCatalog();
+        var sut = new EnvironmentManagementService(
+            new ThrowingResolver(), credentials, catalog, new CapturingProvisioner());
+
+        await sut.ListAsync(null, "ops", CloudInstance.GccHigh, CancellationToken.None);
+
+        Assert.Equal("ops", catalog.LastCredential!.Id);
+        Assert.Equal(CloudInstance.GccHigh, catalog.LastConnection!.Cloud);
+        Assert.Equal("tenant-id", catalog.LastConnection.TenantId);
+    }
+
+    [Fact]
+    public async Task List_WhenNoProfileAndMultipleCredentials_RequiresAuthSelection()
+    {
+        var credentials = new InMemoryCredentialStore(
+            new Credential { Id = "a", Kind = CredentialKind.DeviceCode },
+            new Credential { Id = "b", Kind = CredentialKind.InteractiveBrowser });
+        var sut = new EnvironmentManagementService(
+            new ThrowingResolver(), credentials, new CapturingCatalog(), new CapturingProvisioner());
+
+        var ex = await Assert.ThrowsAsync<ConfigurationResolutionException>(
+            () => sut.ListAsync(null, credentialId: null, cloud: null, CancellationToken.None));
+
+        Assert.Contains("--auth", ex.Message);
+    }
+
+    [Fact]
+    public async Task Create_FallsBackToSingleAuthCredential_WhenNoProfileResolves()
+    {
+        var credentials = new InMemoryCredentialStore(new Credential
+        {
+            Id = "admin",
+            Kind = CredentialKind.InteractiveBrowser,
+            TenantId = "tenant-id",
+        });
+        var provisioner = new CapturingProvisioner();
+        var sut = new EnvironmentManagementService(
+            new ThrowingResolver(), credentials, new CapturingCatalog(), provisioner);
+
+        var result = await sut.CreateAsync(null, new EnvironmentCreateOptions
+        {
+            DisplayName = "First",
+            EnvironmentType = EnvironmentType.Developer,
+            Cloud = CloudInstance.Public,
+        }, CancellationToken.None);
+
+        Assert.Equal("Queued", result.Status);
+        Assert.Equal("admin", provisioner.LastCredential!.Id);
+        Assert.Equal("auth:admin", provisioner.LastConnection!.Id);
+        Assert.Null(provisioner.LastConnection.EnvironmentUrl);
+        Assert.Equal("tenant-id", provisioner.LastConnection.TenantId);
+        Assert.Equal("First", provisioner.LastCreateRequest!.DisplayName);
+    }
+
+    private sealed class ThrowingResolver : IConfigurationResolver
+    {
+        public Task<ResolvedProfileContext> ResolveAsync(string? profileName, CancellationToken ct)
+            => throw new ConfigurationResolutionException("No txc profile could be resolved.");
+    }
+
+    private sealed class InMemoryCredentialStore : ICredentialStore
+    {
+        private readonly Dictionary<string, Credential> _credentials;
+
+        public InMemoryCredentialStore(params Credential[] credentials)
+            => _credentials = credentials.ToDictionary(c => c.Id, StringComparer.OrdinalIgnoreCase);
+
+        public Task<IReadOnlyList<Credential>> ListAsync(CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<Credential>>(_credentials.Values.ToList());
+
+        public Task<Credential?> GetAsync(string id, CancellationToken ct)
+            => Task.FromResult(_credentials.TryGetValue(id, out var credential) ? credential : null);
+
+        public Task UpsertAsync(Credential credential, CancellationToken ct)
+        {
+            _credentials[credential.Id] = credential;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> DeleteAsync(string id, CancellationToken ct)
+            => Task.FromResult(_credentials.Remove(id));
+    }
+
+    private sealed class CapturingCatalog : IPowerPlatformEnvironmentCatalog
+    {
+        private readonly List<PowerPlatformEnvironmentSummary> _environments = [];
+
+        public ConnectionModel? LastConnection { get; private set; }
+        public Credential? LastCredential { get; private set; }
+
+        public void Add(PowerPlatformEnvironmentSummary environment)
+            => _environments.Add(environment);
+
+        public Task<IReadOnlyList<PowerPlatformEnvironmentSummary>> ListAsync(
+            ConnectionModel connection,
+            Credential credential,
+            CancellationToken ct)
+        {
+            LastConnection = connection;
+            LastCredential = credential;
+            return Task.FromResult<IReadOnlyList<PowerPlatformEnvironmentSummary>>(_environments);
+        }
+
+        public Task<PowerPlatformEnvironmentSummary?> TryGetByEnvironmentUrlAsync(
+            ConnectionModel connection,
+            Credential credential,
+            Uri environmentUrl,
+            CancellationToken ct)
+            => Task.FromResult<PowerPlatformEnvironmentSummary?>(null);
+    }
+
+    private sealed class CapturingProvisioner : IPowerPlatformEnvironmentProvisioner
+    {
+        public ConnectionModel? LastConnection { get; private set; }
+        public Credential? LastCredential { get; private set; }
+        public EnvironmentCreateRequest? LastCreateRequest { get; private set; }
+
+        public Task<EnvironmentCreateResult> CreateAsync(
+            ConnectionModel connection,
+            Credential credential,
+            EnvironmentCreateRequest request,
+            CancellationToken ct)
+        {
+            LastConnection = connection;
+            LastCredential = credential;
+            LastCreateRequest = request;
+            return Task.FromResult(new EnvironmentCreateResult(
+                Guid.NewGuid(),
+                request.DisplayName,
+                null,
+                request.EnvironmentType,
+                "Queued",
+                Completed: false,
+                OperationLocation: null));
+        }
+
+        public Task<EnvironmentUpdateResult> UpdateAsync(
+            ConnectionModel connection,
+            Credential credential,
+            EnvironmentUpdateRequest request,
+            CancellationToken ct)
+            => throw new NotSupportedException();
+
+        public Task<EnvironmentDeleteResult> DeleteAsync(
+            ConnectionModel connection,
+            Credential credential,
+            Guid environmentId,
+            bool wait,
+            TimeSpan maxWait,
+            CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+}

--- a/tests/TALXIS.CLI.Tests/Environment/EnvironmentManagementServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/Environment/EnvironmentManagementServiceTests.cs
@@ -60,6 +60,46 @@ public sealed class EnvironmentManagementServiceTests
     }
 
     [Fact]
+    public async Task List_WithProfileAndCloud_UsesResolvedProfile()
+    {
+        var profileCredential = new Credential { Id = "profile-credential", Kind = CredentialKind.DeviceCode };
+        var resolver = new CapturingResolver(new ResolvedProfileContext(
+            new Profile { Id = "profile", ConnectionRef = "profile-connection", CredentialRef = profileCredential.Id },
+            new ConnectionModel { Id = "profile-connection", Provider = ProviderKind.Dataverse, Cloud = CloudInstance.Public },
+            profileCredential,
+            ResolutionSource.CommandLine));
+        var credentials = new InMemoryCredentialStore(
+            profileCredential,
+            new Credential { Id = "admin", Kind = CredentialKind.DeviceCode, Cloud = CloudInstance.GccHigh });
+        var catalog = new CapturingCatalog();
+        var sut = new EnvironmentManagementService(
+            resolver, credentials, catalog, new CapturingProvisioner());
+
+        await sut.ListAsync("profile", credentialId: null, cloud: CloudInstance.GccHigh, CancellationToken.None);
+
+        Assert.Equal("profile", resolver.LastProfileName);
+        Assert.Equal("profile-credential", catalog.LastCredential!.Id);
+        Assert.Equal("profile-connection", catalog.LastConnection!.Id);
+        Assert.Equal(CloudInstance.Public, catalog.LastConnection.Cloud);
+    }
+
+    [Fact]
+    public async Task List_WithCloudFallsBackToMatchingCredential_WhenNoProfileResolves()
+    {
+        var credentials = new InMemoryCredentialStore(
+            new Credential { Id = "public", Kind = CredentialKind.DeviceCode, Cloud = CloudInstance.Public },
+            new Credential { Id = "gcc", Kind = CredentialKind.DeviceCode, Cloud = CloudInstance.GccHigh });
+        var catalog = new CapturingCatalog();
+        var sut = new EnvironmentManagementService(
+            new ThrowingResolver(), credentials, catalog, new CapturingProvisioner());
+
+        await sut.ListAsync(null, credentialId: null, cloud: CloudInstance.GccHigh, CancellationToken.None);
+
+        Assert.Equal("gcc", catalog.LastCredential!.Id);
+        Assert.Equal(CloudInstance.GccHigh, catalog.LastConnection!.Cloud);
+    }
+
+    [Fact]
     public async Task List_WhenNoProfileAndMultipleCredentials_RequiresAuthSelection()
     {
         var credentials = new InMemoryCredentialStore(
@@ -105,7 +145,20 @@ public sealed class EnvironmentManagementServiceTests
     private sealed class ThrowingResolver : IConfigurationResolver
     {
         public Task<ResolvedProfileContext> ResolveAsync(string? profileName, CancellationToken ct)
-            => throw new ConfigurationResolutionException("No txc profile could be resolved.");
+            => throw new ConfigurationResolutionException(
+                "No txc profile could be resolved.",
+                ConfigurationResolutionFailureReason.NoProfile);
+    }
+
+    private sealed class CapturingResolver(ResolvedProfileContext context) : IConfigurationResolver
+    {
+        public string? LastProfileName { get; private set; }
+
+        public Task<ResolvedProfileContext> ResolveAsync(string? profileName, CancellationToken ct)
+        {
+            LastProfileName = profileName;
+            return Task.FromResult(context);
+        }
     }
 
     private sealed class InMemoryCredentialStore : ICredentialStore


### PR DESCRIPTION
## Summary
- Allow tenant-level `txc env list` and `txc env create` to run from a stored auth credential when no profile is resolvable.
- Add `--auth` and `--cloud` to select the credential/cloud explicitly; otherwise a single eligible credential is used.
- Build a tenant-level admin connection without requiring an environment URL, and keep update/delete profile-bound.
- Document bootstrap usage and add unit tests for default, explicit, and ambiguous credential flows.

## Validation
- `dotnet build TALXIS.CLI.sln --no-restore --nologo --verbosity:minimal` ✅
- `dotnet test tests/TALXIS.CLI.Tests/TALXIS.CLI.Tests.csproj --no-build --nologo --verbosity:minimal` ✅
- `dotnet test TALXIS.CLI.sln --no-build --nologo --verbosity:minimal` ⚠️ existing integration failures for `workspace component parameter list pp-entity` because template `pp-entity` is not found in this checkout.

No Mono used.