### PR TITLE
feat(auth): add config auth add-federated for workload identity federation

### DIFF
--- a/docs/profiles-and-authentication.md
+++ b/docs/profiles-and-authentication.md
@@ -96,7 +96,16 @@ txc config profile select ci
 
 After that, all subsequent `txc` commands use `TXC_CONFIG_DIR` plus the selected profile.
 
-For workload identity federation, the Dataverse provider auto-detects the expected GitHub Actions and Azure DevOps token request environment variables at acquisition time.
+For workload identity federation, register the app without a secret:
+
+```sh
+txc config auth add-federated \
+  --tenant "$AZURE_TENANT_ID" \
+  --client-id "$AZURE_CLIENT_ID" \
+  --alias ci-wif
+```
+
+At token acquisition time, the Dataverse provider auto-detects the expected GitHub Actions and Azure DevOps token request environment variables (or `AZURE_FEDERATED_TOKEN_FILE`).
 
 ## Override the target for one command
 

--- a/src/TALXIS.CLI.Core/Headless/HeadlessAuthRequiredException.cs
+++ b/src/TALXIS.CLI.Core/Headless/HeadlessAuthRequiredException.cs
@@ -47,9 +47,10 @@ public sealed class HeadlessAuthRequiredException : Exception
             $"Credential kind '{ToKebab(kind)}' requires an interactive TTY, " +
             $"but this process is running in headless mode ({reason}). " +
             $"Permitted headless kinds: {permitted}. " +
-            "To run non-interactively, register a headless-capable credential with " +
+            "To run non-interactively, register a headless-capable credential with either " +
             "`txc config auth add-service-principal --alias <alias> --tenant <tenant> " +
-            "--client-id <app-id> --secret-from-env <ENV_VAR_NAME>` and bind it to the profile, " +
+            "--client-id <app-id> --secret-from-env <ENV_VAR_NAME>` or " +
+            "`txc config auth add-federated --alias <alias> --tenant <tenant> --client-id <app-id>`, and bind it to the profile, " +
             "or supply the credential via environment variables " +
             "(AZURE_CLIENT_ID / AZURE_CLIENT_SECRET / AZURE_TENANT_ID for SPN, " +
             "AZURE_FEDERATED_TOKEN_FILE for workload-identity federation).";

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthAddFederatedCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthAddFederatedCliCommand.cs
@@ -1,0 +1,83 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.DependencyInjection;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Logging;
+
+namespace TALXIS.CLI.Features.Config.Auth;
+
+/// <summary>
+/// <c>txc config auth add-federated</c> — register a workload-identity
+/// federation credential (tenant + app id, no secret). At token
+/// acquisition time, txc auto-detects the OIDC assertion source from
+/// GitHub Actions (<c>ACTIONS_ID_TOKEN_REQUEST_URL</c> /
+/// <c>ACTIONS_ID_TOKEN_REQUEST_TOKEN</c>) or Azure DevOps
+/// System.AccessToken-backed environment variables.
+/// </summary>
+[CliIdempotent]
+[CliCommand(
+    Name = "add-federated",
+    Aliases = ["add-workload-identity"],
+    Description = "Register a workload-identity federation credential. At token acquisition time, txc auto-detects the OIDC assertion from GitHub Actions (ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN) or Azure DevOps (SYSTEM_ACCESSTOKEN-backed) environment variables."
+)]
+public class AuthAddFederatedCliCommand : TxcLeafCommand
+{
+    protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(AuthAddFederatedCliCommand));
+
+    [CliOption(Name = "--alias", Description = "Credential alias used to reference this federated credential.", Required = true)]
+    public string Alias { get; set; } = string.Empty;
+
+    [CliOption(Name = "--tenant", Description = "Entra tenant id or domain.", Required = true)]
+    public string Tenant { get; set; } = string.Empty;
+
+    [CliOption(Name = "--application-id", Aliases = ["--app-id", "--client-id"], Description = "Entra application (client) id.", Required = true)]
+    public string ApplicationId { get; set; } = string.Empty;
+
+    [CliOption(Name = "--cloud", Description = "Sovereign cloud. Default: public.", Required = false)]
+    public CloudInstance? Cloud { get; set; }
+
+    [CliOption(Name = "--description", Description = "Free-form label shown in 'config auth list'.", Required = false)]
+    public string? Description { get; set; }
+
+    protected override async Task<int> ExecuteAsync()
+    {
+        var headless = TxcServices.Get<IHeadlessDetector>();
+        headless.EnsureKindAllowed(CredentialKind.WorkloadIdentityFederation);
+
+        var alias = Alias.Trim();
+        if (string.IsNullOrEmpty(alias))
+        {
+            Logger.LogError("--alias must not be empty.");
+            return ExitError;
+        }
+
+        var credential = new Credential
+        {
+            Id = alias,
+            Kind = CredentialKind.WorkloadIdentityFederation,
+            TenantId = Tenant.Trim(),
+            ApplicationId = ApplicationId.Trim(),
+            Cloud = Cloud ?? CloudInstance.Public,
+            Description = Description,
+        };
+
+        var store = TxcServices.Get<ICredentialStore>();
+        await store.UpsertAsync(credential, CancellationToken.None).ConfigureAwait(false);
+
+        Logger.LogInformation("Saved federated credential '{Alias}' (app {AppId}, tenant {Tenant}).",
+            alias, credential.ApplicationId, credential.TenantId);
+
+        OutputFormatter.WriteData(new
+        {
+            id = credential.Id,
+            kind = credential.Kind,
+            tenantId = credential.TenantId,
+            applicationId = credential.ApplicationId,
+            cloud = credential.Cloud,
+            description = credential.Description,
+        });
+        return ExitSuccess;
+    }
+}

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthAddFederatedCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthAddFederatedCliCommand.cs
@@ -12,15 +12,17 @@ namespace TALXIS.CLI.Features.Config.Auth;
 /// <c>txc config auth add-federated</c> — register a workload-identity
 /// federation credential (tenant + app id, no secret). At token
 /// acquisition time, txc auto-detects the OIDC assertion source from
-/// GitHub Actions (<c>ACTIONS_ID_TOKEN_REQUEST_URL</c> /
-/// <c>ACTIONS_ID_TOKEN_REQUEST_TOKEN</c>) or Azure DevOps
-/// System.AccessToken-backed environment variables.
+/// GitHub Actions (<c>ACTIONS_ID_TOKEN_REQUEST_URL</c> +
+/// <c>ACTIONS_ID_TOKEN_REQUEST_TOKEN</c>), Azure DevOps
+/// (<c>TXC_ADO_ID_TOKEN_REQUEST_URL</c> +
+/// <c>TXC_ADO_ID_TOKEN_REQUEST_TOKEN</c>; legacy <c>PAC_ADO_*</c> also
+/// honored), or <c>AZURE_FEDERATED_TOKEN_FILE</c>.
 /// </summary>
 [CliIdempotent]
 [CliCommand(
     Name = "add-federated",
     Aliases = ["add-workload-identity"],
-    Description = "Register a workload-identity federation credential. At token acquisition time, txc auto-detects the OIDC assertion from GitHub Actions (ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN) or Azure DevOps (SYSTEM_ACCESSTOKEN-backed) environment variables."
+    Description = "Register a workload-identity federation credential. At token acquisition time, txc auto-detects the OIDC assertion from GitHub Actions (ACTIONS_ID_TOKEN_REQUEST_URL + ACTIONS_ID_TOKEN_REQUEST_TOKEN), Azure DevOps (TXC_ADO_ID_TOKEN_REQUEST_URL + TXC_ADO_ID_TOKEN_REQUEST_TOKEN; legacy PAC_ADO_* also honored), or AZURE_FEDERATED_TOKEN_FILE."
 )]
 public class AuthAddFederatedCliCommand : TxcLeafCommand
 {
@@ -53,12 +55,26 @@ public class AuthAddFederatedCliCommand : TxcLeafCommand
             return ExitError;
         }
 
+        var tenant = Tenant.Trim();
+        if (string.IsNullOrEmpty(tenant))
+        {
+            Logger.LogError("--tenant must not be empty.");
+            return ExitError;
+        }
+
+        var applicationId = ApplicationId.Trim();
+        if (string.IsNullOrEmpty(applicationId))
+        {
+            Logger.LogError("--application-id must not be empty.");
+            return ExitError;
+        }
+
         var credential = new Credential
         {
             Id = alias,
             Kind = CredentialKind.WorkloadIdentityFederation,
-            TenantId = Tenant.Trim(),
-            ApplicationId = ApplicationId.Trim(),
+            TenantId = tenant,
+            ApplicationId = applicationId,
             Cloud = Cloud ?? CloudInstance.Public,
             Description = Description,
         };

--- a/src/TALXIS.CLI.Features.Config/Auth/AuthCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Config/Auth/AuthCliCommand.cs
@@ -16,6 +16,7 @@ namespace TALXIS.CLI.Features.Config.Auth;
     {
         typeof(AuthLoginCliCommand),
         typeof(AuthAddServicePrincipalCliCommand),
+        typeof(AuthAddFederatedCliCommand),
         typeof(AuthListCliCommand),
         typeof(AuthGetCliCommand),
         typeof(AuthDeleteCliCommand),

--- a/src/TALXIS.CLI.MCP/README.md
+++ b/src/TALXIS.CLI.MCP/README.md
@@ -172,8 +172,10 @@ environment (or any other Connection-bound tool):
 
 1. On the human's machine, run `txc config auth login` (interactive
    browser), `txc config auth add-service-principal`, or
-   `txc config auth add-federated` once to register a credential and
-   prime the MSAL token cache.
+   `txc config auth add-federated` once to register a credential entry.
+   Interactive login also primes the MSAL token cache; service-principal
+   and federated entries rely on their configured secret / OIDC
+   assertion source at token-acquisition time.
 2. Run `txc config connection create <name> --provider dataverse ...`
    to register the endpoint.
 3. Run `txc config profile create <name> --auth <alias> --connection <name>`
@@ -181,11 +183,15 @@ environment (or any other Connection-bound tool):
    workspace via `txc config profile pin`).
 
 After that, MCP tool calls resolve the active profile silently via the
-acquired token cache or stored SPN secret. If resolution fails (expired
-refresh token, missing credential, broken config), the subprocess exits
-non-zero and the MCP server surfaces the error through the tool-call
-result; the structured log line includes the fail-fast remedy string
-(`txc config profile validate <name>`).
+acquired token cache, stored SPN secret, or workload-identity
+federation assertion source (`AZURE_FEDERATED_TOKEN_FILE`,
+`ACTIONS_ID_TOKEN_REQUEST_URL` + `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, or
+`TXC_ADO_ID_TOKEN_REQUEST_URL` + `TXC_ADO_ID_TOKEN_REQUEST_TOKEN`;
+legacy `PAC_ADO_*` is also honored). If resolution fails (expired
+refresh token, missing credential, missing assertion source, broken
+config), the subprocess exits non-zero and the MCP server surfaces the
+error through the tool-call result; the structured log line includes the
+fail-fast remedy string (`txc config profile validate <name>`).
 
 ### Per-call profile override
 

--- a/src/TALXIS.CLI.MCP/README.md
+++ b/src/TALXIS.CLI.MCP/README.md
@@ -171,8 +171,9 @@ Prerequisites, before invoking any tool that touches a Dataverse
 environment (or any other Connection-bound tool):
 
 1. On the human's machine, run `txc config auth login` (interactive
-   browser) or `txc config auth add-service-principal` once to register
-   a credential and prime the MSAL token cache.
+   browser), `txc config auth add-service-principal`, or
+   `txc config auth add-federated` once to register a credential and
+   prime the MSAL token cache.
 2. Run `txc config connection create <name> --provider dataverse ...`
    to register the endpoint.
 3. Run `txc config profile create <name> --auth <alias> --connection <name>`
@@ -212,9 +213,11 @@ else is ignored:
 | `TXC_ADO_ID_TOKEN_REQUEST_URL`, `TXC_ADO_ID_TOKEN_REQUEST_TOKEN` | Azure DevOps pipelines workload-identity federation (legacy `PAC_ADO_*` also honored). |
 
 Secrets (client secrets, PATs, certificate passwords) are **never**
-accepted as plain MCP tool arguments — they are stored in the OS-level
-secret vault via `txc config auth add-service-principal` and referenced
-from config by `SecretRef` handle only.
+accepted as plain MCP tool arguments — when a secret is needed it is
+stored in the OS-level secret vault via
+`txc config auth add-service-principal` and referenced from config by
+`SecretRef` handle only. Federated credentials registered with
+`txc config auth add-federated` do not persist any secret.
 
 ### Log redaction
 

--- a/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthAddFederatedCommandTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthAddFederatedCommandTests.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Abstractions;
+using TALXIS.CLI.Core.Model;
+using TALXIS.CLI.Features.Config.Auth;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Config.Commands.Auth;
+
+[Collection("TxcServicesSerial")]
+public sealed class AuthAddFederatedCommandTests
+{
+    [Fact]
+    public async Task AddFederated_PersistsCredentialWithoutVaultSecret()
+    {
+        using var host = new CommandTestHost();
+
+        var sw = new StringWriter();
+        int exit;
+        using (OutputWriter.RedirectTo(sw))
+            exit = await new AuthAddFederatedCliCommand
+            {
+                Alias = "ci",
+                Tenant = "contoso.onmicrosoft.com",
+                ApplicationId = "11111111-1111-1111-1111-111111111111",
+                Description = "GitHub Actions deploy",
+            }.RunAsync();
+
+        Assert.Equal(0, exit);
+
+        var store = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
+        var cred = await store.GetAsync("ci", default);
+        Assert.NotNull(cred);
+        Assert.Equal(CredentialKind.WorkloadIdentityFederation, cred!.Kind);
+        Assert.Equal("contoso.onmicrosoft.com", cred.TenantId);
+        Assert.Equal("11111111-1111-1111-1111-111111111111", cred.ApplicationId);
+        Assert.Equal(CloudInstance.Public, cred.Cloud);
+        Assert.Equal("GitHub Actions deploy", cred.Description);
+        Assert.Null(cred.SecretRef);
+        Assert.Empty(host.Vault.Contents);
+
+        using var doc = JsonDocument.Parse(sw.ToString());
+        Assert.Equal("ci", doc.RootElement.GetProperty("id").GetString());
+        Assert.Equal("workload-identity-federation", doc.RootElement.GetProperty("kind").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("secretRef", out _));
+    }
+
+    [Fact]
+    public async Task AddFederated_WorksInHeadlessMode_SinceFederationIsPermittedThere()
+    {
+        using var host = new CommandTestHost(headless: true);
+
+        var exit = await new AuthAddFederatedCliCommand
+        {
+            Alias = "ci-hl",
+            Tenant = "tenant-guid",
+            ApplicationId = "app-guid",
+        }.RunAsync();
+
+        Assert.Equal(0, exit);
+
+        var store = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
+        var cred = await store.GetAsync("ci-hl", default);
+        Assert.NotNull(cred);
+        Assert.Equal(CredentialKind.WorkloadIdentityFederation, cred!.Kind);
+        Assert.Empty(host.Vault.Contents);
+    }
+}

--- a/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthAddFederatedCommandTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Commands/Auth/AuthAddFederatedCommandTests.cs
@@ -66,4 +66,25 @@ public sealed class AuthAddFederatedCommandTests
         Assert.Equal(CredentialKind.WorkloadIdentityFederation, cred!.Kind);
         Assert.Empty(host.Vault.Contents);
     }
+
+    [Theory]
+    [InlineData("   ", "app-guid")]
+    [InlineData("tenant-guid", "   ")]
+    public async Task AddFederated_FailsWhenTenantOrApplicationIdIsBlank(string tenant, string applicationId)
+    {
+        using var host = new CommandTestHost();
+
+        var exit = await new AuthAddFederatedCliCommand
+        {
+            Alias = "ci-invalid",
+            Tenant = tenant,
+            ApplicationId = applicationId,
+        }.RunAsync();
+
+        Assert.Equal(1, exit);
+
+        var store = (ICredentialStore)host.Provider.GetService(typeof(ICredentialStore))!;
+        Assert.Null(await store.GetAsync("ci-invalid", default));
+        Assert.Empty(host.Vault.Contents);
+    }
 }

--- a/tests/TALXIS.CLI.Tests/Config/Headless/HeadlessAuthRequiredExceptionTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Headless/HeadlessAuthRequiredExceptionTests.cs
@@ -51,6 +51,14 @@ public sealed class HeadlessAuthRequiredExceptionTests
     }
 
     [Fact]
+    public void Message_IncludesHeadlessRegistrationCommands()
+    {
+        var ex = new HeadlessAuthRequiredException(CredentialKind.InteractiveBrowser, "CI=true");
+        Assert.Contains("txc config auth add-service-principal", ex.Message);
+        Assert.Contains("txc config auth add-federated", ex.Message);
+    }
+
+    [Fact]
     public void EnsureKindAllowed_NoThrow_WhenInteractive()
     {
         var detector = new StubDetector { IsHeadless = false };

--- a/tests/TALXIS.CLI.Tests/MCP/CliCommandLookupServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/MCP/CliCommandLookupServiceTests.cs
@@ -97,6 +97,7 @@ public class CliCommandLookupServiceTests
         Assert.Contains("config_profile_create", tools);
         Assert.Contains("config_profile_select", tools);
         Assert.Contains("config_auth_add-service-principal", tools);
+        Assert.Contains("config_auth_add-federated", tools);
         Assert.Contains("workspace_explain", tools);
     }
 


### PR DESCRIPTION
## Summary
- add `txc config auth add-federated` (alias: `add-workload-identity`) to register Workload Identity Federation credentials
- persist `CredentialKind.WorkloadIdentityFederation` entries with tenant/app id only and no vault secret
- document the auto-detected GitHub Actions / Azure DevOps OIDC assertion flow and cover it with tests

## Why
This enables GitHub Actions and other CI deploy flows to authenticate to Dataverse with workload identity federation instead of storing a client secret. The credential can be registered once, then at token-acquisition time `txc` auto-detects the OIDC assertion from the runner environment and exchanges it for an access token.