### PR TITLE
refactor: use --record-id flag for record file upload/download (#86)

### DIFF
--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordDownloadFileCliCommand.cs
@@ -23,8 +23,11 @@ public class EnvDataRecordDownloadFileCliCommand : ProfiledCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. fin_mytable).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(
+    [CliOption(
+        Name = "--record-id",
+        Aliases = ["--record"],
         Description = "The GUID of the record containing the file.",
+        Required = true,
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
     public required Guid RecordId { get; set; }

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUploadFileCliCommand.cs
@@ -23,8 +23,11 @@ public class EnvDataRecordUploadFileCliCommand : StagedCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. fin_mytable).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliArgument(
+    [CliOption(
+        Name = "--record-id",
+        Aliases = ["--record"],
         Description = "The GUID of the record to upload the file to.",
+        Required = true,
         ValidationPattern = CliValidation.GuidPattern,
         ValidationMessage = CliValidation.GuidValidationMessage)]
     public required Guid RecordId { get; set; }


### PR DESCRIPTION
Upload-file and download-file took the record id as a positional argument, which reads badly next to all the other named options. this makes it a proper --record-id flag (with a --record alias) on both commands, so argument order stops mattering.

not a fix for the bug in #86 (image download already works on master), just the flag gap the issue surfaced.

Close #86 