### PR TITLE
fix(data/import): pre-populate LookupKeys cache and newId to eliminate redundant CMT server lookups

### DIFF
--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -47,6 +47,15 @@ public sealed class CmtImportRunner
     /// </summary>
     private int _lookupKeysPrepopulated;
 
+    /// <summary>
+    /// Runtime type of the ImportCrmDataHandler (set during RunInternalAsync).
+    /// Used by <see cref="PrePopulateLookupKeysFromPackage"/> to navigate to
+    /// the correct runtime-loaded DataMigCommon assembly, which may differ from
+    /// the net462 compile-time reference if the assembly resolver returned a
+    /// different instance.
+    /// </summary>
+    private Type? _handlerRuntimeType;
+
     public CmtImportRunner()
     {
         _assemblyMap = new Dictionary<string, Assembly>(
@@ -198,6 +207,10 @@ public sealed class CmtImportRunner
             ConfigurationManager.AppSettings["ExportFiles"] = "true";
 
             // 4. Wire progress event handlers.
+            // Capture the RUNTIME type so PrePopulateLookupKeysFromPackage can
+            // navigate to the correct DataMigCommon assembly instance (which may
+            // differ from the net462 compile-time reference).
+            _handlerRuntimeType = handler.GetType();
             handler.AddNewProgressItem += OnAddNewProgressItem;
             handler.UpdateProgressItem += OnUpdateProgressItem;
 
@@ -485,19 +498,47 @@ public sealed class CmtImportRunner
     {
         try
         {
-            // Locate ImportCommonMethods in the runtime-loaded CMT assembly.
-            // Type.GetType() with assembly-qualified name often fails for Cecil-patched
-            // legacy assemblies; scan all loaded assemblies by partial name instead.
-            Type? importCommonType = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => a.GetName().Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) == true)
-                .Select(a => a.GetType("Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods"))
-                .FirstOrDefault(t => t != null);
+            // Navigate to the RUNTIME-loaded DataMigCommon assembly via the
+            // handler's type. AppDomain.GetAssemblies() may contain both the
+            // compile-time net462 copy and the runtime-loaded copy; they carry
+            // separate static state, so we must find the one CMT actually uses.
+            Type? importCommonType = null;
+            if (_handlerRuntimeType != null)
+            {
+                // Walk ImportProcessor's referenced assemblies to find DataMigCommon.
+                foreach (var asmRef in _handlerRuntimeType.Assembly.GetReferencedAssemblies())
+                {
+                    if (asmRef.Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) != true)
+                        continue;
+
+                    // Get the already-loaded instance with the same name.
+                    var loaded = AppDomain.CurrentDomain.GetAssemblies()
+                        .FirstOrDefault(a => string.Equals(a.GetName().Name, asmRef.Name, StringComparison.OrdinalIgnoreCase));
+                    if (loaded == null) continue;
+
+                    importCommonType = loaded.GetType(
+                        "Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods");
+                    if (importCommonType != null) break;
+                }
+            }
+
+            // Fallback: scan all loaded assemblies (less precise but still useful).
+            if (importCommonType == null)
+            {
+                importCommonType = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => a.GetName().Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) == true)
+                    .Select(a => a.GetType("Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods"))
+                    .FirstOrDefault(t => t != null);
+            }
 
             if (importCommonType == null)
             {
                 _logger.LogInformation("LookupKeys pre-population skipped — ImportCommonMethods type not found in loaded assemblies");
                 return;
             }
+
+            _logger.LogInformation("LookupKeys pre-population: using type from assembly {Assembly}",
+                importCommonType.Assembly.FullName);
 
             // Retrieve the static LookupKeys ConcurrentDictionary<string, Guid>.
             var lookupKeysField = importCommonType.GetField(

--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -368,6 +368,19 @@ public sealed class CmtImportRunner
 
     private void OnAddNewProgressItem(object? sender, ProgressItemEventArgs e)
     {
+        // "Processing Entity: <name>" is the first AddNewProgressItem fired by
+        // ImportCrmEntityActions.BeginEntityImport() — it fires AFTER
+        // ImportDataToCrm() has called ImportCommonMethods.ClearCrossReferanceList()
+        // (which clears LookupKeys), so this is the correct point to pre-seed the
+        // cache. Hooking on "Schema Validation Complete" fires too early — CMT wipes
+        // LookupKeys via ClearCrossReferanceList() after that event returns.
+        string message = e.progressItem?.ItemText ?? string.Empty;
+        if (message.StartsWith("Processing Entity:", StringComparison.OrdinalIgnoreCase)
+            && Interlocked.CompareExchange(ref _lookupKeysPrepopulated, 1, 0) == 0)
+        {
+            PrePopulateLookupKeysFromPackage();
+        }
+
         OnUpdateProgressItem(sender, e);
     }
 
@@ -377,17 +390,6 @@ public sealed class CmtImportRunner
             return;
 
         string message = e.progressItem.ItemText ?? string.Empty;
-
-        // CMT fires "Schema Validation Complete" once ImportDataToCrm() has
-        // parsed both data_schema.xml and data.xml and populated
-        // ImportCommonMethods.dataEntities. This is the earliest safe point to
-        // pre-seed LookupKeys, because dataEntities is null before this event.
-        if (e.progressItem.ItemStatus == ProgressItemStatus.Complete
-            && message.StartsWith("Schema Validation Complete", StringComparison.OrdinalIgnoreCase)
-            && Interlocked.CompareExchange(ref _lookupKeysPrepopulated, 1, 0) == 0)
-        {
-            PrePopulateLookupKeysFromPackage();
-        }
 
         switch (e.progressItem.ItemStatus)
         {

--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -246,7 +246,21 @@ public sealed class CmtImportRunner
 
             _logger.LogInformation("Schema Validation Complete.");
 
-            // 8. Import data (synchronous — blocks via internal WaitOne).
+            // 8. Pre-populate LookupKeys for all package records.
+            // CMT's FindEntity() only sets record.newId when UpsertMultiple returns
+            // RecordCreated=true. For records that already exist in the target,
+            // RecordCreated=false → newId stays null → every child-entity lookup
+            // for that parent falls through to a separate server round-trip.
+            //
+            // Because CMT always preserves source GUIDs (UpsertRequest.Target.Id =
+            // source GUID), the target GUID equals the source GUID for every record
+            // in the package. Pre-seeding LookupKeys with this mapping lets
+            // FindEntity() short-circuit at the cache check (line 2851 in
+            // ImportCrmEntityActions.cs) without any server call, for both new
+            // records and records that already exist in the target.
+            PrePopulateLookupKeysFromPackage();
+
+            // 9. Import data (synchronous — blocks via internal WaitOne).
             _logger.LogInformation("Starting data import...");
             // NOTE: The deleteBeforeAdd parameter is accepted by CMT's API but
             // is never actually used internally — the delete functionality was
@@ -426,5 +440,132 @@ public sealed class CmtImportRunner
 
         _unresolvedAssemblies.Add(key);
         return null;
+    }
+
+    /// <summary>
+    /// Pre-seeds <c>ImportCommonMethods.LookupKeys</c> with every record
+    /// in the loaded package so that <c>FindEntity()</c> can short-circuit the
+    /// cache lookup for internal package references without a server round-trip.
+    ///
+    /// <para>
+    /// CMT's <c>UpsertMultiple</c> handler only sets <c>record.newId</c> when
+    /// <c>RecordCreated == true</c> (line 884 of <c>ImportCrmEntityActions.cs</c>).
+    /// For records that already exist in the target (<c>RecordCreated=false</c>),
+    /// <c>newId</c> stays null, so every child-entity lookup for that parent falls
+    /// through to <c>LookupCustomerOrLookupFieldInCRM</c> — one server call per
+    /// unique lookup reference.
+    /// </para>
+    ///
+    /// <para>
+    /// Because CMT always preserves source GUIDs (the <c>UpsertRequest</c> target
+    /// entity's <c>Id</c> is set to the source record GUID), the target GUID is
+    /// always equal to the source GUID. Pre-seeding the cache with
+    /// <c>"entityName:sourceGuid" → sourceGuid</c> is therefore always correct,
+    /// regardless of whether the record is new or pre-existing in the target.
+    /// </para>
+    ///
+    /// <para>
+    /// This does not affect external lookups (entities not present in the package)
+    /// — those still resolve via the normal server call path.
+    /// </para>
+    ///
+    /// <para>
+    /// Accesses CMT internals via reflection because
+    /// <c>Microsoft.Xrm.Tooling.Dmt.DataMigCommon</c> is a net462 legacy assembly
+    /// that is patched and loaded at runtime — it is not directly referenceable
+    /// from the net10 host at compile time.
+    /// </para>
+    /// </summary>
+    private void PrePopulateLookupKeysFromPackage()
+    {
+        try
+        {
+            // Locate ImportCommonMethods in the runtime-loaded CMT assembly.
+            Type? importCommonType = Type.GetType(
+                "Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods, Microsoft.Xrm.Tooling.Dmt.DataMigCommon",
+                throwOnError: false);
+
+            if (importCommonType == null)
+            {
+                _logger.LogDebug("LookupKeys pre-population skipped — ImportCommonMethods type not found");
+                return;
+            }
+
+            // Retrieve the static LookupKeys ConcurrentDictionary<string, Guid>.
+            var lookupKeysField = importCommonType.GetField(
+                "LookupKeys", BindingFlags.Public | BindingFlags.Static);
+            object? lookupKeys = lookupKeysField?.GetValue(null);
+            if (lookupKeys == null)
+            {
+                _logger.LogDebug("LookupKeys pre-population skipped — LookupKeys field not found or null");
+                return;
+            }
+
+            // Get TryAdd(string, Guid) on the ConcurrentDictionary.
+            MethodInfo? tryAdd = lookupKeys.GetType().GetMethod(
+                "TryAdd", [typeof(string), typeof(Guid)]);
+            if (tryAdd == null)
+            {
+                _logger.LogDebug("LookupKeys pre-population skipped — TryAdd method not found on LookupKeys");
+                return;
+            }
+
+            // Retrieve the static dataEntities property.
+            var dataEntitiesProp = importCommonType.GetProperty(
+                "dataEntities", BindingFlags.Public | BindingFlags.Static);
+            object? dataEntities = dataEntitiesProp?.GetValue(null);
+            if (dataEntities == null)
+            {
+                _logger.LogDebug("LookupKeys pre-population skipped — dataEntities not loaded yet");
+                return;
+            }
+
+            // entities.entity → entitiesEntity[]
+            var entityArrayProp = dataEntities.GetType().GetProperty("entity");
+            if (entityArrayProp?.GetValue(dataEntities) is not System.Collections.IEnumerable entityArray)
+            {
+                _logger.LogDebug("LookupKeys pre-population skipped — entity array not found");
+                return;
+            }
+
+            int count = 0;
+            int entityCount = 0;
+            foreach (object? entity in entityArray)
+            {
+                if (entity == null) continue;
+                entityCount++;
+
+                string? entityName = entity.GetType()
+                    .GetProperty("name")?.GetValue(entity) as string;
+                if (string.IsNullOrEmpty(entityName)) continue;
+
+                // entitiesEntity.records → entitiesEntityRecord[]
+                var recordsProp = entity.GetType().GetProperty("records");
+                if (recordsProp?.GetValue(entity) is not System.Collections.IEnumerable records) continue;
+
+                foreach (object? record in records)
+                {
+                    if (record == null) continue;
+                    string? id = record.GetType()
+                        .GetProperty("id")?.GetValue(record) as string;
+                    if (string.IsNullOrEmpty(id)) continue;
+                    if (!Guid.TryParse(id, out Guid guid)) continue;
+
+                    string key = string.Concat(entityName, ":", id);
+                    tryAdd.Invoke(lookupKeys, [key, guid]);
+                    count++;
+                }
+            }
+
+            _logger.LogInformation(
+                "Pre-populated LookupKeys cache with {Count} records across {EntityCount} entities — "
+                + "eliminates server lookup calls for internal package references",
+                count, entityCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "LookupKeys pre-population failed — import will proceed with standard CMT lookup behavior");
+        }
     }
 }

--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -42,14 +42,15 @@ public sealed class CmtImportRunner
 
     /// <summary>
     /// Guards the one-shot LookupKeys pre-population so it fires exactly once
-    /// when CMT fires the "Schema Validation Complete" progress event (which is
-    /// when <c>ImportCommonMethods.dataEntities</c> is first populated).
+    /// when CMT fires the first "Processing Entity:" progress event (which is
+    /// after <c>ImportCommonMethods.dataEntities</c> is populated and
+    /// <c>ClearCrossReferanceList()</c> has already run).
     /// </summary>
     private int _lookupKeysPrepopulated;
 
     /// <summary>
     /// Runtime type of the ImportCrmDataHandler (set during RunInternalAsync).
-    /// Used by <see cref="PrePopulateLookupKeysFromPackage"/> to navigate to
+    /// Used by <see cref="CmtLookupKeysPrepopulator"/> to navigate to
     /// the correct runtime-loaded DataMigCommon assembly, which may differ from
     /// the net462 compile-time reference if the assembly resolver returned a
     /// different instance.
@@ -378,7 +379,7 @@ public sealed class CmtImportRunner
         if (message.StartsWith("Processing Entity:", StringComparison.OrdinalIgnoreCase)
             && Interlocked.CompareExchange(ref _lookupKeysPrepopulated, 1, 0) == 0)
         {
-            PrePopulateLookupKeysFromPackage();
+            CmtLookupKeysPrepopulator.Prepopulate(_handlerRuntimeType, _logger);
         }
 
         OnUpdateProgressItem(sender, e);
@@ -462,186 +463,4 @@ public sealed class CmtImportRunner
         return null;
     }
 
-    /// <summary>
-    /// Pre-seeds <c>ImportCommonMethods.LookupKeys</c> with every record
-    /// in the loaded package so that <c>FindEntity()</c> can short-circuit the
-    /// cache lookup for internal package references without a server round-trip.
-    ///
-    /// <para>
-    /// CMT's <c>UpsertMultiple</c> handler only sets <c>record.newId</c> when
-    /// <c>RecordCreated == true</c> (line 884 of <c>ImportCrmEntityActions.cs</c>).
-    /// For records that already exist in the target (<c>RecordCreated=false</c>),
-    /// <c>newId</c> stays null, so every child-entity lookup for that parent falls
-    /// through to <c>LookupCustomerOrLookupFieldInCRM</c> — one server call per
-    /// unique lookup reference.
-    /// </para>
-    ///
-    /// <para>
-    /// Because CMT always preserves source GUIDs (the <c>UpsertRequest</c> target
-    /// entity's <c>Id</c> is set to the source record GUID), the target GUID is
-    /// always equal to the source GUID. Pre-seeding the cache with
-    /// <c>"entityName:sourceGuid" → sourceGuid</c> is therefore always correct,
-    /// regardless of whether the record is new or pre-existing in the target.
-    /// </para>
-    ///
-    /// <para>
-    /// This does not affect external lookups (entities not present in the package)
-    /// — those still resolve via the normal server call path.
-    /// </para>
-    ///
-    /// <para>
-    /// Accesses CMT internals via reflection because
-    /// <c>Microsoft.Xrm.Tooling.Dmt.DataMigCommon</c> is a net462 legacy assembly
-    /// that is patched and loaded at runtime — it is not directly referenceable
-    /// from the net10 host at compile time.
-    /// </para>
-    /// </summary>
-    private void PrePopulateLookupKeysFromPackage()
-    {
-        try
-        {
-            // Navigate to the RUNTIME-loaded DataMigCommon assembly via the
-            // handler's type. AppDomain.GetAssemblies() may contain both the
-            // compile-time net462 copy and the runtime-loaded copy; they carry
-            // separate static state, so we must find the one CMT actually uses.
-            Type? importCommonType = null;
-            if (_handlerRuntimeType != null)
-            {
-                // Walk ImportProcessor's referenced assemblies to find DataMigCommon.
-                foreach (var asmRef in _handlerRuntimeType.Assembly.GetReferencedAssemblies())
-                {
-                    if (asmRef.Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) != true)
-                        continue;
-
-                    // Get the already-loaded instance with the same name.
-                    var loaded = AppDomain.CurrentDomain.GetAssemblies()
-                        .FirstOrDefault(a => string.Equals(a.GetName().Name, asmRef.Name, StringComparison.OrdinalIgnoreCase));
-                    if (loaded == null) continue;
-
-                    importCommonType = loaded.GetType(
-                        "Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods");
-                    if (importCommonType != null) break;
-                }
-            }
-
-            // Fallback: scan all loaded assemblies (less precise but still useful).
-            if (importCommonType == null)
-            {
-                importCommonType = AppDomain.CurrentDomain.GetAssemblies()
-                    .Where(a => a.GetName().Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) == true)
-                    .Select(a => a.GetType("Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods"))
-                    .FirstOrDefault(t => t != null);
-            }
-
-            if (importCommonType == null)
-            {
-                _logger.LogInformation("LookupKeys pre-population skipped — ImportCommonMethods type not found in loaded assemblies");
-                return;
-            }
-
-            _logger.LogInformation("LookupKeys pre-population: using type from assembly {Assembly}",
-                importCommonType.Assembly.FullName);
-
-            // Retrieve the static LookupKeys ConcurrentDictionary<string, Guid>.
-            var lookupKeysField = importCommonType.GetField(
-                "LookupKeys", BindingFlags.Public | BindingFlags.Static);
-            object? lookupKeys = lookupKeysField?.GetValue(null);
-            if (lookupKeys == null)
-            {
-                _logger.LogInformation("LookupKeys pre-population skipped — LookupKeys field not found or null");
-                return;
-            }
-
-            // Get TryAdd(string, Guid) on the ConcurrentDictionary.
-            MethodInfo? tryAdd = lookupKeys.GetType().GetMethod(
-                "TryAdd", [typeof(string), typeof(Guid)]);
-            if (tryAdd == null)
-            {
-                _logger.LogInformation("LookupKeys pre-population skipped — TryAdd method not found on LookupKeys");
-                return;
-            }
-
-            // Retrieve the static dataEntities property.
-            var dataEntitiesProp = importCommonType.GetProperty(
-                "dataEntities", BindingFlags.Public | BindingFlags.Static);
-            object? dataEntities = dataEntitiesProp?.GetValue(null);
-            if (dataEntities == null)
-            {
-                _logger.LogInformation("LookupKeys pre-population skipped — dataEntities not loaded yet");
-                return;
-            }
-
-            // entities.entity → entitiesEntity[]
-            var entityArrayProp = dataEntities.GetType().GetProperty("entity");
-            if (entityArrayProp?.GetValue(dataEntities) is not System.Collections.IEnumerable entityArray)
-            {
-                _logger.LogDebug("LookupKeys pre-population skipped — entity array not found");
-                return;
-            }
-
-            int count = 0;
-            int entityCount = 0;
-            foreach (object? entity in entityArray)
-            {
-                if (entity == null) continue;
-                entityCount++;
-
-                string? entityName = entity.GetType()
-                    .GetProperty("name")?.GetValue(entity) as string;
-                if (string.IsNullOrEmpty(entityName)) continue;
-
-                // entitiesEntity.records → entitiesEntityRecord[]
-                var recordsProp = entity.GetType().GetProperty("records");
-                if (recordsProp?.GetValue(entity) is not System.Collections.IEnumerable records) continue;
-
-                PropertyInfo? idProp = null;
-                PropertyInfo? newIdProp = null;
-
-                foreach (object? record in records)
-                {
-                    if (record == null) continue;
-
-                    // Cache property lookups after first record.
-                    if (idProp == null)
-                    {
-                        idProp = record.GetType().GetProperty("id");
-                        newIdProp = record.GetType().GetProperty("newId");
-                    }
-
-                    string? id = idProp?.GetValue(record) as string;
-                    if (string.IsNullOrEmpty(id)) continue;
-                    if (!Guid.TryParse(id, out Guid guid)) continue;
-
-                    // Strategy A: pre-seed LookupKeys so FindEntity() short-circuits
-                    // at the cache check (line 2851 of ImportCrmEntityActions.cs).
-                    string key = string.Concat(entityName, ":", id);
-                    tryAdd.Invoke(lookupKeys, [key, guid]);
-
-                    // Strategy B: set newId = id on the record object so that even
-                    // if the LookupKeys check misses, FindEntity() at line 2912 finds
-                    // a non-empty newId and returns without a server round-trip.
-                    // CMT preserves source GUIDs (UpsertRequest.Target.Id = source GUID),
-                    // so newId == id is always correct for package-internal references.
-                    if (newIdProp != null)
-                    {
-                        string? existingNewId = newIdProp.GetValue(record) as string;
-                        if (string.IsNullOrWhiteSpace(existingNewId))
-                            newIdProp.SetValue(record, id);
-                    }
-
-                    count++;
-                }
-            }
-
-            _logger.LogInformation(
-                "Pre-populated LookupKeys cache and set newId for {Count} records across {EntityCount} entities — "
-                + "eliminates server lookup calls for internal package references",
-                count, entityCount);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogInformation(ex,
-                "LookupKeys pre-population failed — import will proceed with standard CMT lookup behavior");
-        }
-    }
 }

--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -594,22 +594,47 @@ public sealed class CmtImportRunner
                 var recordsProp = entity.GetType().GetProperty("records");
                 if (recordsProp?.GetValue(entity) is not System.Collections.IEnumerable records) continue;
 
+                PropertyInfo? idProp = null;
+                PropertyInfo? newIdProp = null;
+
                 foreach (object? record in records)
                 {
                     if (record == null) continue;
-                    string? id = record.GetType()
-                        .GetProperty("id")?.GetValue(record) as string;
+
+                    // Cache property lookups after first record.
+                    if (idProp == null)
+                    {
+                        idProp = record.GetType().GetProperty("id");
+                        newIdProp = record.GetType().GetProperty("newId");
+                    }
+
+                    string? id = idProp?.GetValue(record) as string;
                     if (string.IsNullOrEmpty(id)) continue;
                     if (!Guid.TryParse(id, out Guid guid)) continue;
 
+                    // Strategy A: pre-seed LookupKeys so FindEntity() short-circuits
+                    // at the cache check (line 2851 of ImportCrmEntityActions.cs).
                     string key = string.Concat(entityName, ":", id);
                     tryAdd.Invoke(lookupKeys, [key, guid]);
+
+                    // Strategy B: set newId = id on the record object so that even
+                    // if the LookupKeys check misses, FindEntity() at line 2912 finds
+                    // a non-empty newId and returns without a server round-trip.
+                    // CMT preserves source GUIDs (UpsertRequest.Target.Id = source GUID),
+                    // so newId == id is always correct for package-internal references.
+                    if (newIdProp != null)
+                    {
+                        string? existingNewId = newIdProp.GetValue(record) as string;
+                        if (string.IsNullOrWhiteSpace(existingNewId))
+                            newIdProp.SetValue(record, id);
+                    }
+
                     count++;
                 }
             }
 
             _logger.LogInformation(
-                "Pre-populated LookupKeys cache with {Count} records across {EntityCount} entities — "
+                "Pre-populated LookupKeys cache and set newId for {Count} records across {EntityCount} entities — "
                 + "eliminates server lookup calls for internal package references",
                 count, entityCount);
         }

--- a/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtImportRunner.cs
@@ -40,6 +40,13 @@ public sealed class CmtImportRunner
     /// </summary>
     private int _failedStageCount;
 
+    /// <summary>
+    /// Guards the one-shot LookupKeys pre-population so it fires exactly once
+    /// when CMT fires the "Schema Validation Complete" progress event (which is
+    /// when <c>ImportCommonMethods.dataEntities</c> is first populated).
+    /// </summary>
+    private int _lookupKeysPrepopulated;
+
     public CmtImportRunner()
     {
         _assemblyMap = new Dictionary<string, Assembly>(
@@ -246,21 +253,7 @@ public sealed class CmtImportRunner
 
             _logger.LogInformation("Schema Validation Complete.");
 
-            // 8. Pre-populate LookupKeys for all package records.
-            // CMT's FindEntity() only sets record.newId when UpsertMultiple returns
-            // RecordCreated=true. For records that already exist in the target,
-            // RecordCreated=false → newId stays null → every child-entity lookup
-            // for that parent falls through to a separate server round-trip.
-            //
-            // Because CMT always preserves source GUIDs (UpsertRequest.Target.Id =
-            // source GUID), the target GUID equals the source GUID for every record
-            // in the package. Pre-seeding LookupKeys with this mapping lets
-            // FindEntity() short-circuit at the cache check (line 2851 in
-            // ImportCrmEntityActions.cs) without any server call, for both new
-            // records and records that already exist in the target.
-            PrePopulateLookupKeysFromPackage();
-
-            // 9. Import data (synchronous — blocks via internal WaitOne).
+            // 8. Import data (synchronous — blocks via internal WaitOne).
             _logger.LogInformation("Starting data import...");
             // NOTE: The deleteBeforeAdd parameter is accepted by CMT's API but
             // is never actually used internally — the delete functionality was
@@ -371,6 +364,18 @@ public sealed class CmtImportRunner
             return;
 
         string message = e.progressItem.ItemText ?? string.Empty;
+
+        // CMT fires "Schema Validation Complete" once ImportDataToCrm() has
+        // parsed both data_schema.xml and data.xml and populated
+        // ImportCommonMethods.dataEntities. This is the earliest safe point to
+        // pre-seed LookupKeys, because dataEntities is null before this event.
+        if (e.progressItem.ItemStatus == ProgressItemStatus.Complete
+            && message.StartsWith("Schema Validation Complete", StringComparison.OrdinalIgnoreCase)
+            && Interlocked.CompareExchange(ref _lookupKeysPrepopulated, 1, 0) == 0)
+        {
+            PrePopulateLookupKeysFromPackage();
+        }
+
         switch (e.progressItem.ItemStatus)
         {
             case ProgressItemStatus.Complete:
@@ -481,13 +486,16 @@ public sealed class CmtImportRunner
         try
         {
             // Locate ImportCommonMethods in the runtime-loaded CMT assembly.
-            Type? importCommonType = Type.GetType(
-                "Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods, Microsoft.Xrm.Tooling.Dmt.DataMigCommon",
-                throwOnError: false);
+            // Type.GetType() with assembly-qualified name often fails for Cecil-patched
+            // legacy assemblies; scan all loaded assemblies by partial name instead.
+            Type? importCommonType = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(a => a.GetName().Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) == true)
+                .Select(a => a.GetType("Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods"))
+                .FirstOrDefault(t => t != null);
 
             if (importCommonType == null)
             {
-                _logger.LogDebug("LookupKeys pre-population skipped — ImportCommonMethods type not found");
+                _logger.LogInformation("LookupKeys pre-population skipped — ImportCommonMethods type not found in loaded assemblies");
                 return;
             }
 
@@ -497,7 +505,7 @@ public sealed class CmtImportRunner
             object? lookupKeys = lookupKeysField?.GetValue(null);
             if (lookupKeys == null)
             {
-                _logger.LogDebug("LookupKeys pre-population skipped — LookupKeys field not found or null");
+                _logger.LogInformation("LookupKeys pre-population skipped — LookupKeys field not found or null");
                 return;
             }
 
@@ -506,7 +514,7 @@ public sealed class CmtImportRunner
                 "TryAdd", [typeof(string), typeof(Guid)]);
             if (tryAdd == null)
             {
-                _logger.LogDebug("LookupKeys pre-population skipped — TryAdd method not found on LookupKeys");
+                _logger.LogInformation("LookupKeys pre-population skipped — TryAdd method not found on LookupKeys");
                 return;
             }
 
@@ -516,7 +524,7 @@ public sealed class CmtImportRunner
             object? dataEntities = dataEntitiesProp?.GetValue(null);
             if (dataEntities == null)
             {
-                _logger.LogDebug("LookupKeys pre-population skipped — dataEntities not loaded yet");
+                _logger.LogInformation("LookupKeys pre-population skipped — dataEntities not loaded yet");
                 return;
             }
 
@@ -564,7 +572,7 @@ public sealed class CmtImportRunner
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex,
+            _logger.LogInformation(ex,
                 "LookupKeys pre-population failed — import will proceed with standard CMT lookup behavior");
         }
     }

--- a/src/TALXIS.CLI.Platform.Xrm/CmtLookupKeysPrepopulator.cs
+++ b/src/TALXIS.CLI.Platform.Xrm/CmtLookupKeysPrepopulator.cs
@@ -1,0 +1,284 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace TALXIS.CLI.Platform.Xrm;
+
+/// <summary>
+/// Pre-seeds CMT's internal lookup-resolution state for package-internal
+/// references, eliminating redundant "LOOKUP TO CRM" server round-trips
+/// during import.
+///
+/// <para>
+/// <b>Root cause:</b> CMT's <c>FindEntity()</c>
+/// (<c>ImportCrmEntityActions.cs</c>) falls back to a live server query
+/// whenever a referenced record's in-memory <c>newId</c> is empty.
+/// <c>newId</c> is only populated once the batch response callback for
+/// that specific record's create/upsert has fired. With
+/// <c>--batch-mode</c> and <c>--connection-count &gt; 1</c>, CMT dispatches
+/// an entity's batches asynchronously and can begin preprocessing the next
+/// (dependent) entity before every parent batch has actually received its
+/// response — so a perfectly valid, already-created parent record still
+/// looks "unresolved" locally, triggering a costly live lookup that almost
+/// always just confirms what CMT could already have known. This is a local
+/// cache-staleness / async race inherent to CMT's batch+multi-connection
+/// architecture, not a genuine missing-dependency or ordering problem.
+/// </para>
+///
+/// <para>
+/// <b>Fix:</b> because CMT always preserves source GUIDs (an upserted
+/// record's target <c>Id</c> is set to the source record's GUID), the
+/// target GUID is always equal to the source GUID for package-internal
+/// references. We can therefore pre-seed both of <c>FindEntity()</c>'s
+/// lookup paths — the <c>LookupKeys</c> cache and each record's own
+/// <c>newId</c> field — before any batch is ever dispatched, removing the
+/// dependency on batch-response timing entirely. This does not affect
+/// external lookups (entities not present in the package); those still
+/// resolve via the normal server call path.
+/// </para>
+///
+/// <para>
+/// Accesses CMT internals via reflection because
+/// <c>Microsoft.Xrm.Tooling.Dmt.DataMigCommon</c> is a net462 legacy
+/// assembly that is patched and loaded at runtime — it is not directly
+/// referenceable from the net10 host at compile time.
+/// </para>
+/// </summary>
+internal static class CmtLookupKeysPrepopulator
+{
+    private const string ImportCommonMethodsTypeName =
+        "Microsoft.Xrm.Tooling.Dmt.DataMigCommon.DataInteraction.ImportCommonMethods";
+
+    /// <summary>
+    /// Result of a pre-population run, for logging/telemetry by the caller.
+    /// </summary>
+    public readonly record struct Result(int RecordCount, int EntityCount);
+
+    /// <summary>
+    /// Pre-seeds the LookupKeys cache and newId fields for every record in
+    /// the already-loaded package. Safe to call multiple times; each call
+    /// re-scans the current in-memory package data.
+    /// </summary>
+    /// <param name="handlerRuntimeType">
+    /// Runtime type of the ImportCrmDataHandler instance in use. Used to
+    /// navigate to the correct runtime-loaded DataMigCommon assembly, which
+    /// may differ from the net462 compile-time reference if the assembly
+    /// resolver returned a different instance (there can be two loaded
+    /// copies of DataMigCommon with independent static state).
+    /// </param>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <returns>
+    /// The number of records/entities updated, or <c>null</c> if
+    /// pre-population could not run (e.g. package not loaded yet).
+    /// </returns>
+    public static Result? Prepopulate(Type? handlerRuntimeType, ILogger logger)
+    {
+        try
+        {
+            Type? importCommonType = ResolveImportCommonMethodsType(handlerRuntimeType);
+            if (importCommonType == null)
+            {
+                logger.LogInformation(
+                    "LookupKeys pre-population skipped — ImportCommonMethods type not found in loaded assemblies");
+                return null;
+            }
+
+            logger.LogInformation(
+                "LookupKeys pre-population: using type from assembly {Assembly}",
+                importCommonType.Assembly.FullName);
+
+            if (!TryGetLookupKeysTryAdd(importCommonType, logger, out object? lookupKeys, out MethodInfo? tryAdd))
+                return null;
+
+            if (!TryGetDataEntities(importCommonType, logger, out System.Collections.IEnumerable? entityArray))
+                return null;
+
+            Result result = PrepopulateRecords(entityArray!, lookupKeys!, tryAdd!);
+
+            logger.LogInformation(
+                "Pre-populated LookupKeys cache and set newId for {Count} records across {EntityCount} entities — "
+                + "eliminates server lookup calls for internal package references",
+                result.RecordCount, result.EntityCount);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            logger.LogInformation(ex,
+                "LookupKeys pre-population failed — import will proceed with standard CMT lookup behavior");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Navigates to the RUNTIME-loaded DataMigCommon assembly via the
+    /// handler's type. AppDomain.GetAssemblies() may contain both the
+    /// compile-time net462 copy and the runtime-loaded copy; they carry
+    /// separate static state, so we must find the one CMT actually uses.
+    /// </summary>
+    private static Type? ResolveImportCommonMethodsType(Type? handlerRuntimeType)
+    {
+        if (handlerRuntimeType != null)
+        {
+            foreach (AssemblyName asmRef in handlerRuntimeType.Assembly.GetReferencedAssemblies())
+            {
+                if (asmRef.Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) != true)
+                    continue;
+
+                Assembly? loaded = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => string.Equals(a.GetName().Name, asmRef.Name, StringComparison.OrdinalIgnoreCase));
+                if (loaded == null) continue;
+
+                Type? candidate = loaded.GetType(ImportCommonMethodsTypeName);
+                if (candidate != null) return candidate;
+            }
+        }
+
+        // Fallback: scan all loaded assemblies (less precise but still useful).
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => a.GetName().Name?.Contains("DataMigCommon", StringComparison.OrdinalIgnoreCase) == true)
+            .Select(a => a.GetType(ImportCommonMethodsTypeName))
+            .FirstOrDefault(t => t != null);
+    }
+
+    /// <summary>
+    /// Retrieves the static <c>LookupKeys</c> ConcurrentDictionary&lt;string, Guid&gt;
+    /// and its <c>TryAdd(string, Guid)</c> method.
+    /// </summary>
+    private static bool TryGetLookupKeysTryAdd(
+        Type importCommonType,
+        ILogger logger,
+        out object? lookupKeys,
+        out MethodInfo? tryAdd)
+    {
+        lookupKeys = null;
+        tryAdd = null;
+
+        FieldInfo? lookupKeysField = importCommonType.GetField(
+            "LookupKeys", BindingFlags.Public | BindingFlags.Static);
+        lookupKeys = lookupKeysField?.GetValue(null);
+        if (lookupKeys == null)
+        {
+            logger.LogInformation("LookupKeys pre-population skipped — LookupKeys field not found or null");
+            return false;
+        }
+
+        tryAdd = lookupKeys.GetType().GetMethod("TryAdd", [typeof(string), typeof(Guid)]);
+        if (tryAdd == null)
+        {
+            logger.LogInformation("LookupKeys pre-population skipped — TryAdd method not found on LookupKeys");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Retrieves the static <c>dataEntities</c> property and its <c>entity</c> array.
+    /// </summary>
+    private static bool TryGetDataEntities(
+        Type importCommonType,
+        ILogger logger,
+        out System.Collections.IEnumerable? entityArray)
+    {
+        entityArray = null;
+
+        PropertyInfo? dataEntitiesProp = importCommonType.GetProperty(
+            "dataEntities", BindingFlags.Public | BindingFlags.Static);
+        object? dataEntities = dataEntitiesProp?.GetValue(null);
+        if (dataEntities == null)
+        {
+            logger.LogInformation("LookupKeys pre-population skipped — dataEntities not loaded yet");
+            return false;
+        }
+
+        PropertyInfo? entityArrayProp = dataEntities.GetType().GetProperty("entity");
+        entityArray = entityArrayProp?.GetValue(dataEntities) as System.Collections.IEnumerable;
+        if (entityArray == null)
+        {
+            logger.LogDebug("LookupKeys pre-population skipped — entity array not found");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Walks every entity/record in the package and applies both
+    /// pre-population strategies.
+    /// </summary>
+    private static Result PrepopulateRecords(
+        System.Collections.IEnumerable entityArray,
+        object lookupKeys,
+        MethodInfo tryAdd)
+    {
+        int count = 0;
+        int entityCount = 0;
+
+        foreach (object? entity in entityArray)
+        {
+            if (entity == null) continue;
+            entityCount++;
+
+            string? entityName = entity.GetType().GetProperty("name")?.GetValue(entity) as string;
+            if (string.IsNullOrEmpty(entityName)) continue;
+
+            if (entity.GetType().GetProperty("records")?.GetValue(entity)
+                is not System.Collections.IEnumerable records)
+            {
+                continue;
+            }
+
+            count += PrepopulateEntityRecords(entityName, records, lookupKeys, tryAdd);
+        }
+
+        return new Result(count, entityCount);
+    }
+
+    private static int PrepopulateEntityRecords(
+        string entityName,
+        System.Collections.IEnumerable records,
+        object lookupKeys,
+        MethodInfo tryAdd)
+    {
+        int count = 0;
+        PropertyInfo? idProp = null;
+        PropertyInfo? newIdProp = null;
+
+        foreach (object? record in records)
+        {
+            if (record == null) continue;
+
+            // Cache property lookups after first record.
+            if (idProp == null)
+            {
+                idProp = record.GetType().GetProperty("id");
+                newIdProp = record.GetType().GetProperty("newId");
+            }
+
+            string? id = idProp?.GetValue(record) as string;
+            if (string.IsNullOrEmpty(id)) continue;
+            if (!Guid.TryParse(id, out Guid guid)) continue;
+
+            // Strategy A: pre-seed LookupKeys so FindEntity() short-circuits
+            // at the cache check (line 2851 of ImportCrmEntityActions.cs).
+            string key = string.Concat(entityName, ":", id);
+            tryAdd.Invoke(lookupKeys, [key, guid]);
+
+            // Strategy B: set newId = id on the record object so that even
+            // if the LookupKeys check misses, FindEntity() at line 2912 finds
+            // a non-empty newId and returns without a server round-trip.
+            // CMT preserves source GUIDs (UpsertRequest.Target.Id = source GUID),
+            // so newId == id is always correct for package-internal references.
+            if (newIdProp != null)
+            {
+                string? existingNewId = newIdProp.GetValue(record) as string;
+                if (string.IsNullOrWhiteSpace(existingNewId))
+                    newIdProp.SetValue(record, id);
+            }
+
+            count++;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Problem

CMT's `FindEntity()` does a server round-trip ("LOOKUP TO CRM") whenever a referenced record's in-memory `newId` is empty. Crucially, `newId` is only populated **after the batch response callback for that specific record's create/upsert has fired** — and with `--batch-mode` + `--connection-count > 1`, CMT dispatches an entity's batches asynchronously and can begin preprocessing the *next* (dependent) entity before every parent batch has actually received its response.

This is confirmed empirically, not just theoretically: in a baseline benchmark run, **2,354 of 2,354** "LOOKUP TO CRM" calls resolved as `FOUND` (not `NOTFOUND`). The referenced parent record already existed on the server in every single case — CMT's local `newId` bookkeeping just hadn't caught up yet. So this isn't a genuine missing-dependency/ordering problem (none of the 17 entities in the test package are even self-referential); it's a **local cache staleness / async race inherent to CMT's batch+multi-connection architecture**, and it costs a full server round-trip per occurrence regardless.

On a real customer package (167,915 records / 17 entities), this was estimated at ~55 hours to import.

## Fix

`CmtLookupKeysPrepopulator.Prepopulate()` is invoked from `CmtImportRunner` on the first `"Processing Entity:"` progress message (i.e. right after CMT's internal `ClearCrossReferanceList()` call, so it isn't wiped) and, via reflection into the runtime-loaded `DataMigCommon` assembly:

1. **Pre-seeds `ImportCommonMethods.LookupKeys`** with `"entity:sourceGuid" -> Guid` for every record in the package.
2. **Sets `record.newId = record.id`** on every `entitiesEntityRecord` *before* any batch is ever dispatched, since CMT always upserts using the source GUID as the target GUID. This removes the dependency on batch-response timing entirely — `FindEntity()` sees a populated `newId` immediately, with no race window.

Both strategies are needed because `FindEntity()` has two independent lookup paths, and pre-populating only `LookupKeys` left ~1,362 server calls remaining out of a 2,364 baseline.

The prepopulation logic lives in its own `CmtLookupKeysPrepopulator` class (small, single-purpose helper methods) rather than inline in `CmtImportRunner`, which already mixes CLI orchestration, assembly resolution, and progress-event wiring.

## Results (`tiny-chain-100` benchmark: 3,679 records / 17 entities)

| | LOOKUP TO CRM calls | Total time |
|---|---|---|
| Baseline | 2,364 | 15m45s |
| LookupKeys-only | 1,362 | ~10m |
| **This fix (LookupKeys + newId)** | **13** | **~4m49s** |

(The remaining 13 are genuine external references — e.g. `talxis_documenttype` — which is not part of the package and correctly requires a real server lookup.)

Also validated at ~12x scale on a 43,760-record referentially-closed subset of the real customer package (proportional 15% slice preserving actual entity distribution): **0 LOOKUP TO CRM calls** through 8 of 17 entities / ~30k records before the run was stopped (sufficient confirmation the fix holds at scale). Re-validated after the class-extraction refactor with a fresh, non-overlapping 4,127-record subset: **8 LOOKUP TO CRM calls**, confirming parity.

## Testing

- Manual benchmarks against a live Dataverse SIT environment using `quick-tests/tiny-chain-100` and larger proportional subsets of the real package, with `--batch-mode --batch-size 200 --connection-count 2 --override-safety-checks --verbose`.
- Confirmed via `ilspycmd` decompilation of the built DLL that the fix is actually present in the compiled binary (ran into a stale Roslyn compiler-server caching issue during development, resolved via `dotnet build-server shutdown`).

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
