### PR TITLE
fix(shim): resolve real org version instead of hardcoded 9.2.0.0 fallback

### DIFF
--- a/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
+++ b/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
@@ -1,3 +1,4 @@
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.PowerPlatform.Dataverse.Client;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
@@ -157,12 +158,26 @@ public class CrmServiceClient : ServiceClient, IDisposable
     /// Hides the base <see cref="ServiceClient.ConnectedOrgVersion"/> which
     /// returns the hardcoded default <c>9.0.0.0</c> when the token-provider
     /// constructor path is used (the SDK's <c>ExternalTokenManagement</c> path
-    /// skips <c>GetServerVersion</c>/<c>RefreshInstanceDetails</c>).
+    /// sets <c>OrganizationVersion = 9.0.0.0</c> at connect time and skips the
+    /// normal server-version discovery — see
+    /// <c>ConnectionService.cs</c> in the Dataverse SDK source).
     /// <para>
-    /// When the base property still returns 9.0.0.0 this property falls back
-    /// to <c>9.2.0.0</c> — the minimum version of any modern Power Platform
-    /// environment — so Package Deployer's <c>SolutionPackageVersion</c>
-    /// compatibility check does not reject solutions built against the 9.1 schema.
+    /// Rather than guessing a constant, this recovers the real org version
+    /// using public SDK APIs, in order of cost:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>The base property, in case it is already populated.</description></item>
+    /// <item><description><see cref="ServiceClient.OrganizationDetail"/>, whose getter
+    /// triggers the SDK's internal <c>RefreshInstanceDetails</c> and is confirmed
+    /// (via live testing) to return the real version even on the
+    /// <c>ExternalTokenManagement</c> path.</description></item>
+    /// <item><description><see cref="RetrieveVersionRequest"/>, a strongly-typed
+    /// SOAP request confirmed (via live testing) to succeed and return the real
+    /// version as a last resort.</description></item>
+    /// </list>
+    /// <para>
+    /// If every mechanism still returns the SDK default, the base value is
+    /// returned as-is rather than substituting a hardcoded lie.
     /// </para>
     /// </summary>
     public new Version ConnectedOrgVersion
@@ -172,19 +187,36 @@ public class CrmServiceClient : ServiceClient, IDisposable
             if (_cachedOrgVersion != null)
                 return _cachedOrgVersion;
 
+            var sdkDefault = new Version(9, 0, 0, 0);
+
             var baseVersion = base.ConnectedOrgVersion;
-            if (baseVersion > new Version(9, 0, 0, 0))
+            if (baseVersion > sdkDefault)
+                return _cachedOrgVersion = baseVersion;
+
+            // Base returned the SDK's hardcoded default — this happens because
+            // the ExternalTokenManagement path skips server version discovery at
+            // connect time. Accessing OrganizationDetail forces the SDK to
+            // actually retrieve it.
+            if (Version.TryParse(base.OrganizationDetail?.OrganizationVersion, out var detailVersion)
+                && detailVersion > sdkDefault)
             {
-                _cachedOrgVersion = baseVersion;
-                return baseVersion;
+                return _cachedOrgVersion = detailVersion;
             }
 
-            // Base returned the SDK's hardcoded default (9.0.0.0) — this happens
-            // because the ExternalTokenManagement path skips server version discovery.
-            // All modern Power Platform environments are at least 9.2; return that
-            // so Package Deployer's SolutionPackageVersion compatibility check passes.
-            _cachedOrgVersion = new Version(9, 2, 0, 0);
-            return _cachedOrgVersion;
+            baseVersion = base.ConnectedOrgVersion;
+            if (baseVersion > sdkDefault)
+                return _cachedOrgVersion = baseVersion;
+
+            // Last resort: explicitly ask the server via a strongly-typed request.
+            if (base.Execute(new RetrieveVersionRequest()) is RetrieveVersionResponse retrieveVersionResponse
+                && Version.TryParse(retrieveVersionResponse.Version, out var requestVersion)
+                && requestVersion > sdkDefault)
+            {
+                return _cachedOrgVersion = requestVersion;
+            }
+
+            // Give up honestly rather than hardcoding a fallback constant.
+            return base.ConnectedOrgVersion;
         }
     }
 


### PR DESCRIPTION
## Problem

`CrmServiceClient` (our `Microsoft.Xrm.Tooling.Connector.CrmServiceClient`-compatible shim over `Microsoft.PowerPlatform.Dataverse.Client.ServiceClient`) hardcoded `ConnectedOrgVersion` to `9.2.0.0` whenever the base SDK returned its own stub default of `9.0.0.0` — which happens under the token-provider (`ExternalTokenManagement`) constructor path used by `CmtImportRunner`, `CmtExportRunner`, and `PackageDeployerRunner`.

`9.2.0.0` is below CMT's `UpsertMultiple` batch-mode version gate (`9.2.23083.00120`), so the Configuration Migration Tool import path silently fell back to slow, one-by-one `Create`/`Update` calls through our wrapper — regardless of how modern the real connected org actually is.

## Root cause

The underlying SDK's `ExternalTokenManagement` auth path sets `OrganizationVersion = 9.0.0.0` at connect time and skips normal server-version discovery. This was previously worked around (see history of this file) by hardcoding a fallback constant, after earlier attempts using `RetrieveVersion`/`OrganizationDetail` were believed to fail silently in that auth mode.

That belief no longer holds for the SDK version we consume (`1.2.10`) — confirmed live against a real Dataverse online environment (actual org version `9.2.26061.150`):

- `ConnectedOrgVersion` initially reports the SDK's stub default `9.0.0.0`.
- `ServiceClient.OrganizationDetail` (public property, forces a real `RefreshInstanceDetails`) correctly returns the real version (`9.2.26061.150`).
- `Execute(new RetrieveVersionRequest())` also correctly returns the real version.

Filed upstream for the SDK-level bug: https://github.com/microsoft/PowerPlatform-DataverseServiceClient/issues/538

## Fix

Replaced the hardcoded `9.2.0.0` constant in `CrmServiceClient.ConnectedOrgVersion` with a cascade using only public SDK APIs:

1. Base property (fast path, in case already populated).
2. `OrganizationDetail` (forces a real refresh).
3. `Execute(new RetrieveVersionRequest())` (last resort, strongly-typed request).

If every mechanism still returns the SDK default, the base value is returned honestly instead of substituting a hardcoded constant.

## Related

- Complements #167 (LookupKeys/newId pre-population) — both fixes reduce CMT import time via different mechanisms: this one restores fast batch upserts (`UpsertMultiple`), #167 removes redundant per-record lookup calls.
