### PR TITLE
docs: document special Dataverse type formats in data command --data (#63)

### DIFF
--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkCreateCliCommand.cs
@@ -26,7 +26,7 @@ public class EnvDataBulkCreateCliCommand : ProfiledCliCommand
     [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
     public string? File { get; set; }
 
-    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    [CliOption(Name = "--data", Description = "Inline JSON array of records. Special column types: OptionSet as an integer (e.g. 375970000), Lookup as a GUID string or {Id,LogicalName} object, Money as a decimal (e.g. 1500.50), Boolean as true/false, DateTime as an ISO-8601 UTC string (e.g. 2026-05-01T00:00:00Z).", Required = false)]
     public string? Data { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpdateCliCommand.cs
@@ -26,7 +26,7 @@ public class EnvDataBulkUpdateCliCommand : ProfiledCliCommand
     [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
     public string? File { get; set; }
 
-    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    [CliOption(Name = "--data", Description = "Inline JSON array of records. Special column types: OptionSet as an integer (e.g. 375970000), Lookup as a GUID string or {Id,LogicalName} object, Money as a decimal (e.g. 1500.50), Boolean as true/false, DateTime as an ISO-8601 UTC string (e.g. 2026-05-01T00:00:00Z).", Required = false)]
     public string? Data { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpsertCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Bulk/EnvDataBulkUpsertCliCommand.cs
@@ -26,7 +26,7 @@ public class EnvDataBulkUpsertCliCommand : ProfiledCliCommand
     [CliOption(Name = "--file", Description = "Path to a JSON file containing an array of records.", Required = false)]
     public string? File { get; set; }
 
-    [CliOption(Name = "--data", Description = "Inline JSON array of records.", Required = false)]
+    [CliOption(Name = "--data", Description = "Inline JSON array of records. Special column types: OptionSet as an integer (e.g. 375970000), Lookup as a GUID string or {Id,LogicalName} object, Money as a decimal (e.g. 1500.50), Boolean as true/false, DateTime as an ISO-8601 UTC string (e.g. 2026-05-01T00:00:00Z).", Required = false)]
     public string? Data { get; set; }
 
     protected override async Task<int> ExecuteAsync()

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordCreateCliCommand.cs
@@ -24,7 +24,7 @@ public class EnvDataRecordCreateCliCommand : StagedCliCommand
     [CliOption(Name = "--entity", Description = "Entity logical name (e.g. account).", Required = true)]
     public string Entity { get; set; } = null!;
 
-    [CliOption(Name = "--data", Description = "Inline JSON object with record attributes.", Required = false)]
+    [CliOption(Name = "--data", Description = "Inline JSON object with record attributes. Special column types: OptionSet as an integer (e.g. 375970000), Lookup as a GUID string or {Id,LogicalName} object, Money as a decimal (e.g. 1500.50), Boolean as true/false, DateTime as an ISO-8601 UTC string (e.g. 2026-05-01T00:00:00Z).", Required = false)]
     public string? Data { get; set; }
 
     [CliOption(Name = "--file", Description = "Path to a JSON file containing record attributes.", Required = false)]

--- a/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Data/Record/EnvDataRecordUpdateCliCommand.cs
@@ -30,7 +30,7 @@ public class EnvDataRecordUpdateCliCommand : StagedCliCommand
         ValidationMessage = CliValidation.GuidValidationMessage)]
     public required Guid RecordId { get; set; }
 
-    [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update.", Required = false)]
+    [CliOption(Name = "--data", Description = "Inline JSON object with attributes to update. Special column types: OptionSet as an integer (e.g. 375970000), Lookup as a GUID string or {Id,LogicalName} object, Money as a decimal (e.g. 1500.50), Boolean as true/false, DateTime as an ISO-8601 UTC string (e.g. 2026-05-01T00:00:00Z).", Required = false)]
     public string? Data { get; set; }
 
     [CliOption(Name = "--file", Description = "Path to a JSON file containing attributes to update.", Required = false)]


### PR DESCRIPTION
Closes #63

The `--data` option on `record create/update` and `bulk create/update/upsert` didn't explain how to format special Dataverse column types, so MCP agents had to discover by trial and error that option sets go as plain integers and lookups as GUID strings. Since the MCP input schemas are generated from the same `CliOption` attributes, the gap was visible both in CLI help and in the tool descriptions.

This adds the formats to the `--data` description on all five commands: OptionSet as an integer, Lookup as a GUID string or `{Id,LogicalName}` object, Money as a decimal, Boolean as true/false, DateTime as an ISO-8601 UTC string.