### PR TITLE
docs: explain Debug vs Release managed/unmanaged for package import (#60)

### DIFF
--- a/src/TALXIS.CLI.Features.Docs/Skills/deployment-workflow.md
+++ b/src/TALXIS.CLI.Features.Docs/Skills/deployment-workflow.md
@@ -40,6 +40,24 @@ Tool: environment_deployment_get --latest
 ```
 Check the deployment status and review any findings (warnings, errors, informational messages).
 
+## Build Configuration: Managed vs Unmanaged
+
+The build configuration you pack/publish with decides whether the package contains **managed** or **unmanaged** solutions, and getting it wrong is a common deployment failure.
+
+| Config | Solutions | Use for |
+|---|---|---|
+| `Debug` (`dotnet build`, `dotnet publish -c Debug`) | **unmanaged** | dev/test environments that already hold unmanaged solutions |
+| `Release` (`dotnet publish -c Release`) | **managed** | staging/production |
+
+**You cannot overwrite an unmanaged solution with a managed one (or vice versa).** A `-c Release` package imported over an existing unmanaged solution fails with:
+
+> You can't overwrite an unmanaged version of this solution with a managed version.
+
+When deploying, first check what's already there:
+1. Are the existing solutions on the environment managed or unmanaged? (`environment_solution_uninstall-check` / inspect the environment)
+2. Build with the matching configuration.
+3. On a mismatch, either uninstall the existing solution and re-import, or rebuild with the correct configuration.
+
 ## Pre-Flight Checks
 
 Before deploying, validate:

--- a/src/TALXIS.CLI.Features.Environment/Package/PackageImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Environment/Package/PackageImportCliCommand.cs
@@ -13,7 +13,7 @@ namespace TALXIS.CLI.Features.Environment.Package;
 [CliLongRunning]
 [CliCommand(
     Name = "import",
-    Description = "Import a deployable package into the target environment."
+    Description = "Import a deployable package into the LIVE target environment. Requires an active profile. Build configuration determines solution managed state: Release packs managed solutions, Debug packs unmanaged. A managed package cannot overwrite an existing unmanaged solution (or vice versa) without uninstalling the existing one first."
 )]
 public class PackageImportCliCommand : ProfiledCliCommand
 {

--- a/src/TALXIS.CLI.MCP/Skills/Internal/deployment-sequence.md
+++ b/src/TALXIS.CLI.MCP/Skills/Internal/deployment-sequence.md
@@ -23,8 +23,8 @@ Before deploying:
   │    ├─ YES → proceed
   │    └─ NO → config_profile_validate, then config_profile_get to confirm target
   └─→ Dev or prod target?
-       ├─ DEV → unmanaged import is fine
-       └─ PROD/UAT → managed import ONLY, never unmanaged
+       ├─ DEV → unmanaged import is fine → build/pack with Debug (Debug packs unmanaged)
+       └─ PROD/UAT → managed import ONLY, never unmanaged → publish with Release (Release packs managed)
 ```
 
 ## Failure Recovery Sequence
@@ -51,5 +51,6 @@ Import failed
 - ❌ Deploying without building first → XML errors only caught at import (slow feedback)
 - ❌ Skipping `environment_solution_publish` → UI changes invisible to users
 - ❌ Deploying unmanaged to production → can't cleanly uninstall, no version tracking
+- ❌ Importing a Release (managed) package over an existing unmanaged solution (or vice versa) → Dataverse rejects it; uninstall the existing solution first or rebuild with the matching configuration
 - ❌ Retrying failed imports without checking `environment_deployment_get` → repeating the same error
 - ❌ Querying `asyncoperation` table directly via `environment_data_query_sql` to check import status → use `environment_deployment_get --async-operation-id <id>` instead — it returns structured findings, not raw status codes


### PR DESCRIPTION
Closes #60

`dotnet publish -c Release` packs solutions as managed, Debug as unmanaged, and a managed package can't be imported over an existing unmanaged solution. Nothing in the skills or tool descriptions mentioned this, which burned us during a demo.

Added the explanation to the deployment-workflow skill, the `environment package import` tool description and the internal deployment-sequence decision tree.