### PR TITLE
feat: support for data pkg import `--batch-mode`

### DIFF
--- a/docs/configuration-migration.md
+++ b/docs/configuration-migration.md
@@ -137,8 +137,8 @@ txc data package import <path> [options]
 | Argument / Option | Alias | Required | Default | Description |
 |---|---|---|---|---|
 | `<path>` *(argument)* | — | **Yes** | — | Path to the CMT data package (`.zip` file or folder containing `data.xml` and `data_schema.xml`). |
-| `--connection-count <N>` | — | No | `1` | How many parallel connections to open against the environment. More connections = faster import for large datasets. Each connection authenticates separately. |
-| `--batch-mode` | — | No | `false` | Send records in batches instead of one-by-one. Much faster for large imports. Batches use `ExecuteMultiple` or `UpsertMultiple` depending on org version. |
+| `--connection-count <N>` | — | No | `1` | Opens 1 primary management connection and `N-1` cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is `N-1`. To get 4 parallel workers, pass `5`. Matches `pac data import` behaviour. |
+| `--batch-mode` | — | No | `false` | Send records in batches instead of one-by-one. Much faster for large imports. Batches use `ExecuteMultiple` or `UpsertMultiple` depending on org version. **⚠️ Even though the logs show M2M relationship records as processed, they are skipped in batch mode** — omit this flag or run a second pass without it if your package contains M2M relationships. |
 | `--batch-size <N>` | — | No | `600` | How many records to send per batch request. Only used when `--batch-mode` is on. Lower values are safer, higher values are faster. |
 | `--override-safety-checks` | — | No | `false` | **DANGEROUS:** Skip all duplicate checking. Every record will be created as new, even if it already exists. Use only when importing into a clean empty environment. |
 | `--prefetch-limit <N>` | — | No | `4000` | How many existing records to load into memory per entity for faster duplicate detection. If an entity has more records than this limit, each record is checked individually against the server (slower). Increase for large entities. |
@@ -662,12 +662,19 @@ The import command exposes several options that control parallelism, batching, a
 
 **Default:** `1`
 
-Opens **N** parallel `CrmServiceClient` connections to the target environment. During the preprocessing phase, records are distributed round-robin across the available connections. Each connection authenticates separately.
+Controls how many connections are opened against the target environment. Internally, CMT uses **one primary management connection** (`CrmConnection`) plus a pool of **cloned connections** (`ImportConnections`) for the actual parallel record import. Only the cloned pool is used for record distribution — the management connection is reserved for coordination.
 
-**When to increase:** Large imports (thousands of records). Typical sweet spot is 2–8 connections. Going beyond 8 rarely helps and may trigger throttling.
+This means:
+- `--connection-count 1` → 0 cloned connections (sequential import via the management connection)
+- `--connection-count 2` → 1 cloned connection (2 connections total, but only 1 doing parallel import)
+- `--connection-count 5` → 4 cloned connections (effective parallelism of 4)
+
+> **In short: the number of parallel import workers equals `N-1`.** To get 4 workers, pass `--connection-count 5`. This is the same behaviour as `pac data import --connection-count`.
+
+**When to increase:** Large imports (thousands of records). Typical sweet spot is `3`–`9` (giving 2–8 effective parallel workers). Going beyond `9` rarely helps and may trigger throttling.
 
 ```bash
-txc data package import data.zip --connection-count 4
+txc data package import data.zip --connection-count 5
 ```
 
 ### `--batch-mode`
@@ -676,7 +683,9 @@ txc data package import data.zip --connection-count 4
 
 When enabled, records are sent in batches using `ExecuteMultiple` requests instead of individual `Create` / `Update` calls. If the target organization is version **9.2.23083 or higher**, CMT automatically upgrades to `UpsertMultiple` for even better throughput.
 
-**When to use:** Any import with more than a few hundred records. The performance difference is dramatic — a 10,000-record import that takes 30 minutes one-by-one can complete in 2–3 minutes with batch mode.
+> **⚠️ Many-to-many (M2M) relationship records are skipped when `--batch-mode` is enabled.** CMT does not include M2M association records in batch requests. If your data package contains M2M relationships, import without `--batch-mode` or perform a second pass without it to populate those relationships.
+
+**When to use:** Any import with more than a few hundred records that does **not** rely on M2M relationships. The performance difference is dramatic — a 10,000-record import that takes 30 minutes one-by-one can complete in 2–3 minutes with batch mode.
 
 ```bash
 txc data package import data.zip --batch-mode

--- a/docs/configuration-migration.md
+++ b/docs/configuration-migration.md
@@ -137,7 +137,7 @@ txc data package import <path> [options]
 | Argument / Option | Alias | Required | Default | Description |
 |---|---|---|---|---|
 | `<path>` *(argument)* | — | **Yes** | — | Path to the CMT data package (`.zip` file or folder containing `data.xml` and `data_schema.xml`). |
-| `--connection-count <N>` | — | No | `1` | Opens 1 primary management connection and `N-1` cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is `N-1`. To get 4 parallel workers, pass `5`. Matches `pac data import` behaviour. |
+| `--connection-count <N>` | — | No | `1` | Opens 1 primary management connection and `N-1` cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is `N-1`. To get 4 parallel workers, pass `5`. |
 | `--batch-mode` | — | No | `false` | Send records in batches instead of one-by-one. Much faster for large imports. Batches use `ExecuteMultiple` or `UpsertMultiple` depending on org version. **⚠️ Even though the logs show M2M relationship records as processed, they are skipped in batch mode** — omit this flag or run a second pass without it if your package contains M2M relationships. |
 | `--batch-size <N>` | — | No | `600` | How many records to send per batch request. Only used when `--batch-mode` is on. Lower values are safer, higher values are faster. |
 | `--override-safety-checks` | — | No | `false` | **DANGEROUS:** Skip all duplicate checking. Every record will be created as new, even if it already exists. Use only when importing into a clean empty environment. |

--- a/src/TALXIS.CLI.Features.Data/DataPackageImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageImportCliCommand.cs
@@ -22,11 +22,11 @@ public class DataPackageImportCliCommand : ProfiledCliCommand
     [CliArgument(Description = "Path to the CMT data package (.zip file or folder containing data.xml and data_schema.xml)")]
     public required string Data { get; set; }
 
-    [CliOption(Name = "--connection-count", Description = "How many parallel connections to open against the environment. More connections = faster import for large datasets. Each connection authenticates separately.", Required = false)]
+    [CliOption(Name = "--connection-count", Description = "Opens 1 primary management connection and N-1 cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is N-1. To get 4 parallel workers, pass 5. Matches 'pac data import' behaviour.", Required = false)]
     [DefaultValue(1)]
     public int ConnectionCount { get; set; } = 1;
 
-    [CliOption(Name = "--batch-mode", Description = "Send records in batches instead of one-by-one. Much faster for large imports. Batches use ExecuteMultiple or UpsertMultiple depending on org version.", Required = false)]
+    [CliOption(Name = "--batch-mode", Description = "Send records in batches instead of one-by-one. Much faster for large imports. Batches use ExecuteMultiple or UpsertMultiple depending on org version. WARNING: M2M relationship records are skipped in batch mode — omit this flag or run a second pass without it if your package contains M2M relationships.", Required = false)]
     [DefaultValue(false)]
     public bool BatchMode { get; set; }
 

--- a/src/TALXIS.CLI.Features.Data/DataPackageImportCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Data/DataPackageImportCliCommand.cs
@@ -22,7 +22,7 @@ public class DataPackageImportCliCommand : ProfiledCliCommand
     [CliArgument(Description = "Path to the CMT data package (.zip file or folder containing data.xml and data_schema.xml)")]
     public required string Data { get; set; }
 
-    [CliOption(Name = "--connection-count", Description = "Opens 1 primary management connection and N-1 cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is N-1. To get 4 parallel workers, pass 5. Matches 'pac data import' behaviour.", Required = false)]
+    [CliOption(Name = "--connection-count", Description = "Opens 1 primary management connection and N-1 cloned worker connections. Only the cloned connections are used for parallel record import, so the effective parallelism is N-1. To get 4 parallel workers, pass 5.", Required = false)]
     [DefaultValue(1)]
     public int ConnectionCount { get; set; } = 1;
 

--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseConnectionFactory.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Runtime/DataverseConnectionFactory.cs
@@ -49,6 +49,12 @@ public sealed class DataverseConnectionFactory : IDataverseConnectionFactory
         // IDataverseAccessTokenService delegates to MSAL which provides its own caching.
         var conn = context.Connection;
         var cred = context.Credential;
+
+        // Prevent indefinite hangs when token acquisition fails silently.
+        // This class-level static timeout value must be set before a ServiceClient class is instantiated.
+        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.powerplatform.dataverse.client.serviceclient.maxconnectiontimeout?view=dataverse-sdk-latest
+        ServiceClient.MaxConnectionTimeout = TimeSpan.FromMinutes(2);
+
         var client = new ServiceClient(
             envUri,
             async resource =>
@@ -65,9 +71,6 @@ public sealed class DataverseConnectionFactory : IDataverseConnectionFactory
             },
             useUniqueInstance: true,
             logger: null);
-
-        // Prevent indefinite hangs when token acquisition fails silently.
-        ServiceClient.MaxConnectionTimeout = TimeSpan.FromMinutes(2);
 
         if (!client.IsReady)
         {

--- a/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
+++ b/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
@@ -475,16 +475,8 @@ public class CrmServiceClient : ServiceClient, IDisposable
 
     public Guid CreateNewRecord(string entityName, Dictionary<string, CrmDataTypeWrapper> valueArray, string applyToSolution = "", bool enabledDuplicateDetection = false, Guid batchId = default)
     {
-        var entity = new Entity(entityName);
-        PopulateEntityFromDataTypeWrappers(entity, valueArray);
-
-        var request = new CreateRequest { Target = entity };
-        request.Parameters["SuppressDuplicateDetection"] = !enabledDuplicateDetection;
-        if (!string.IsNullOrWhiteSpace(applyToSolution))
-            request.Parameters["SolutionUniqueName"] = applyToSolution;
-
-        var response = (CreateResponse)Execute(request);
-        return response?.id ?? Guid.Empty;
+        return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
+            .CreateNewRecord(this, entityName, ConvertToDataverseDataTypeWrappers(valueArray), applyToSolution, enabledDuplicateDetection, batchId);
     }
 
     public List<EntityMetadata> GetAllEntityMetadata(bool onlyPublished = true, EntityFilters filter = EntityFilters.Entity)
@@ -550,44 +542,21 @@ public class CrmServiceClient : ServiceClient, IDisposable
 
     public bool UpdateEntity(string entityName, string keyFieldName, Guid id, Dictionary<string, CrmDataTypeWrapper> fieldList, string applyToSolution = "", bool enabledDuplicateDetection = false, Guid batchId = default)
     {
-        try
-        {
-            var entity = new Entity(entityName, id);
-            PopulateEntityFromDataTypeWrappers(entity, fieldList);
-
-            var request = new UpdateRequest { Target = entity };
-            request.Parameters["SuppressDuplicateDetection"] = !enabledDuplicateDetection;
-            if (!string.IsNullOrWhiteSpace(applyToSolution))
-                request.Parameters["SolutionUniqueName"] = applyToSolution;
-
-            Execute(request);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
+        return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
+            .UpdateEntity(this, entityName, keyFieldName, id, ConvertToDataverseDataTypeWrappers(fieldList), applyToSolution, enabledDuplicateDetection, batchId);
     }
 
     public bool DeleteEntity(string entityType, Guid entityId, Guid batchId = default)
     {
-        try
-        {
-            Delete(entityType, entityId);
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
+        return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
+            .DeleteEntity(this, entityType, entityId, batchId);
     }
 
     public bool UpdateStateAndStatusForEntity(string entName, Guid id, string stateCode, string statusCode, Guid batchId = default)
     {
         try
         {
-            return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
-                .UpdateStateAndStatusForEntity(this, entName, id, stateCode, statusCode, batchId);
+            return UpdateStateAndStatusForEntity(entName, id, int.Parse(stateCode), int.Parse(statusCode), batchId);
         }
         catch
         {
@@ -597,28 +566,14 @@ public class CrmServiceClient : ServiceClient, IDisposable
 
     public bool UpdateStateAndStatusForEntity(string entName, Guid id, int stateCode, int statusCode, Guid batchId = default)
     {
-        try
-        {
-            return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
-                .UpdateStateAndStatusForEntity(this, entName, id, stateCode, statusCode, batchId);
-        }
-        catch
-        {
-            return false;
-        }
+        return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
+            .UpdateStateAndStatusForEntity(this, entName, id, stateCode, statusCode, batchId);
     }
 
     public bool DeleteEntityAssociation(string entityName1, Guid entity1Id, string entityName2, Guid entity2Id, string relationshipName, Guid batchId = default)
     {
-        try
-        {
-            Disassociate(entityName1, entity1Id, new Relationship(relationshipName), new EntityReferenceCollection { new EntityReference(entityName2, entity2Id) });
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
+        return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
+            .DeleteEntityAssociation(this, entityName1, entity1Id, entityName2, entity2Id, relationshipName, batchId);
     }
 
     /// <summary>
@@ -647,7 +602,7 @@ public class CrmServiceClient : ServiceClient, IDisposable
     public Guid CloseOpportunity(Guid opportunityId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, Guid batchId = default)
     {
         string requestName = status == 2 ? "LoseOpportunity" : "WinOpportunity";
-        return ExecuteCloseRequest("opportunityclose", "opportunityid", "opportunity", opportunityId, closeData, status, requestName);
+        return ExecuteCloseRequest("opportunityclose", "opportunityid", "opportunity", opportunityId, closeData, status, requestName, batchId);
     }
 
     /// <summary>
@@ -655,7 +610,7 @@ public class CrmServiceClient : ServiceClient, IDisposable
     /// </summary>
     public Guid CloseIncident(Guid incidentId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, Guid batchId = default)
     {
-        return ExecuteCloseRequest("incidentresolution", "incidentid", "incident", incidentId, closeData, status, "CloseIncident");
+        return ExecuteCloseRequest("incidentresolution", "incidentid", "incident", incidentId, closeData, status, "CloseIncident", batchId);
     }
 
     /// <summary>
@@ -663,7 +618,7 @@ public class CrmServiceClient : ServiceClient, IDisposable
     /// </summary>
     public Guid CloseQuote(Guid quoteId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, Guid batchId = default)
     {
-        return ExecuteCloseRequest("quoteclose", "quoteid", "quote", quoteId, closeData, status, "CloseQuote");
+        return ExecuteCloseRequest("quoteclose", "quoteid", "quote", quoteId, closeData, status, "CloseQuote", batchId);
     }
 
     /// <summary>
@@ -671,14 +626,14 @@ public class CrmServiceClient : ServiceClient, IDisposable
     /// </summary>
     public Guid CancelSalesOrder(Guid orderId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, Guid batchId = default)
     {
-        return ExecuteCloseRequest("orderclose", "salesorderid", "salesorder", orderId, closeData, status, "CancelSalesOrder");
+        return ExecuteCloseRequest("orderclose", "salesorderid", "salesorder", orderId, closeData, status, "CancelSalesOrder", batchId);
     }
 
     /// <summary>
     /// Shared helper for close/cancel operations. Creates an activity entity
     /// and executes the corresponding organization request.
     /// </summary>
-    private Guid ExecuteCloseRequest(string closeEntityName, string regardingFieldName, string regardingEntityName, Guid regardingId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, string requestName)
+    private Guid ExecuteCloseRequest(string closeEntityName, string regardingFieldName, string regardingEntityName, Guid regardingId, Dictionary<string, CrmDataTypeWrapper> closeData, int status, string requestName, Guid batchId)
     {
         var closeEntity = new Entity(closeEntityName);
         closeEntity[regardingFieldName] = new EntityReference(regardingEntityName, regardingId);
@@ -703,6 +658,11 @@ public class CrmServiceClient : ServiceClient, IDisposable
             _ => closeEntityName,
         };
         request[closeParamName] = closeEntity;
+
+        if (TryQueueRequest(batchId, request, $"Close request {requestName}"))
+        {
+            return Guid.Empty;
+        }
 
         var response = Execute(request);
         return response.Results.TryGetValue("id", out var id) ? (Guid)id : Guid.Empty;
@@ -1020,6 +980,56 @@ public class CrmServiceClient : ServiceClient, IDisposable
         };
     }
 
+    private static Dictionary<string, DataverseDataTypeWrapper> ConvertToDataverseDataTypeWrappers(
+        Dictionary<string, CrmDataTypeWrapper>? valueArray)
+    {
+        if (valueArray == null || valueArray.Count == 0)
+            return new Dictionary<string, DataverseDataTypeWrapper>(0, StringComparer.OrdinalIgnoreCase);
+
+        var converted = new Dictionary<string, DataverseDataTypeWrapper>(valueArray.Count, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var kvp in valueArray)
+        {
+            var wrapper = kvp.Value;
+            if (wrapper == null)
+            {
+                // Note: Not sure if CMT even allows null values in the xml, but if it does, we should handle them gracefully.
+                converted[kvp.Key] = new DataverseDataTypeWrapper(null, DataverseFieldType.Raw);
+                continue;
+            }
+
+            var dataverseFieldType = ConvertCrmFieldTypeToDataverseFieldType(wrapper.Type);
+            converted[kvp.Key] = string.IsNullOrWhiteSpace(wrapper.ReferencedEntity)
+                ? new DataverseDataTypeWrapper(wrapper.Value!, dataverseFieldType)
+                : new DataverseDataTypeWrapper(wrapper.Value!, dataverseFieldType, wrapper.ReferencedEntity);
+        }
+
+        return converted;
+    }
+
+    private static DataverseFieldType ConvertCrmFieldTypeToDataverseFieldType(CrmFieldType fieldType)
+    {
+        return fieldType switch
+        {
+            CrmFieldType.CrmBoolean => DataverseFieldType.Boolean,
+            CrmFieldType.CrmDateTime => DataverseFieldType.DateTime,
+            CrmFieldType.CrmDecimal => DataverseFieldType.Decimal,
+            CrmFieldType.CrmFloat => DataverseFieldType.Float,
+            CrmFieldType.CrmMoney => DataverseFieldType.Money,
+            CrmFieldType.CrmNumber => DataverseFieldType.Number,
+            CrmFieldType.Customer => DataverseFieldType.Customer,
+            CrmFieldType.Key => DataverseFieldType.Key,
+            CrmFieldType.Lookup => DataverseFieldType.Lookup,
+            CrmFieldType.Picklist => DataverseFieldType.Picklist,
+            CrmFieldType.String => DataverseFieldType.String,
+            CrmFieldType.UniqueIdentifier => DataverseFieldType.UniqueIdentifier,
+            CrmFieldType.Image => DataverseFieldType.Image,
+            CrmFieldType.File => DataverseFieldType.File,
+            CrmFieldType.Raw => DataverseFieldType.Raw,
+            _ => throw new ArgumentOutOfRangeException(nameof(fieldType), fieldType, "Unsupported CRM field type.")
+        };
+    }
+
     #endregion
 
     #region Solution import methods
@@ -1183,4 +1193,28 @@ public class CrmServiceClient : ServiceClient, IDisposable
     }
 
     #endregion
+
+    private bool TryQueueRequest(Guid batchId, OrganizationRequest request, string debugMessage)
+    {
+        if (batchId == Guid.Empty)
+        {
+            return false;
+        }
+
+        Microsoft.PowerPlatform.Dataverse.Client.RequestBatch? modern =
+            Microsoft.PowerPlatform.Dataverse.Client.Extensions.BatchExtensions.GetBatchById(this, batchId);
+
+        if (modern is null)
+        {
+            return false;
+        }
+
+        modern.BatchItems.Add(new Microsoft.PowerPlatform.Dataverse.Client.BatchItemOrganizationRequest
+        {
+            Request = request,
+            RequestDebugMessage = debugMessage,
+            RequestReferenceNumber = Guid.NewGuid()
+        });
+        return true;
+    }
 }

--- a/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
+++ b/src/TALXIS.CLI.Platform.XrmShim/CrmServiceClient.cs
@@ -476,7 +476,21 @@ public class CrmServiceClient : ServiceClient, IDisposable
     public Guid CreateNewRecord(string entityName, Dictionary<string, CrmDataTypeWrapper> valueArray, string applyToSolution = "", bool enabledDuplicateDetection = false, Guid batchId = default)
     {
         return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
-            .CreateNewRecord(this, entityName, ConvertToDataverseDataTypeWrappers(valueArray), applyToSolution, enabledDuplicateDetection, batchId);
+            .CreateNewRecord(
+                this,
+                entityName,
+                valueArray.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => new Microsoft.PowerPlatform.Dataverse.Client.DataverseDataTypeWrapper(
+                        kvp.Value.Value,
+                        (Microsoft.PowerPlatform.Dataverse.Client.DataverseFieldType)(int)kvp.Value.Type,
+                        kvp.Value.ReferencedEntity
+                    )
+                ),
+                applyToSolution,
+                enabledDuplicateDetection,
+                batchId
+            );
     }
 
     public List<EntityMetadata> GetAllEntityMetadata(bool onlyPublished = true, EntityFilters filter = EntityFilters.Entity)
@@ -543,7 +557,23 @@ public class CrmServiceClient : ServiceClient, IDisposable
     public bool UpdateEntity(string entityName, string keyFieldName, Guid id, Dictionary<string, CrmDataTypeWrapper> fieldList, string applyToSolution = "", bool enabledDuplicateDetection = false, Guid batchId = default)
     {
         return Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions
-            .UpdateEntity(this, entityName, keyFieldName, id, ConvertToDataverseDataTypeWrappers(fieldList), applyToSolution, enabledDuplicateDetection, batchId);
+            .UpdateEntity(
+                this,
+                entityName,
+                keyFieldName,
+                id,
+                fieldList.ToDictionary(
+                    kvp => kvp.Key,
+                    kvp => new Microsoft.PowerPlatform.Dataverse.Client.DataverseDataTypeWrapper(
+                        kvp.Value.Value,
+                        (Microsoft.PowerPlatform.Dataverse.Client.DataverseFieldType)(int)kvp.Value.Type,
+                        kvp.Value.ReferencedEntity
+                    )
+                ),
+                applyToSolution,
+                enabledDuplicateDetection,
+                batchId
+            );
     }
 
     public bool DeleteEntity(string entityType, Guid entityId, Guid batchId = default)
@@ -977,56 +1007,6 @@ public class CrmServiceClient : ServiceClient, IDisposable
             // Raw: pass through as-is — CMT already creates the correct SDK type
             // (OptionSetValue, OptionSetValueCollection, EntityCollection, byte[], etc.)
             _ => wrapper.Value
-        };
-    }
-
-    private static Dictionary<string, DataverseDataTypeWrapper> ConvertToDataverseDataTypeWrappers(
-        Dictionary<string, CrmDataTypeWrapper>? valueArray)
-    {
-        if (valueArray == null || valueArray.Count == 0)
-            return new Dictionary<string, DataverseDataTypeWrapper>(0, StringComparer.OrdinalIgnoreCase);
-
-        var converted = new Dictionary<string, DataverseDataTypeWrapper>(valueArray.Count, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var kvp in valueArray)
-        {
-            var wrapper = kvp.Value;
-            if (wrapper == null)
-            {
-                // Note: Not sure if CMT even allows null values in the xml, but if it does, we should handle them gracefully.
-                converted[kvp.Key] = new DataverseDataTypeWrapper(null, DataverseFieldType.Raw);
-                continue;
-            }
-
-            var dataverseFieldType = ConvertCrmFieldTypeToDataverseFieldType(wrapper.Type);
-            converted[kvp.Key] = string.IsNullOrWhiteSpace(wrapper.ReferencedEntity)
-                ? new DataverseDataTypeWrapper(wrapper.Value!, dataverseFieldType)
-                : new DataverseDataTypeWrapper(wrapper.Value!, dataverseFieldType, wrapper.ReferencedEntity);
-        }
-
-        return converted;
-    }
-
-    private static DataverseFieldType ConvertCrmFieldTypeToDataverseFieldType(CrmFieldType fieldType)
-    {
-        return fieldType switch
-        {
-            CrmFieldType.CrmBoolean => DataverseFieldType.Boolean,
-            CrmFieldType.CrmDateTime => DataverseFieldType.DateTime,
-            CrmFieldType.CrmDecimal => DataverseFieldType.Decimal,
-            CrmFieldType.CrmFloat => DataverseFieldType.Float,
-            CrmFieldType.CrmMoney => DataverseFieldType.Money,
-            CrmFieldType.CrmNumber => DataverseFieldType.Number,
-            CrmFieldType.Customer => DataverseFieldType.Customer,
-            CrmFieldType.Key => DataverseFieldType.Key,
-            CrmFieldType.Lookup => DataverseFieldType.Lookup,
-            CrmFieldType.Picklist => DataverseFieldType.Picklist,
-            CrmFieldType.String => DataverseFieldType.String,
-            CrmFieldType.UniqueIdentifier => DataverseFieldType.UniqueIdentifier,
-            CrmFieldType.Image => DataverseFieldType.Image,
-            CrmFieldType.File => DataverseFieldType.File,
-            CrmFieldType.Raw => DataverseFieldType.Raw,
-            _ => throw new ArgumentOutOfRangeException(nameof(fieldType), fieldType, "Unsupported CRM field type.")
         };
     }
 


### PR DESCRIPTION
This pull request introduces important improvements and refactoring to the data package import functionality, with a focus on improving documentation clarity and refactoring the `CrmServiceClient` to use modern extension methods for CRUD operations.

**Refactoring and Modernization of `CrmServiceClient`:**

* Refactored CRUD methods (`CreateNewRecord`, `UpdateEntity`, `DeleteEntity`, `DeleteEntityAssociation`) to delegate to the corresponding methods in `Microsoft.PowerPlatform.Dataverse.Client.Extensions.CRUDExtentions`, reducing custom code and improving maintainability. [[1]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1L478-R479) [[2]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1L553-R559) [[3]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1L599-R576)
* Added a utility method to convert between legacy `CrmDataTypeWrapper` and modern `DataverseDataTypeWrapper` types, ensuring compatibility with the new CRUD extension methods.

**Batch Operation Handling:**

* Modified close/cancel operation methods (e.g., `CloseOpportunity`, `CloseIncident`, etc.) and their helper to support batch queuing by accepting a `batchId` parameter and using a new `TryQueueRequest` method. This enables these operations to participate in batch requests when appropriate. [[1]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1L650-R636) [[2]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1R662-R666) [[3]](diffhunk://#diff-c3d8a778b4e3288c95adcb649934531c26bc4e3084ec3d06a69483de2e2a06d1R1196-R1219)

**Documentation and CLI Usability Improvements:**

* Updated the `--connection-count` option documentation and CLI description to clarify that the effective parallelism is `N-1` (one management connection plus `N-1` worker connections), matching `pac data import` behavior. Examples and recommendations were updated to reflect this. [[1]](diffhunk://#diff-f869b9add7f522aac7131b7f41cd72661b3ec6113e29d6e3b6893f90c8e7cd75L140-R141) [[2]](diffhunk://#diff-f869b9add7f522aac7131b7f41cd72661b3ec6113e29d6e3b6893f90c8e7cd75L665-R677) [[3]](diffhunk://#diff-0e8fd52dd2c62506fc3319e33a266c842a15101d177abeabec850bc8bbd8c8beL25-R29)
* Clarified in both documentation and CLI help that enabling `--batch-mode` skips M2M relationship records, and provided guidance for users who need to import M2M data. [[1]](diffhunk://#diff-f869b9add7f522aac7131b7f41cd72661b3ec6113e29d6e3b6893f90c8e7cd75L140-R141) [[2]](diffhunk://#diff-f869b9add7f522aac7131b7f41cd72661b3ec6113e29d6e3b6893f90c8e7cd75L679-R688) [[3]](diffhunk://#diff-0e8fd52dd2c62506fc3319e33a266c842a15101d177abeabec850bc8bbd8c8beL25-R29)

**Connection Timeout Handling:**

* Ensured that the `ServiceClient.MaxConnectionTimeout` is set before instantiating a new client, preventing indefinite hangs during token acquisition. [[1]](diffhunk://#diff-c05fa3572cddbef05fd4484353b364724c486bbd2e0c3301f81f5879fe27f5c2R52-R57) [[2]](diffhunk://#diff-c05fa3572cddbef05fd4484353b364724c486bbd2e0c3301f81f5879fe27f5c2L69-L71).