### PR TITLE
fix: resolve environment metadata on profile create with explicit --name

### DIFF
--- a/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
+++ b/src/TALXIS.CLI.Platform.Dataverse.Runtime/Bootstrapping/DataverseConnectionProviderBootstrapper.cs
@@ -136,49 +136,39 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
             ? null
             : await FindExistingProfileAsync(existingConnection.Id, acquired.Credential.Id, ct).ConfigureAwait(false);
 
+        // Resolve environment metadata on every path (not only when deriving
+        // a name) so EnvironmentType reaches the connection and the
+        // destructive-operation guard can tell dev/test apart from production.
+        var environment = await TryGetEnvironmentAsync(request, environmentUrl, cloud, acquired, ct).ConfigureAwait(false);
+
+        // Fall back to metadata already stored on the connection so a failed
+        // catalog lookup does not wipe values a previous refresh persisted.
+        var resolvedEnvironmentId = environment?.EnvironmentId ?? existingConnection?.EnvironmentId;
+        var resolvedDisplayName = environment?.DisplayName ?? existingConnection?.DisplayName;
+        var resolvedEnvironmentType = environment?.EnvironmentType ?? existingConnection?.EnvironmentType;
+        var resolvedOrganizationId = environment?.OrganizationId;
+        if (resolvedOrganizationId is null && Guid.TryParse(existingConnection?.OrganizationId, out var existingOrgId))
+            resolvedOrganizationId = existingOrgId;
+
         if (!string.IsNullOrEmpty(explicitName))
-            return new BindingNames(explicitName, existingConnection?.Id ?? explicitName);
+        {
+            return new BindingNames(explicitName, existingConnection?.Id ?? explicitName,
+                resolvedEnvironmentId, resolvedDisplayName, resolvedEnvironmentType, resolvedOrganizationId);
+        }
 
         if (existingProfile is not null)
-            return new BindingNames(existingProfile.Id, existingProfile.ConnectionRef!);
+        {
+            return new BindingNames(existingProfile.Id, existingProfile.ConnectionRef!,
+                resolvedEnvironmentId, resolvedDisplayName, resolvedEnvironmentType, resolvedOrganizationId);
+        }
 
         string? preferredBase = null;
-        Guid? resolvedEnvironmentId = null;
-        string? resolvedDisplayName = null;
-        EnvironmentType? resolvedEnvironmentType = null;
-        Guid? resolvedOrganizationId = null;
-        var ephemeralConnection = new Connection
+        if (environment is not null)
         {
-            Id = "(ephemeral)",
-            Provider = request.Provider,
-            EnvironmentUrl = environmentUrl.ToString().TrimEnd('/'),
-            Cloud = cloud,
-            TenantId = request.TenantId ?? acquired.TenantId,
-        };
-
-        try
-        {
-            var environment = await _environmentCatalog
-                .TryGetByEnvironmentUrlAsync(ephemeralConnection, acquired.Credential, environmentUrl, ct)
-                .ConfigureAwait(false);
-            if (environment is not null)
-            {
-                // Include tenant domain in the slug so multi-customer users can
-                // distinguish environments across tenants at a glance.
-                var tenantDomain = CredentialAliasResolver.ExtractTenantShortName(acquired.Upn);
-                preferredBase = ProviderUrlResolver.DeriveDefaultName(environment.DisplayName, request.EnvironmentUrl, tenantDomain);
-                resolvedEnvironmentId = environment.EnvironmentId;
-                resolvedDisplayName = environment.DisplayName;
-                resolvedEnvironmentType = environment.EnvironmentType;
-                resolvedOrganizationId = environment.OrganizationId;
-            }
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
-        {
-            _logger.LogWarning(
-                ex,
-                "Could not resolve Power Platform environment metadata for '{Url}'. Falling back to the URL host.",
-                request.EnvironmentUrl);
+            // Include tenant domain in the slug so multi-customer users can
+            // distinguish environments across tenants at a glance.
+            var tenantDomain = CredentialAliasResolver.ExtractTenantShortName(acquired.Upn);
+            preferredBase = ProviderUrlResolver.DeriveDefaultName(environment.DisplayName, request.EnvironmentUrl, tenantDomain);
         }
 
         if (string.IsNullOrEmpty(preferredBase))
@@ -212,6 +202,38 @@ public sealed class DataverseConnectionProviderBootstrapper : IConnectionProvide
 
         return new BindingNames(sharedName, sharedName, resolvedEnvironmentId,
             resolvedDisplayName, resolvedEnvironmentType, resolvedOrganizationId);
+    }
+
+    private async Task<PowerPlatformEnvironmentSummary?> TryGetEnvironmentAsync(
+        ProfileBootstrapRequest request,
+        Uri environmentUrl,
+        CloudInstance cloud,
+        InteractiveCredentialResult acquired,
+        CancellationToken ct)
+    {
+        var ephemeralConnection = new Connection
+        {
+            Id = "(ephemeral)",
+            Provider = request.Provider,
+            EnvironmentUrl = environmentUrl.ToString().TrimEnd('/'),
+            Cloud = cloud,
+            TenantId = request.TenantId ?? acquired.TenantId,
+        };
+
+        try
+        {
+            return await _environmentCatalog
+                .TryGetByEnvironmentUrlAsync(ephemeralConnection, acquired.Credential, environmentUrl, ct)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not resolve Power Platform environment metadata for '{Url}'. Falling back to the URL host.",
+                request.EnvironmentUrl);
+            return null;
+        }
     }
 
     private async Task<Connection?> FindExistingConnectionAsync(

--- a/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProfileCreateOneLinerTests.cs
+++ b/tests/TALXIS.CLI.Tests/Config/Bootstrapping/ProfileCreateOneLinerTests.cs
@@ -283,6 +283,76 @@ public sealed class ProfileCreateOneLinerTests
     }
 
     [Fact]
+    public async Task UrlMode_ExplicitName_StillResolvesEnvironmentMetadata()
+    {
+        var catalog = new CommandTestHost.FakePowerPlatformEnvironmentCatalog();
+        catalog.Add(new PowerPlatformEnvironmentSummary(
+            EnvironmentId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            DisplayName: "Contoso DevBox",
+            EnvironmentUrl: new Uri("https://devbox.crm4.dynamics.com/"),
+            UniqueName: "contoso-devbox",
+            DomainName: "devbox",
+            OrganizationId: Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            EnvironmentType: EnvironmentType.Developer));
+
+        using var host = new CommandTestHost(environmentCatalog: catalog);
+        using (OutputWriter.RedirectTo(new StringWriter()))
+        {
+            var exit = await new ProfileCreateCliCommand
+            {
+                Url = "https://devbox.crm4.dynamics.com/",
+                Name = "devbox-2896",
+            }.RunAsync();
+            Assert.Equal(0, exit);
+        }
+
+        var connections = (IConnectionStore)host.Provider.GetService(typeof(IConnectionStore))!;
+        var connection = await connections.GetAsync("devbox-2896", default);
+        Assert.NotNull(connection);
+        Assert.Equal(EnvironmentType.Developer, connection!.EnvironmentType);
+        Assert.Equal("Contoso DevBox", connection.DisplayName);
+        Assert.Equal(Guid.Parse("11111111-2222-3333-4444-555555555555"), connection.EnvironmentId);
+        Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", connection.OrganizationId);
+    }
+
+    [Fact]
+    public async Task UrlMode_Recreate_WhenLookupFails_PreservesExistingMetadata()
+    {
+        var catalog = new CommandTestHost.FakePowerPlatformEnvironmentCatalog();
+        catalog.Add(new PowerPlatformEnvironmentSummary(
+            EnvironmentId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+            DisplayName: "Contoso DevBox",
+            EnvironmentUrl: new Uri("https://devbox.crm4.dynamics.com/"),
+            UniqueName: "contoso-devbox",
+            DomainName: "devbox",
+            OrganizationId: Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            EnvironmentType: EnvironmentType.Developer));
+
+        using var host = new CommandTestHost(environmentCatalog: catalog);
+        using (OutputWriter.RedirectTo(new StringWriter()))
+        {
+            Assert.Equal(0, await new ProfileCreateCliCommand
+            {
+                Url = "https://devbox.crm4.dynamics.com/",
+                Name = "devbox-2896",
+            }.RunAsync());
+
+            catalog.Failure = new InvalidOperationException("admin lookup failed");
+            Assert.Equal(0, await new ProfileCreateCliCommand
+            {
+                Url = "https://devbox.crm4.dynamics.com/",
+                Name = "devbox-2896",
+            }.RunAsync());
+        }
+
+        var connections = (IConnectionStore)host.Provider.GetService(typeof(IConnectionStore))!;
+        var connection = await connections.GetAsync("devbox-2896", default);
+        Assert.NotNull(connection);
+        Assert.Equal(EnvironmentType.Developer, connection!.EnvironmentType);
+        Assert.Equal("Contoso DevBox", connection.DisplayName);
+    }
+
+    [Fact]
     public async Task UrlMode_InfersSovereignCloud_FromEnvironmentUrl_WhenCloudOmitted()
     {
         using var host = new CommandTestHost();


### PR DESCRIPTION
`config profile create --url ... --name ...` saved the connection without environmentType, displayName, organizationId and environmentId. The catalog lookup only ran when we needed to derive a profile name, so passing --name (or re-creating a profile for an already known connection) skipped it entirely. Worse, since the upsert replaces the whole connection, re-running create actually wiped metadata that `profile validate --refresh-env-type` had persisted earlier.

The practical fallout: a connection without environmentType is treated as production by the destructive-operation guard, so deletes on a plain devbox started demanding --allow-production. Agents then just pass the flag automatically, which defeats the point of the guard.

The lookup now runs on every create path (still best-effort, failure logs a warning and falls back), and when it fails we carry over whatever metadata the existing connection already had instead of overwriting it with nulls. Two new tests cover the explicit-name case and the don't-wipe-on-failed-lookup case.