### PR TITLE
feat(workspace): manifest-driven control attach command

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/Controls/ControlAttachCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Controls/ControlAttachCliCommand.cs
@@ -1,0 +1,183 @@
+using DotMake.CommandLine;
+using Microsoft.Extensions.Logging;
+using TALXIS.CLI.Core;
+using TALXIS.CLI.Core.Contracts.Packaging;
+using TALXIS.CLI.Logging;
+using TALXIS.Platform.Metadata.Validation;
+
+namespace TALXIS.CLI.Features.Workspace.Controls;
+
+/// <summary>
+/// Overlays a PCF custom control on an existing subgrid of a form. The control's
+/// <c>ControlManifest.xml</c> supplies the parameter schema — resolved from a NuGet
+/// package name (downloaded automatically, like <c>env pkg import</c>) or from a local
+/// file (bare manifest, solution zip, pdpkg.zip, or nupkg); dataset binding is copied
+/// from the host subgrid; the modified form is re-validated with the platform metadata
+/// schema validator.
+/// </summary>
+[CliIdempotent]
+[CliCommand(
+    Description = "Attach a custom control to a subgrid on a form, driven by the control's manifest",
+    Name = "attach")]
+public class ControlAttachCliCommand : TxcLeafCommand
+{
+    protected override ILogger Logger { get; } = TxcLoggerFactory.CreateLogger(nameof(ControlAttachCliCommand));
+
+    [CliOption(Name = "--output", Aliases = ["-o"], Description = "Solution project root containing the Entities folder", Required = true)]
+    public string OutputPath { get; set; } = null!;
+
+    [CliOption(Name = "--entity", Description = "Logical name of the entity that owns the form (e.g. almlab_warehouselocation)", Required = true)]
+    public string EntityLogicalName { get; set; } = null!;
+
+    [CliOption(Name = "--form-type", Description = "Form type folder name", Required = false)]
+    public string FormType { get; set; } = "main";
+
+    [CliOption(Name = "--form-id", Description = "Form GUID (without braces). Optional when the entity has exactly one form of the given type.", Required = false)]
+    public string? FormId { get; set; }
+
+    [CliOption(Name = "--target-control", Description = "FormXml id of the subgrid to overlay (e.g. subgrid)", Required = true)]
+    public string TargetControlId { get; set; } = null!;
+
+    [CliOption(Name = "--package", Description = "NuGet package name of the control (downloaded automatically), or local path to its ControlManifest.xml / solution .zip / .pdpkg.zip / .nupkg", Required = true)]
+    public string Package { get; set; } = null!;
+
+    [CliOption(Name = "--version", Description = "NuGet package version (only when '--package' is a NuGet name).", Required = false)]
+    public string PackageVersion { get; set; } = "latest";
+
+    [CliOption(Name = "--control-name", Description = "Publisher-prefixed control name for FormXml (e.g. talxis_TALXIS.PCF.Grid). Required only when it cannot be resolved from the manifest source.", Required = false)]
+    public string? ControlName { get; set; }
+
+    [CliOption(Description = "Control parameters in key=value format (validated against the manifest). Can be specified multiple times.")]
+    public List<string> Param { get; set; } = new();
+
+    [CliOption(Description = "Replace an existing custom control attachment on the same subgrid.")]
+    public bool Force { get; set; }
+
+    private readonly NuGetPackageInstallerService _packageInstaller = new();
+
+    protected override async Task<int> ExecuteAsync()
+    {
+        string manifestSource;
+        string? tempWorkingDirectory = null;
+        if (File.Exists(Package))
+        {
+            manifestSource = Path.GetFullPath(Package);
+        }
+        else if (Package.IndexOfAny(['\\', '/']) >= 0 || HasManifestFileExtension(Package))
+        {
+            // Looks like a file path (NuGet ids contain dots but never these extensions).
+            Logger.LogError("Manifest source not found: {Package}", Package);
+            return ExitValidationError;
+        }
+        else
+        {
+            var install = await _packageInstaller.InstallAsync(new NuGetPackageInstallOptions(Package, PackageVersion, null));
+            Logger.LogInformation("Resolved {PackageName} version {Version}", install.PackageName, install.ResolvedVersion);
+            manifestSource = install.DownloadedPackagePath;
+            if (install.UsesTemporaryWorkingDirectory)
+                tempWorkingDirectory = install.WorkingDirectory;
+        }
+
+        try
+        {
+            return AttachFromManifest(manifestSource);
+        }
+        finally
+        {
+            if (tempWorkingDirectory != null)
+                Directory.Delete(tempWorkingDirectory, recursive: true);
+        }
+    }
+
+    private int AttachFromManifest(string manifestSource)
+    {
+        var manifest = ControlManifestReader.Read(manifestSource);
+
+        var controlName = ControlName ?? manifest.PrefixedName;
+        if (string.IsNullOrEmpty(controlName))
+        {
+            Logger.LogError("The publisher-prefixed control name could not be resolved from '{Manifest}'. Pass it explicitly with --control-name (e.g. talxis_{Qualified}).", manifestSource, manifest.QualifiedName);
+            return ExitValidationError;
+        }
+
+        var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in Param)
+        {
+            var idx = p.IndexOf('=');
+            if (idx <= 0 || idx == p.Length - 1)
+                throw new ArgumentException($"Invalid parameter format: '{p}'. Use key=value.");
+            parameters[p.Substring(0, idx)] = p.Substring(idx + 1);
+        }
+
+        var formFile = ResolveFormFile();
+        var preErrors = CountSchemaErrors(formFile);
+
+        var result = FormControlAttachmentService.Attach(new ControlAttachmentRequest
+        {
+            FormFilePath = formFile,
+            TargetControlId = TargetControlId,
+            Manifest = manifest,
+            ControlName = controlName,
+            Parameters = parameters,
+            Force = Force,
+        });
+
+        var postErrors = CountSchemaErrors(formFile);
+        if (postErrors > preErrors)
+            Logger.LogWarning("Schema validation reports {New} new issue(s) on {File} after the change — run 'txc workspace validate' for details.", postErrors - preErrors, formFile);
+
+        var action = result.ReplacedExisting ? "replaced on" : "attached to";
+        OutputFormatter.WriteResult("succeeded", $"{controlName} {action} '{TargetControlId}' in {formFile}");
+        return ExitSuccess;
+    }
+
+    private string ResolveFormFile()
+    {
+        var formDir = Path.Combine(OutputPath, "Entities", EntityLogicalName, "FormXml", FormType);
+        if (!Directory.Exists(formDir))
+            throw new InvalidOperationException($"Form folder not found: {formDir}");
+
+        if (!string.IsNullOrEmpty(FormId))
+        {
+            var wanted = FormId.Trim('{', '}');
+            var match = Directory.GetFiles(formDir, "*.xml").FirstOrDefault(f =>
+                NormalizeFormFileName(f).Equals(wanted, StringComparison.OrdinalIgnoreCase));
+            return match ?? throw new InvalidOperationException($"Form {FormId} not found in {formDir}");
+        }
+
+        var forms = Directory.GetFiles(formDir, "*.xml");
+        return forms.Length switch
+        {
+            1 => forms[0],
+            0 => throw new InvalidOperationException($"No forms found in {formDir}"),
+            _ => throw new InvalidOperationException($"Multiple forms found in {formDir} — pass --form-id. Candidates: {string.Join(", ", forms.Select(Path.GetFileName))}"),
+        };
+    }
+
+    private static bool HasManifestFileExtension(string value) =>
+        value.EndsWith(".xml", StringComparison.OrdinalIgnoreCase) ||
+        value.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
+        value.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+
+    // Managed-layer sources use a "{guid}_managed.xml" file name — match on the guid alone.
+    private static string NormalizeFormFileName(string path)
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+        if (name.EndsWith("_managed", StringComparison.OrdinalIgnoreCase))
+            name = name[..^"_managed".Length];
+        return name.Trim('{', '}');
+    }
+
+    private static int CountSchemaErrors(string formFile)
+    {
+        try
+        {
+            var results = new SchemaValidator().ValidateFile(formFile);
+            return results.Count(r => r.Severity == ValidationSeverity.Error);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/Controls/ControlCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Controls/ControlCliCommand.cs
@@ -1,0 +1,25 @@
+using DotMake.CommandLine;
+
+namespace TALXIS.CLI.Features.Workspace.Controls;
+
+/// <summary>
+/// Custom control (PCF) operations on forms in the local workspace.
+/// Unlike <c>component create</c>, these commands are manifest-driven rather than
+/// template-driven: the parameter schema comes from the control's own
+/// <c>ControlManifest.xml</c> at run time, so no per-control template is needed.
+/// </summary>
+[CliCommand(
+    Description = "Attach custom controls (PCF) to forms in your local workspace",
+    Name = "control",
+    Children = new[]
+    {
+        typeof(ControlAttachCliCommand),
+    },
+    ShortFormAutoGenerate = CliNameAutoGenerate.None)]
+public class ControlCliCommand
+{
+    public void Run(CliContext context)
+    {
+        context.ShowHelp();
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/Controls/ControlManifestInfo.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Controls/ControlManifestInfo.cs
@@ -1,0 +1,50 @@
+namespace TALXIS.CLI.Features.Workspace.Controls;
+
+/// <summary>
+/// Parsed PCF <c>ControlManifest.xml</c> — the runtime parameter schema of a custom control.
+/// Replaces the per-control template approach: the manifest ships with the control itself,
+/// so one generic attach command can validate and emit parameters for any control.
+/// </summary>
+public sealed class ControlManifestInfo
+{
+    /// <summary>Control namespace, e.g. <c>TALXIS.PCF</c>.</summary>
+    public required string Namespace { get; init; }
+
+    /// <summary>Control constructor, e.g. <c>Grid</c>.</summary>
+    public required string Constructor { get; init; }
+
+    /// <summary>Control version from the manifest.</summary>
+    public string? Version { get; init; }
+
+    /// <summary>Unprefixed qualified name, e.g. <c>TALXIS.PCF.Grid</c>.</summary>
+    public string QualifiedName => $"{Namespace}.{Constructor}";
+
+    /// <summary>
+    /// Publisher-prefixed name used in FormXml (e.g. <c>talxis_TALXIS.PCF.Grid</c>).
+    /// Resolved from the accompanying solution's <c>customizations.xml</c> when the manifest
+    /// was read from a solution/package archive; null for a bare manifest file.
+    /// </summary>
+    public string? PrefixedName { get; set; }
+
+    /// <summary>Dataset bindings declared by the control, in document order (e.g. <c>Grid</c>, <c>RibbonGroupingDataset</c>).</summary>
+    public IReadOnlyList<string> DataSets { get; init; } = [];
+
+    /// <summary>Input properties declared by the control.</summary>
+    public IReadOnlyList<ControlManifestProperty> Properties { get; init; } = [];
+}
+
+/// <summary>A single <c>property</c> element from a control manifest.</summary>
+public sealed class ControlManifestProperty
+{
+    public required string Name { get; init; }
+
+    /// <summary>Dataverse type from <c>of-type</c> (e.g. <c>Enum</c>, <c>SingleLine.Text</c>, <c>Whole.None</c>, <c>Multiple</c>).</summary>
+    public required string OfType { get; init; }
+
+    public string? DefaultValue { get; init; }
+
+    public bool Required { get; init; }
+
+    /// <summary>Allowed values for <c>Enum</c> properties (the element texts of the <c>value</c> children).</summary>
+    public IReadOnlyList<string> EnumValues { get; init; } = [];
+}

--- a/src/TALXIS.CLI.Features.Workspace/Controls/ControlManifestReader.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Controls/ControlManifestReader.cs
@@ -1,0 +1,157 @@
+using System.IO.Compression;
+using System.Xml.Linq;
+
+namespace TALXIS.CLI.Features.Workspace.Controls;
+
+/// <summary>
+/// Locates and parses a PCF <c>ControlManifest.xml</c> from a bare file or from inside
+/// a control distribution archive (solution zip, Package Deployer pdpkg.zip, or NuGet nupkg —
+/// archives are searched recursively, so a nupkg wrapping a pdpkg wrapping a solution works).
+/// When the manifest comes from a solution archive, the publisher-prefixed control name
+/// (e.g. <c>talxis_TALXIS.PCF.Grid</c>) is resolved from the solution's <c>customizations.xml</c>.
+/// </summary>
+public static class ControlManifestReader
+{
+    private const int MaxArchiveDepth = 3;
+
+    public static ControlManifestInfo Read(string path)
+    {
+        if (!File.Exists(path))
+            throw new FileNotFoundException($"Manifest source not found: {path}");
+
+        if (path.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
+        {
+            using var stream = File.OpenRead(path);
+            return ParseManifest(stream);
+        }
+
+        using var archiveStream = File.OpenRead(path);
+        var result = SearchArchive(archiveStream, MaxArchiveDepth);
+        if (result.Manifest == null)
+            throw new InvalidOperationException($"No ControlManifest.xml found inside '{path}' (searched nested archives up to {MaxArchiveDepth} levels).");
+
+        result.Manifest.PrefixedName = ResolvePrefixedName(result);
+        return result.Manifest;
+    }
+
+    private sealed class ArchiveSearchResult
+    {
+        public ControlManifestInfo? Manifest { get; set; }
+        /// <summary>The archive entry path the manifest was found at (e.g. Controls/talxis_TALXIS.PCF.Grid/ControlManifest.xml).</summary>
+        public string? ManifestEntryPath { get; set; }
+        /// <summary>CustomControl names declared in customizations.xml of the same solution archive.</summary>
+        public List<string> CustomControlNames { get; } = [];
+    }
+
+    private static ArchiveSearchResult SearchArchive(Stream stream, int depthBudget)
+    {
+        var result = new ArchiveSearchResult();
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: true);
+
+        foreach (var entry in archive.Entries)
+        {
+            if (entry.Name.Equals("ControlManifest.xml", StringComparison.OrdinalIgnoreCase) && result.Manifest == null)
+            {
+                using var entryStream = entry.Open();
+                result.Manifest = ParseManifest(entryStream);
+                result.ManifestEntryPath = entry.FullName;
+            }
+            else if (entry.Name.Equals("customizations.xml", StringComparison.OrdinalIgnoreCase))
+            {
+                using var entryStream = entry.Open();
+                result.CustomControlNames.AddRange(ReadCustomControlNames(entryStream));
+            }
+        }
+
+        if (result.Manifest != null || depthBudget <= 0)
+            return result;
+
+        foreach (var entry in archive.Entries)
+        {
+            if (!IsNestedArchive(entry.Name))
+                continue;
+            using var entryStream = entry.Open();
+            using var buffered = CopyToMemory(entryStream);
+            var nested = SearchArchive(buffered, depthBudget - 1);
+            if (nested.Manifest != null)
+                return nested;
+        }
+
+        return result;
+    }
+
+    private static bool IsNestedArchive(string name) =>
+        name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
+        name.EndsWith(".nupkg", StringComparison.OrdinalIgnoreCase);
+
+    // ZipArchive entry streams are not seekable, but nested ZipArchive needs a seekable stream.
+    private static MemoryStream CopyToMemory(Stream source)
+    {
+        var memory = new MemoryStream();
+        source.CopyTo(memory);
+        memory.Position = 0;
+        return memory;
+    }
+
+    private static string? ResolvePrefixedName(ArchiveSearchResult result)
+    {
+        if (result.Manifest == null)
+            return null;
+
+        // The solution declares the prefixed name; match on the qualified-name suffix.
+        var suffix = "_" + result.Manifest.QualifiedName;
+        var fromCustomizations = result.CustomControlNames.FirstOrDefault(n => n.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        if (fromCustomizations != null)
+            return fromCustomizations;
+
+        // Fall back to the folder name in the solution layout (Controls/<prefixed-name>/ControlManifest.xml).
+        var folder = Path.GetDirectoryName(result.ManifestEntryPath)?.Replace('\\', '/').Split('/').LastOrDefault();
+        if (!string.IsNullOrEmpty(folder) && folder.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            return folder;
+
+        return null;
+    }
+
+    private static IEnumerable<string> ReadCustomControlNames(Stream customizationsStream)
+    {
+        var doc = XDocument.Load(customizationsStream);
+        return doc.Descendants("CustomControl")
+            .Select(c => c.Element("Name")?.Value)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .ToList();
+    }
+
+    private static ControlManifestInfo ParseManifest(Stream stream)
+    {
+        var doc = XDocument.Load(stream);
+        var control = doc.Descendants("control").FirstOrDefault()
+            ?? throw new InvalidOperationException("Invalid control manifest: no <control> element.");
+
+        var ns = control.Attribute("namespace")?.Value
+            ?? throw new InvalidOperationException("Invalid control manifest: <control> has no 'namespace' attribute.");
+        var constructor = control.Attribute("constructor")?.Value
+            ?? throw new InvalidOperationException("Invalid control manifest: <control> has no 'constructor' attribute.");
+
+        var properties = control.Elements("property")
+            .Select(p => new ControlManifestProperty
+            {
+                Name = p.Attribute("name")?.Value ?? "",
+                OfType = p.Attribute("of-type")?.Value ?? p.Attribute("of-type-group")?.Value ?? "SingleLine.Text",
+                DefaultValue = p.Attribute("default-value")?.Value,
+                Required = string.Equals(p.Attribute("required")?.Value, "true", StringComparison.OrdinalIgnoreCase),
+                EnumValues = p.Elements("value").Select(v => v.Value.Trim()).ToList(),
+            })
+            .Where(p => p.Name.Length > 0)
+            .ToList();
+
+        return new ControlManifestInfo
+        {
+            Namespace = ns,
+            Constructor = constructor,
+            Version = control.Attribute("version")?.Value,
+            DataSets = control.Elements("data-set").Select(d => d.Attribute("name")?.Value ?? "").Where(n => n.Length > 0).ToList(),
+            Properties = properties,
+        };
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/Controls/FormControlAttachmentService.cs
+++ b/src/TALXIS.CLI.Features.Workspace/Controls/FormControlAttachmentService.cs
@@ -1,0 +1,182 @@
+using System.Xml.Linq;
+
+namespace TALXIS.CLI.Features.Workspace.Controls;
+
+/// <summary>Request to overlay a custom control on an existing form control.</summary>
+public sealed class ControlAttachmentRequest
+{
+    public required string FormFilePath { get; init; }
+    /// <summary>FormXml control id of the host control (e.g. <c>subgrid</c>).</summary>
+    public required string TargetControlId { get; init; }
+    public required ControlManifestInfo Manifest { get; init; }
+    /// <summary>Publisher-prefixed control name for FormXml (e.g. <c>talxis_TALXIS.PCF.Grid</c>).</summary>
+    public required string ControlName { get; init; }
+    /// <summary>Control parameter values keyed by manifest property name.</summary>
+    public IReadOnlyDictionary<string, string> Parameters { get; init; } = new Dictionary<string, string>();
+    /// <summary>Replace an existing attachment on the same host control instead of failing.</summary>
+    public bool Force { get; init; }
+}
+
+public sealed class ControlAttachmentResult
+{
+    public required string FormFilePath { get; init; }
+    public required string ControlName { get; init; }
+    public required string HostControlUniqueId { get; init; }
+    public bool ReplacedExisting { get; init; }
+}
+
+/// <summary>
+/// Overlays a PCF custom control on an existing subgrid of a form by inserting the
+/// <c>controlDescriptions/controlDescription</c> node (base control block + one
+/// <c>customControl</c> block per form factor), mirroring the shape produced by the
+/// Dataverse form designer. Parameter values are validated against the control manifest,
+/// and dataset binding values (ViewId, TargetEntityType, RelationshipName) are read from
+/// the host subgrid so they never need to be supplied by hand.
+/// </summary>
+public static class FormControlAttachmentService
+{
+    private const string SubgridClassId = "{E7A81278-8635-4D9E-8D4D-59480B391C5B}";
+
+    public static ControlAttachmentResult Attach(ControlAttachmentRequest request)
+    {
+        var doc = XDocument.Load(request.FormFilePath);
+        var form = doc.Descendants("form").FirstOrDefault()
+            ?? throw new InvalidOperationException($"No <form> element in '{request.FormFilePath}'.");
+
+        var host = FindHostControl(form, request.TargetControlId);
+        var uniqueId = host.Attribute("uniqueid")?.Value
+            ?? throw new InvalidOperationException($"Host control '{request.TargetControlId}' has no uniqueid attribute.");
+
+        ValidateParameters(request.Manifest, request.Parameters);
+
+        var parameters = BuildParametersElement(request, host);
+        var description = new XElement("controlDescription",
+            new XAttribute("forControl", uniqueId),
+            new XElement("customControl",
+                new XAttribute("id", SubgridClassId),
+                new XElement("parameters")));
+        foreach (var formFactor in new[] { "0", "1", "2" })
+        {
+            description.Add(new XElement("customControl",
+                new XAttribute("formFactor", formFactor),
+                new XAttribute("name", request.ControlName),
+                new XElement(parameters)));
+        }
+
+        var replaced = InsertDescription(form, description, uniqueId, request.Force);
+        doc.Save(request.FormFilePath);
+
+        return new ControlAttachmentResult
+        {
+            FormFilePath = request.FormFilePath,
+            ControlName = request.ControlName,
+            HostControlUniqueId = uniqueId,
+            ReplacedExisting = replaced,
+        };
+    }
+
+    private static XElement FindHostControl(XElement form, string targetControlId)
+    {
+        var host = form.Descendants("control").FirstOrDefault(c => c.Attribute("id")?.Value == targetControlId)
+            ?? throw new InvalidOperationException(
+                $"Control '{targetControlId}' not found on the form. Available controls: " +
+                string.Join(", ", form.Descendants("control").Select(c => c.Attribute("id")?.Value).Where(id => id != null)));
+
+        if (!string.Equals(host.Attribute("indicationOfSubgrid")?.Value, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Control '{targetControlId}' is not a subgrid. Only subgrid-bound controls are supported; " +
+                "field-bound controls (e.g. VirtualDataset on a placeholder column) are not supported yet.");
+        }
+
+        return host;
+    }
+
+    private static void ValidateParameters(ControlManifestInfo manifest, IReadOnlyDictionary<string, string> values)
+    {
+        var byName = manifest.Properties.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        var errors = new List<string>();
+
+        foreach (var (name, value) in values)
+        {
+            if (!byName.TryGetValue(name, out var property))
+            {
+                errors.Add($"'{name}' is not a parameter of {manifest.QualifiedName}. Valid parameters: {string.Join(", ", manifest.Properties.Select(p => p.Name))}.");
+                continue;
+            }
+            if (property.EnumValues.Count > 0 && !property.EnumValues.Contains(value, StringComparer.Ordinal))
+                errors.Add($"'{name}': '{value}' is not an allowed value. Allowed: {string.Join(", ", property.EnumValues)}.");
+            else if (property.OfType.StartsWith("Whole.", StringComparison.Ordinal) && !long.TryParse(value, out _))
+                errors.Add($"'{name}': '{value}' is not a whole number ({property.OfType}).");
+            else if (property.OfType == "TwoOptions" && value is not ("true" or "false"))
+                errors.Add($"'{name}': '{value}' must be 'true' or 'false' (TwoOptions).");
+        }
+
+        if (errors.Count > 0)
+            throw new ArgumentException("Invalid control parameters:\n  " + string.Join("\n  ", errors));
+    }
+
+    private static XElement BuildParametersElement(ControlAttachmentRequest request, XElement host)
+    {
+        var parameters = new XElement("parameters");
+
+        // Dataset binding mirrors the host subgrid; the control's primary data-set gets the same view.
+        var primaryDataSet = request.Manifest.DataSets.FirstOrDefault();
+        if (primaryDataSet != null)
+        {
+            var hostParameters = host.Element("parameters");
+            var viewId = hostParameters?.Element("ViewId")?.Value ?? "";
+            parameters.Add(new XElement("data-set",
+                new XAttribute("name", primaryDataSet),
+                new XElement("ViewId", viewId),
+                new XElement("TargetEntityType", hostParameters?.Element("TargetEntityType")?.Value ?? ""),
+                new XElement("IsUserView", "false"),
+                new XElement("EnableViewPicker", hostParameters?.Element("EnableViewPicker")?.Value ?? "false"),
+                new XElement("RelationshipName", hostParameters?.Element("RelationshipName")?.Value ?? ""),
+                new XElement("FilteredViewIds", viewId)));
+        }
+
+        var byName = request.Manifest.Properties.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, value) in request.Parameters)
+        {
+            var property = byName[name];
+            parameters.Add(new XElement(property.Name,
+                new XAttribute("type", property.OfType),
+                new XAttribute("static", "true"),
+                value));
+        }
+
+        return parameters;
+    }
+
+    /// <returns>True when an existing attachment for the same host control was replaced.</returns>
+    private static bool InsertDescription(XElement form, XElement description, string uniqueId, bool force)
+    {
+        var container = form.Element("controlDescriptions");
+        if (container == null)
+        {
+            container = new XElement("controlDescriptions");
+            // Match the designer's element order: controlDescriptions precedes
+            // DisplayConditions / formLibraries / events.
+            var anchor = form.Element("DisplayConditions") ?? form.Element("formLibraries") ?? form.Element("events") as XNode;
+            if (anchor != null) anchor.AddBeforeSelf(container);
+            else form.Add(container);
+        }
+
+        var existing = container.Elements("controlDescription")
+            .FirstOrDefault(d => string.Equals(d.Attribute("forControl")?.Value, uniqueId, StringComparison.OrdinalIgnoreCase));
+        if (existing != null)
+        {
+            if (!force)
+            {
+                throw new InvalidOperationException(
+                    $"A custom control is already attached to control '{uniqueId}'. Use --force to replace it.");
+            }
+            existing.ReplaceWith(description);
+            return true;
+        }
+
+        container.Add(description);
+        return false;
+    }
+}

--- a/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
+++ b/src/TALXIS.CLI.Features.Workspace/WorkspaceCliCommand.cs
@@ -1,4 +1,5 @@
 using DotMake.CommandLine;
+using TALXIS.CLI.Features.Workspace.Controls;
 
 namespace TALXIS.CLI.Features.Workspace;
 
@@ -8,6 +9,7 @@ namespace TALXIS.CLI.Features.Workspace;
     Children = new[]
     {
         typeof(ComponentCliCommand),
+        typeof(ControlCliCommand),
         typeof(ProjectCliCommand),
         typeof(WorkspaceExplainCliCommand),
         typeof(WorkspaceValidateCliCommand)

--- a/tests/TALXIS.CLI.Tests/Workspace/Controls/ControlManifestReaderTests.cs
+++ b/tests/TALXIS.CLI.Tests/Workspace/Controls/ControlManifestReaderTests.cs
@@ -1,0 +1,142 @@
+using System.IO.Compression;
+using System.Text;
+using TALXIS.CLI.Features.Workspace.Controls;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Workspace.Controls;
+
+public class ControlManifestReaderTests : IDisposable
+{
+    private const string GridManifestXml = """
+        <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+        <manifest>
+          <control namespace="TALXIS.PCF" constructor="Grid" version="0.0.59648" display-name-key="TALXIS Grid" control-type="standard" api-version="1.3.18">
+            <external-service-usage enabled="false"/>
+            <data-set name="Grid" display-name-key="Main Dataset"/>
+            <data-set name="RibbonGroupingDataset" display-name-key="Ribbon Grouping Dataset"/>
+            <property name="Columns" display-name-key="Columns" default-value="[]" of-type="Multiple" usage="input" required="false"/>
+            <property name="RowHeight" display-name-key="Row Height" of-type="Whole.None" default-value="42" usage="input" required="false"/>
+            <property name="EnableEditing" display-name-key="Enable Editing" of-type="Enum" usage="input">
+              <value name="Yes" display-name-key="Yes">true</value>
+              <value name="No" default="true" display-name-key="No">false</value>
+            </property>
+            <property name="ClientApiWebresourceName" display-name-key="Client API Webresource Name" of-type="SingleLine.Text" usage="input"/>
+          </control>
+        </manifest>
+        """;
+
+    private const string CustomizationsXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <ImportExportXml>
+          <CustomControls>
+            <CustomControl>
+              <Name>talxis_TALXIS.PCF.Grid</Name>
+            </CustomControl>
+          </CustomControls>
+        </ImportExportXml>
+        """;
+
+    private readonly string _tempDir = Directory.CreateTempSubdirectory("txc-manifest-tests").FullName;
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    private string WriteFile(string name, byte[] content)
+    {
+        var path = Path.Combine(_tempDir, name);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    private static byte[] BuildZip(params (string EntryName, byte[] Content)[] entries)
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, content) in entries)
+            {
+                using var entryStream = archive.CreateEntry(name).Open();
+                entryStream.Write(content);
+            }
+        }
+        return stream.ToArray();
+    }
+
+    [Fact]
+    public void Read_BareManifestFile_ParsesControlAndProperties()
+    {
+        var path = WriteFile("ControlManifest.xml", Encoding.UTF8.GetBytes(GridManifestXml));
+
+        var manifest = ControlManifestReader.Read(path);
+
+        Assert.Equal("TALXIS.PCF", manifest.Namespace);
+        Assert.Equal("Grid", manifest.Constructor);
+        Assert.Equal("TALXIS.PCF.Grid", manifest.QualifiedName);
+        Assert.Equal("0.0.59648", manifest.Version);
+        Assert.Equal(new[] { "Grid", "RibbonGroupingDataset" }, manifest.DataSets);
+        Assert.Null(manifest.PrefixedName);
+
+        var enableEditing = manifest.Properties.Single(p => p.Name == "EnableEditing");
+        Assert.Equal("Enum", enableEditing.OfType);
+        Assert.Equal(new[] { "true", "false" }, enableEditing.EnumValues);
+
+        var rowHeight = manifest.Properties.Single(p => p.Name == "RowHeight");
+        Assert.Equal("Whole.None", rowHeight.OfType);
+        Assert.Equal("42", rowHeight.DefaultValue);
+    }
+
+    [Fact]
+    public void Read_SolutionZip_ResolvesPrefixedNameFromCustomizations()
+    {
+        var zip = BuildZip(
+            ("customizations.xml", Encoding.UTF8.GetBytes(CustomizationsXml)),
+            ("Controls/talxis_TALXIS.PCF.Grid/ControlManifest.xml", Encoding.UTF8.GetBytes(GridManifestXml)));
+        var path = WriteFile("Grid.Solution.zip", zip);
+
+        var manifest = ControlManifestReader.Read(path);
+
+        Assert.Equal("TALXIS.PCF.Grid", manifest.QualifiedName);
+        Assert.Equal("talxis_TALXIS.PCF.Grid", manifest.PrefixedName);
+    }
+
+    [Fact]
+    public void Read_NestedArchives_FindsManifestThroughPdpkgAndSolution()
+    {
+        var solutionZip = BuildZip(
+            ("customizations.xml", Encoding.UTF8.GetBytes(CustomizationsXml)),
+            ("Controls/talxis_TALXIS.PCF.Grid/ControlManifest.xml", Encoding.UTF8.GetBytes(GridManifestXml)));
+        var pdpkgZip = BuildZip(("PkgAssets/Grid.Solution.zip", solutionZip));
+        var nupkg = BuildZip(("contentFiles/any/any/Grid.pdpkg.zip", pdpkgZip));
+        var path = WriteFile("grid.nupkg", nupkg);
+
+        var manifest = ControlManifestReader.Read(path);
+
+        Assert.Equal("TALXIS.PCF.Grid", manifest.QualifiedName);
+        Assert.Equal("talxis_TALXIS.PCF.Grid", manifest.PrefixedName);
+    }
+
+    [Fact]
+    public void Read_SolutionZipWithoutCustomizations_FallsBackToControlsFolderName()
+    {
+        var zip = BuildZip(("Controls/talxis_TALXIS.PCF.Grid/ControlManifest.xml", Encoding.UTF8.GetBytes(GridManifestXml)));
+        var path = WriteFile("NoCustomizations.zip", zip);
+
+        var manifest = ControlManifestReader.Read(path);
+
+        Assert.Equal("talxis_TALXIS.PCF.Grid", manifest.PrefixedName);
+    }
+
+    [Fact]
+    public void Read_ZipWithoutManifest_Throws()
+    {
+        var zip = BuildZip(("readme.txt", Encoding.UTF8.GetBytes("nothing here")));
+        var path = WriteFile("empty.zip", zip);
+
+        Assert.Throws<InvalidOperationException>(() => ControlManifestReader.Read(path));
+    }
+
+    [Fact]
+    public void Read_MissingFile_Throws()
+    {
+        Assert.Throws<FileNotFoundException>(() => ControlManifestReader.Read(Path.Combine(_tempDir, "missing.xml")));
+    }
+}

--- a/tests/TALXIS.CLI.Tests/Workspace/Controls/FormControlAttachmentServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/Workspace/Controls/FormControlAttachmentServiceTests.cs
@@ -1,0 +1,231 @@
+using System.Xml.Linq;
+using TALXIS.CLI.Features.Workspace.Controls;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.Workspace.Controls;
+
+public class FormControlAttachmentServiceTests : IDisposable
+{
+    private const string SubgridUniqueId = "{bbbb2222-0000-0000-0000-000000000002}";
+    private const string ViewId = "{cccc3333-0000-0000-0000-000000000003}";
+
+    private const string FormXml = $$"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <forms xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          <systemform>
+            <formid>{aaaa1111-0000-0000-0000-000000000001}</formid>
+            <form shownavigationbar="false">
+              <tabs>
+                <tab id="{aaaa1111-0000-0000-0000-00000000000a}" name="generaltab">
+                  <columns><column width="100%"><sections>
+                    <section id="{aaaa1111-0000-0000-0000-00000000000b}" name="generalsection">
+                      <rows>
+                        <row>
+                          <cell id="{aaaa1111-0000-0000-0000-00000000000c}">
+                            <control indicationOfSubgrid="true" id="subgrid" classid="{E7A81278-8635-4D9E-8D4D-59480B391C5B}" uniqueid="{{SubgridUniqueId}}">
+                              <parameters>
+                                <TargetEntityType>almlab_warehouseitem</TargetEntityType>
+                                <ViewId>{{ViewId}}</ViewId>
+                                <ViewIds>{{ViewId}}</ViewIds>
+                                <EnableViewPicker>false</EnableViewPicker>
+                                <RelationshipName>almlab_location_item</RelationshipName>
+                              </parameters>
+                            </control>
+                          </cell>
+                        </row>
+                        <row>
+                          <cell id="{aaaa1111-0000-0000-0000-00000000000d}">
+                            <control id="almlab_name" classid="{4273EDBD-AC1D-40D3-9FB2-095C621B552D}" datafieldname="almlab_name" uniqueid="{aaaa1111-0000-0000-0000-00000000000e}" />
+                          </cell>
+                        </row>
+                      </rows>
+                    </section>
+                  </sections></column></columns>
+                </tab>
+              </tabs>
+              <DisplayConditions Order="1" FallbackForm="true"><Everyone /></DisplayConditions>
+              <formLibraries><Library name="almlab_main.js" libraryUniqueId="{aaaa1111-0000-0000-0000-00000000000f}" /></formLibraries>
+            </form>
+          </systemform>
+        </forms>
+        """;
+
+    private readonly string _tempDir = Directory.CreateTempSubdirectory("txc-attach-tests").FullName;
+    private readonly string _formPath;
+
+    public FormControlAttachmentServiceTests()
+    {
+        _formPath = Path.Combine(_tempDir, "{aaaa1111-0000-0000-0000-000000000001}.xml");
+        File.WriteAllText(_formPath, FormXml);
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    private static ControlManifestInfo GridManifest() => new()
+    {
+        Namespace = "TALXIS.PCF",
+        Constructor = "Grid",
+        PrefixedName = "talxis_TALXIS.PCF.Grid",
+        DataSets = ["Grid", "RibbonGroupingDataset"],
+        Properties =
+        [
+            new ControlManifestProperty { Name = "Columns", OfType = "Multiple" },
+            new ControlManifestProperty { Name = "RowHeight", OfType = "Whole.None", DefaultValue = "42" },
+            new ControlManifestProperty { Name = "EnableGrouping", OfType = "Enum", EnumValues = ["true", "false"] },
+            new ControlManifestProperty { Name = "ClientApiWebresourceName", OfType = "SingleLine.Text" },
+        ],
+    };
+
+    private ControlAttachmentRequest Request(
+        IReadOnlyDictionary<string, string>? parameters = null,
+        string targetControlId = "subgrid",
+        bool force = false) => new()
+    {
+        FormFilePath = _formPath,
+        TargetControlId = targetControlId,
+        Manifest = GridManifest(),
+        ControlName = "talxis_TALXIS.PCF.Grid",
+        Parameters = parameters ?? new Dictionary<string, string>(),
+        Force = force,
+    };
+
+    [Fact]
+    public void Attach_InsertsControlDescriptionWithAllFormFactors()
+    {
+        var result = FormControlAttachmentService.Attach(Request(new Dictionary<string, string>
+        {
+            ["EnableGrouping"] = "true",
+            ["RowHeight"] = "42",
+        }));
+
+        Assert.Equal(SubgridUniqueId, result.HostControlUniqueId);
+        Assert.False(result.ReplacedExisting);
+
+        var doc = XDocument.Load(_formPath);
+        var description = doc.Descendants("controlDescription").Single();
+        Assert.Equal(SubgridUniqueId, description.Attribute("forControl")?.Value);
+
+        var customControls = description.Elements("customControl").ToList();
+        Assert.Equal(4, customControls.Count);
+        Assert.Equal("{E7A81278-8635-4D9E-8D4D-59480B391C5B}", customControls[0].Attribute("id")?.Value);
+        Assert.Equal(new[] { "0", "1", "2" }, customControls.Skip(1).Select(c => c.Attribute("formFactor")?.Value));
+        Assert.All(customControls.Skip(1), c => Assert.Equal("talxis_TALXIS.PCF.Grid", c.Attribute("name")?.Value));
+    }
+
+    [Fact]
+    public void Attach_CopiesDatasetBindingFromHostSubgrid()
+    {
+        FormControlAttachmentService.Attach(Request());
+
+        var doc = XDocument.Load(_formPath);
+        var dataSet = doc.Descendants("customControl")
+            .First(c => c.Attribute("formFactor")?.Value == "0")
+            .Element("parameters")!.Element("data-set")!;
+
+        Assert.Equal("Grid", dataSet.Attribute("name")?.Value);
+        Assert.Equal(ViewId, dataSet.Element("ViewId")?.Value);
+        Assert.Equal("almlab_warehouseitem", dataSet.Element("TargetEntityType")?.Value);
+        Assert.Equal("almlab_location_item", dataSet.Element("RelationshipName")?.Value);
+        Assert.Equal(ViewId, dataSet.Element("FilteredViewIds")?.Value);
+        Assert.Equal("false", dataSet.Element("IsUserView")?.Value);
+    }
+
+    [Fact]
+    public void Attach_EmitsTypedParameterElements()
+    {
+        FormControlAttachmentService.Attach(Request(new Dictionary<string, string>
+        {
+            ["EnableGrouping"] = "true",
+            ["ClientApiWebresourceName"] = "almlab_main.js",
+        }));
+
+        var doc = XDocument.Load(_formPath);
+        var parameters = doc.Descendants("customControl")
+            .First(c => c.Attribute("formFactor")?.Value == "0")
+            .Element("parameters")!;
+
+        var grouping = parameters.Element("EnableGrouping")!;
+        Assert.Equal("Enum", grouping.Attribute("type")?.Value);
+        Assert.Equal("true", grouping.Attribute("static")?.Value);
+        Assert.Equal("true", grouping.Value);
+
+        var webresource = parameters.Element("ClientApiWebresourceName")!;
+        Assert.Equal("SingleLine.Text", webresource.Attribute("type")?.Value);
+        Assert.Equal("almlab_main.js", webresource.Value);
+    }
+
+    [Fact]
+    public void Attach_InsertsContainerBeforeDisplayConditions()
+    {
+        FormControlAttachmentService.Attach(Request());
+
+        var doc = XDocument.Load(_formPath);
+        var formChildren = doc.Descendants("form").Single().Elements().Select(e => e.Name.LocalName).ToList();
+        Assert.Equal(["tabs", "controlDescriptions", "DisplayConditions", "formLibraries"], formChildren);
+    }
+
+    [Fact]
+    public void Attach_UnknownParameter_ThrowsWithValidParameterList()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            FormControlAttachmentService.Attach(Request(new Dictionary<string, string> { ["Nope"] = "1" })));
+        Assert.Contains("not a parameter", ex.Message);
+        Assert.Contains("EnableGrouping", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_InvalidEnumValue_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            FormControlAttachmentService.Attach(Request(new Dictionary<string, string> { ["EnableGrouping"] = "banana" })));
+        Assert.Contains("Allowed: true, false", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_NonNumericWholeValue_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            FormControlAttachmentService.Attach(Request(new Dictionary<string, string> { ["RowHeight"] = "tall" })));
+        Assert.Contains("whole number", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_MissingTargetControl_ThrowsListingAvailableControls()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FormControlAttachmentService.Attach(Request(targetControlId: "nosuchgrid")));
+        Assert.Contains("subgrid", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_FieldBoundControl_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            FormControlAttachmentService.Attach(Request(targetControlId: "almlab_name")));
+        Assert.Contains("not a subgrid", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_ExistingAttachment_ThrowsWithoutForce()
+    {
+        FormControlAttachmentService.Attach(Request());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => FormControlAttachmentService.Attach(Request()));
+        Assert.Contains("--force", ex.Message);
+    }
+
+    [Fact]
+    public void Attach_ExistingAttachment_ReplacedWithForce()
+    {
+        FormControlAttachmentService.Attach(Request(new Dictionary<string, string> { ["EnableGrouping"] = "true" }));
+        var result = FormControlAttachmentService.Attach(Request(new Dictionary<string, string> { ["EnableGrouping"] = "false" }, force: true));
+
+        Assert.True(result.ReplacedExisting);
+        var doc = XDocument.Load(_formPath);
+        Assert.Single(doc.Descendants("controlDescription"));
+        var grouping = doc.Descendants("customControl")
+            .First(c => c.Attribute("formFactor")?.Value == "0")
+            .Element("parameters")!.Element("EnableGrouping")!;
+        Assert.Equal("false", grouping.Value);
+    }
+}


### PR DESCRIPTION
adds `txc workspace control attach` - overlays a PCF control on an existing subgrid of a form without any per-control template. the parameter schema comes from the control's own ControlManifest.xml at run time: pass a nuget package name (downloaded automatically, same mechanism as `env pkg import`) or a local path to a manifest / solution zip / pdpkg.zip / nupkg. parameter values are validated against the manifest (enum values, whole numbers), the dataset binding (view, relationship) is copied from the host subgrid, and the publisher-prefixed control name resolves from customizations.xml inside the package - nested archives included, so a nupkg wrapping a pdpkg wrapping a solution just works.

the controlDescription it writes mirrors what the form designer produces: a base control block plus one customControl block per form factor, inserted before DisplayConditions. the modified form is re-checked with the platform metadata schema validator and warns if new issues appeared. `--force` replaces an existing attachment on the same subgrid, managed-layer file names (`{guid}_managed.xml`) resolve fine, and error paths don't touch the file.

why not templates: generating a dotnet-new template per control (the old Template Builder approach) means hundreds of templates in the pack. one generic command plus the manifest the control already ships with covers any dataset-bound control - verified against TALXIS.Controls.Grid.Package from nuget.org and a GalleryGrid manifest straight from INT0015 sources.

known limits, follow-ups:

- subgrid hosts only for now, field-bound controls (VirtualDataset on a placeholder column) are rejected with a clear error
- nuget resolution is nuget.org only, same as env pkg import (no NuGet.config feeds)
- "latest" can resolve to a prerelease, again same as env pkg import
- alm-lab's CP09/CP10 already use this command, so a release unblocks TALXIS/alm-lab#10

17 unit tests cover the manifest reader (incl. the nested archive traversal) and the attachment service (dataset copy, typed parameters, --force replace, validation errors). the LayeringTests failure on master (Features.Environment referencing Features.Workspace) predates this branch.
