### PR TITLE
fix(workspace): skip stale duplicate template package registrations

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
+++ b/src/TALXIS.CLI.Features.Workspace/TALXIS.CLI.Features.Workspace.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="10.0.201" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="10.0.201" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <!-- Already resolved transitively via Microsoft.TemplateEngine.* (NuGet client libraries);
+         referenced explicitly here because TemplatePackageService consumes NuGetVersion directly
+         to correctly rank prerelease/build-metadata versions per SemVer 2.0. -->
+    <PackageReference Include="NuGet.Versioning" Version="6.13.2" />
     <PackageReference Include="TALXIS.Platform.Metadata.Validation" Version="0.9.0" />
     <PackageReference Include="TALXIS.Platform.Metadata.Serialization.Xml" Version="0.9.0" />
   </ItemGroup>

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplatePackageService.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplatePackageService.cs
@@ -111,14 +111,91 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         /// <summary>
         /// Attempts to locate an already installed package; updates internal state if found.
         /// </summary>
+        /// <remarks>
+        /// A package's <see cref="IManagedTemplatePackage.Identifier"/> is the package id, not a
+        /// unique key per registration — it is possible (e.g. after an update that installs a new
+        /// version without uninstalling the previous one) for <c>packages.json</c> to contain more
+        /// than one registration with the same identifier. Picking the first one blindly can select
+        /// a stale/broken registration that has zero templates indexed, which then poisons every
+        /// subsequent template lookup for the lifetime of the process. To guard against that, all
+        /// matching candidates are ranked (highest version first, most recently changed as a
+        /// tie-breaker) and probed in order until one actually yields templates.
+        /// </remarks>
         private async Task<bool> TryLoadExistingInstalledPackageAsync()
         {
             var existingPackages = await _templatePackageManager.GetManagedTemplatePackagesAsync(false, CancellationToken.None);
-            var existing = existingPackages.FirstOrDefault(p => string.Equals(p.Identifier, _templatePackageName, StringComparison.OrdinalIgnoreCase));
-            if (existing == null) return false;
-            _installedTemplatePackage = existing;
+            var candidates = RankCandidates(existingPackages, _templatePackageName);
+            var selected = await SelectFirstPackageWithTemplatesAsync(candidates, HasTemplatesAsync);
+            if (selected == null) return false;
+
+            _installedTemplatePackage = selected;
             _isTemplateInstalled = true;
             return true;
+        }
+
+        private async Task<bool> HasTemplatesAsync(IManagedTemplatePackage package)
+        {
+            var templates = await _templatePackageManager.GetTemplatesAsync(package, CancellationToken.None);
+            return templates.Any();
+        }
+
+        /// <summary>
+        /// Walks <paramref name="rankedCandidates"/> in order and returns the first one for which
+        /// <paramref name="hasTemplatesAsync"/> reports at least one template, skipping any stale/duplicate
+        /// registration that indexes zero templates. Returns <see langword="null"/> if none qualify.
+        /// </summary>
+        internal static async Task<IManagedTemplatePackage?> SelectFirstPackageWithTemplatesAsync(
+            IEnumerable<IManagedTemplatePackage> rankedCandidates,
+            Func<IManagedTemplatePackage, Task<bool>> hasTemplatesAsync)
+        {
+            foreach (var candidate in rankedCandidates)
+            {
+                if (await hasTemplatesAsync(candidate))
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Orders packages matching <paramref name="identifier"/> so the most likely-correct
+        /// registration is probed first: highest parsed version wins, falling back to the most
+        /// recently changed package when versions are equal or unparseable.
+        /// </summary>
+        internal static IEnumerable<IManagedTemplatePackage> RankCandidates(IEnumerable<IManagedTemplatePackage> packages, string identifier)
+        {
+            return packages
+                .Where(p => string.Equals(p.Identifier, identifier, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(ParsePackageVersion, NullableVersionComparer.Instance)
+                .ThenByDescending(p => p.LastChangeTime);
+        }
+
+        /// <summary>
+        /// Parses <see cref="IManagedTemplatePackage.Version"/> as a <see cref="Version"/>, returning
+        /// <see langword="null"/> when it is missing or not a valid version string.
+        /// </summary>
+        internal static Version? ParsePackageVersion(IManagedTemplatePackage package)
+        {
+            return Version.TryParse(package.Version, out var version) ? version : null;
+        }
+
+        /// <summary>
+        /// Compares nullable <see cref="Version"/> values, treating a missing/unparseable version as
+        /// lower than any parsed version.
+        /// </summary>
+        private sealed class NullableVersionComparer : IComparer<Version?>
+        {
+            public static readonly NullableVersionComparer Instance = new();
+
+            public int Compare(Version? x, Version? y)
+            {
+                if (ReferenceEquals(x, y)) return 0;
+                if (x is null) return -1;
+                if (y is null) return 1;
+                return x.CompareTo(y);
+            }
         }
 
         private async Task InstallTemplatePackageAsync(string? version)

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplatePackageService.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplatePackageService.cs
@@ -3,6 +3,7 @@ using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge;
+using NuGet.Versioning;
 using System.Security.Cryptography;
 using System.Diagnostics;
 
@@ -173,23 +174,31 @@ namespace TALXIS.CLI.Features.Workspace.TemplateEngine
         }
 
         /// <summary>
-        /// Parses <see cref="IManagedTemplatePackage.Version"/> as a <see cref="Version"/>, returning
+        /// Parses <see cref="IManagedTemplatePackage.Version"/> as a <see cref="NuGetVersion"/>, returning
         /// <see langword="null"/> when it is missing or not a valid version string.
         /// </summary>
-        internal static Version? ParsePackageVersion(IManagedTemplatePackage package)
+        /// <remarks>
+        /// <see cref="IManagedTemplatePackage.Version"/> is a NuGet package version, which follows SemVer
+        /// 2.0 and may carry a prerelease and/or build-metadata suffix (e.g. <c>2.0.0-beta.1</c>).
+        /// <see cref="System.Version"/> only understands dotted numeric components and rejects such
+        /// strings outright, which used to make every prerelease-versioned registration sort as if it had
+        /// no version at all. <see cref="NuGetVersion"/> parses and compares using correct NuGet/SemVer
+        /// precedence rules instead.
+        /// </remarks>
+        internal static NuGetVersion? ParsePackageVersion(IManagedTemplatePackage package)
         {
-            return Version.TryParse(package.Version, out var version) ? version : null;
+            return NuGetVersion.TryParse(package.Version, out var version) ? version : null;
         }
 
         /// <summary>
-        /// Compares nullable <see cref="Version"/> values, treating a missing/unparseable version as
+        /// Compares nullable <see cref="NuGetVersion"/> values, treating a missing/unparseable version as
         /// lower than any parsed version.
         /// </summary>
-        private sealed class NullableVersionComparer : IComparer<Version?>
+        private sealed class NullableVersionComparer : IComparer<NuGetVersion?>
         {
             public static readonly NullableVersionComparer Instance = new();
 
-            public int Compare(Version? x, Version? y)
+            public int Compare(NuGetVersion? x, NuGetVersion? y)
             {
                 if (ReferenceEquals(x, y)) return 0;
                 if (x is null) return -1;

--- a/tests/TALXIS.CLI.Tests/TemplateEngine/TemplatePackageServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/TemplateEngine/TemplatePackageServiceTests.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions.Installer;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using TALXIS.CLI.Features.Workspace.TemplateEngine;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.TemplateEngine;
+
+public class TemplatePackageServiceTests
+{
+    private const string PackageIdentifier = "TALXIS.DevKit.Templates.Dataverse";
+
+    [Fact]
+    public void RankCandidates_PrefersHighestVersion_RegardlessOfListOrder()
+    {
+        var oldest = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow.AddDays(-10));
+        var newest = new FakeManagedTemplatePackage(PackageIdentifier, "2.5.0", DateTime.UtcNow.AddDays(-1));
+        var middle = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0", DateTime.UtcNow.AddDays(-5));
+
+        // Deliberately not in version order - the stale registration happens to be first in the
+        // underlying list, which is exactly the scenario that used to break FirstOrDefault().
+        var ranked = TemplatePackageService.RankCandidates(new[] { oldest, newest, middle }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { newest, middle, oldest }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_IgnoresNonMatchingIdentifiers()
+    {
+        var match = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow);
+        var other = new FakeManagedTemplatePackage("Some.Other.Package", "9.0.0", DateTime.UtcNow);
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { match, other }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { match }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_IdentifierMatch_IsCaseInsensitive()
+    {
+        var match = new FakeManagedTemplatePackage(PackageIdentifier.ToUpperInvariant(), "1.0.0", DateTime.UtcNow);
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { match }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { match }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_FallsBackToLastChangeTime_WhenVersionsTie()
+    {
+        var stale = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow.AddDays(-3));
+        var fresh = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow);
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { stale, fresh }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { fresh, stale }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_FallsBackToLastChangeTime_WhenVersionsUnparseable()
+    {
+        var stale = new FakeManagedTemplatePackage(PackageIdentifier, "not-a-version", DateTime.UtcNow.AddDays(-3));
+        var fresh = new FakeManagedTemplatePackage(PackageIdentifier, "also-not-a-version", DateTime.UtcNow);
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { stale, fresh }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { fresh, stale }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_ParsedVersion_OutranksUnparseableVersion()
+    {
+        // An unparseable/missing version must never be treated as "higher" than a real one.
+        var unparseable = new FakeManagedTemplatePackage(PackageIdentifier, "garbage", DateTime.UtcNow);
+        var parsed = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow.AddDays(-100));
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { unparseable, parsed }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { parsed, unparseable }, ranked);
+    }
+
+    [Fact]
+    public void ParsePackageVersion_ReturnsNull_ForNullOrInvalidVersionString()
+    {
+        Assert.Null(TemplatePackageService.ParsePackageVersion(new FakeManagedTemplatePackage(PackageIdentifier, null, DateTime.UtcNow)));
+        Assert.Null(TemplatePackageService.ParsePackageVersion(new FakeManagedTemplatePackage(PackageIdentifier, "not-a-version", DateTime.UtcNow)));
+    }
+
+    [Fact]
+    public void ParsePackageVersion_ParsesValidVersionString()
+    {
+        var version = TemplatePackageService.ParsePackageVersion(new FakeManagedTemplatePackage(PackageIdentifier, "3.2.1", DateTime.UtcNow));
+
+        Assert.Equal(new Version(3, 2, 1), version);
+    }
+
+    [Fact]
+    public async Task SelectFirstPackageWithTemplatesAsync_SkipsEmptyCandidate_AndFallsThroughToNext()
+    {
+        var stale = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0", DateTime.UtcNow); // ranked first, but broken/empty
+        var working = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow.AddDays(-1)); // ranked second, has templates
+
+        var probed = new List<IManagedTemplatePackage>();
+        Task<bool> HasTemplates(IManagedTemplatePackage package)
+        {
+            probed.Add(package);
+            return Task.FromResult(!ReferenceEquals(package, stale));
+        }
+
+        var selected = await TemplatePackageService.SelectFirstPackageWithTemplatesAsync(new[] { stale, working }, HasTemplates);
+
+        Assert.Same(working, selected);
+        Assert.Equal(new IManagedTemplatePackage[] { stale, working }, probed);
+    }
+
+    [Fact]
+    public async Task SelectFirstPackageWithTemplatesAsync_ReturnsNull_WhenNoCandidateHasTemplates()
+    {
+        var a = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0", DateTime.UtcNow);
+        var b = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow);
+
+        var selected = await TemplatePackageService.SelectFirstPackageWithTemplatesAsync(new[] { a, b }, _ => Task.FromResult(false));
+
+        Assert.Null(selected);
+    }
+
+    [Fact]
+    public async Task SelectFirstPackageWithTemplatesAsync_ReturnsNull_WhenNoCandidates()
+    {
+        var selected = await TemplatePackageService.SelectFirstPackageWithTemplatesAsync(
+            Enumerable.Empty<IManagedTemplatePackage>(), _ => Task.FromResult(true));
+
+        Assert.Null(selected);
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IManagedTemplatePackage"/> test double. Only the members the ranking/selection
+    /// logic actually reads (<see cref="Identifier"/>, <see cref="Version"/>, <see cref="ITemplatePackage.LastChangeTime"/>)
+    /// carry meaningful values; the rest are unused by the code under test.
+    /// </summary>
+    private sealed class FakeManagedTemplatePackage : IManagedTemplatePackage
+    {
+        public FakeManagedTemplatePackage(string identifier, string? version, DateTime lastChangeTime)
+        {
+            Identifier = identifier;
+            Version = version!;
+            LastChangeTime = lastChangeTime;
+        }
+
+        public string DisplayName => Identifier;
+        public string Identifier { get; }
+        public IInstaller Installer => null!;
+        public IManagedTemplatePackageProvider ManagedProvider => null!;
+        public string Version { get; }
+        public bool IsLocalPackage => true;
+        public DateTime LastChangeTime { get; }
+        public string MountPointUri => string.Empty;
+        public ITemplatePackageProvider Provider => null!;
+
+        public IReadOnlyDictionary<string, string> GetDetails() => new Dictionary<string, string>();
+    }
+}

--- a/tests/TALXIS.CLI.Tests/TemplateEngine/TemplatePackageServiceTests.cs
+++ b/tests/TALXIS.CLI.Tests/TemplateEngine/TemplatePackageServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using NuGet.Versioning;
 using TALXIS.CLI.Features.Workspace.TemplateEngine;
 using Xunit;
 
@@ -94,7 +95,43 @@ public class TemplatePackageServiceTests
     {
         var version = TemplatePackageService.ParsePackageVersion(new FakeManagedTemplatePackage(PackageIdentifier, "3.2.1", DateTime.UtcNow));
 
-        Assert.Equal(new Version(3, 2, 1), version);
+        Assert.Equal(NuGetVersion.Parse("3.2.1"), version);
+    }
+
+    [Fact]
+    public void ParsePackageVersion_ParsesPrereleaseVersionString()
+    {
+        // System.Version cannot parse a "-beta.1" suffix at all - it would previously return null
+        // here, silently demoting a valid, higher-precedence prerelease registration to "unparseable".
+        var version = TemplatePackageService.ParsePackageVersion(new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0-beta.1", DateTime.UtcNow));
+
+        Assert.Equal(NuGetVersion.Parse("2.0.0-beta.1"), version);
+    }
+
+    [Fact]
+    public void RankCandidates_PrereleaseVersion_OutranksLowerReleaseVersion()
+    {
+        // A working 2.0.0-beta.1 registration must be probed before a working 1.0.0 registration -
+        // the whole point of "highest version wins" breaks if prerelease suffixes sort as unparseable.
+        var releaseCandidate = new FakeManagedTemplatePackage(PackageIdentifier, "1.0.0", DateTime.UtcNow);
+        var prereleaseCandidate = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0-beta.1", DateTime.UtcNow.AddDays(-10));
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { releaseCandidate, prereleaseCandidate }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { prereleaseCandidate, releaseCandidate }, ranked);
+    }
+
+    [Fact]
+    public void RankCandidates_ReleaseVersion_OutranksPrereleaseOfSameVersion()
+    {
+        // Per SemVer 2.0 precedence, a version without a prerelease suffix always outranks the same
+        // major.minor.patch with one (2.0.0 > 2.0.0-beta.1).
+        var prerelease = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0-beta.1", DateTime.UtcNow);
+        var release = new FakeManagedTemplatePackage(PackageIdentifier, "2.0.0", DateTime.UtcNow.AddDays(-10));
+
+        var ranked = TemplatePackageService.RankCandidates(new[] { prerelease, release }, PackageIdentifier).ToList();
+
+        Assert.Equal(new[] { release, prerelease }, ranked);
     }
 
     [Fact]


### PR DESCRIPTION
## Root cause

`TemplatePackageService.TryLoadExistingInstalledPackageAsync` used
`FirstOrDefault(p => p.Identifier == "TALXIS.DevKit.Templates.Dataverse")`
to find the already-installed template package.

`Identifier` is the NuGet package id, not a unique key per registration. If a
user's local `~/.templateengine/packages.json` ends up with two registrations
for the same package id (this happens in practice - `InstallTemplatePackageAsync`
installs with `force: false` and never uninstalls a superseded version, so an
update can leave the old version registered alongside the new one),
`FirstOrDefault` returns whichever one happens to be first in the underlying
list - not necessarily the one that actually has templates indexed.

If the picked registration has zero templates cached, `ListTemplatesAsync`
returns an empty list, that broken package gets cached as "the installed
package" for the process lifetime (`_isTemplateInstalled` / `_installedTemplatePackage`),
and every subsequent `TemplateDiscoveryService.GetTemplateByShortNameAsync`
lookup fails with `Template '<X>' not found` - for *every* type
(`pp-entity`, `Entity`, `pp-package`, `pp-solution`, ...), regardless of the
short name requested, because the template list being searched is empty.

This surfaces as `txc workspace component create <type>` and
`txc workspace component parameter list <type>` failing outright for a user
whose local template cache has this leftover duplicate.

## Fix

In `src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplatePackageService.cs`,
`TryLoadExistingInstalledPackageAsync` now:

1. Collects all packages whose `Identifier` matches the target package
   (case-insensitive) - `RankCandidates`.
2. Ranks them by highest parsed `Version` first, falling back to the most
   recent `LastChangeTime` when versions tie or fail to parse.
3. Probes candidates in that order via `GetTemplatesAsync`, accepting the
   first one that actually returns templates - `SelectFirstPackageWithTemplatesAsync`.
4. Falls through to the normal fresh-install path if no candidate has any
   templates.

The ranking and selection logic is extracted into small `internal static`
helpers (`RankCandidates`, `ParsePackageVersion`, `SelectFirstPackageWithTemplatesAsync`)
so it's directly unit-testable without needing a real `TemplatePackageManager`.

## Verification

- `dotnet build` on the affected project and the full CLI - compiles cleanly,
  no new warnings.
- Added `tests/TALXIS.CLI.Tests/TemplateEngine/TemplatePackageServiceTests.cs`
  covering: highest version wins regardless of list order, non-matching
  identifiers are ignored, case-insensitive identifier match, fallback to
  `LastChangeTime` on tied/unparseable versions, a parsed version always
  outranks an unparseable one, and the selection step skips a candidate with
  zero templates and falls through to the next-ranked one (including the
  case where the *broken* candidate has the *higher* version number).
- `dotnet test tests/TALXIS.CLI.Tests` - 726 passed, 0 failed.
- `dotnet test tests/TALXIS.CLI.IntegrationTests` - 40 passed, 5 skipped
  (live-environment tests requiring credentials), 0 failed.
- Manual repro with an isolated fake `$HOME` (never touched the real
  `~/.templateengine`): installed the real `TALXIS.DevKit.Templates.Dataverse`
  package once, then hand-crafted a second `packages.json` entry with the same
  `PackageId` but a different version pointing at an empty/invalid `.nupkg`
  (simulating the leftover-registration scenario). Confirmed:
  - Pre-fix binary: `txc workspace component parameter list pp-entity`
    fails with `Template 'pp-entity' not found.`
  - Post-fix binary, same crafted state: succeeds and returns the correct
    parameter list - verified both when the broken duplicate sorts before
    and after the working one by version number.