### PR TITLE
fix(workspace): resolve componentType tag aliases symmetrically in TemplateResolver

### DIFF
--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateResolver.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateResolver.cs
@@ -21,8 +21,11 @@ public static class TemplateResolver
     /// Resolves a user input to a template. Lookup order:
     /// <list type="number">
     ///   <item>Exact match on template short name or full template name</item>
-    ///   <item>Exact match on <c>componentType</c> tag value (each template has a unique value)</item>
-    ///   <item>Match via <see cref="ComponentDefinitionRegistry.GetByName"/> alias resolution, then tag match</item>
+    ///   <item>Match on <c>componentType</c> tag value, with both the input and the tag
+    ///   normalized through <see cref="ComponentDefinitionRegistry.GetByName"/> so that a
+    ///   canonical registry name (e.g. "Role") and any of its aliases (e.g. "SecurityRole")
+    ///   resolve to the same template regardless of which form the template happens to be
+    ///   tagged with</item>
     /// </list>
     /// </summary>
     public static ITemplateInfo? Resolve(string input, IReadOnlyList<ITemplateInfo> templates)
@@ -35,44 +38,38 @@ public static class TemplateResolver
         if (direct != null)
             return direct;
 
-        // 2. Direct match on componentType tag value (e.g. "FormTab", "BpfStage", "Entity")
-        var byTag = templates.FirstOrDefault(t =>
-            string.Equals(GetComponentTypeName(t), input, StringComparison.OrdinalIgnoreCase));
-
-        if (byTag != null)
-            return byTag;
-
-        // 3. Resolve via registry aliases (e.g. "Table" → "Entity", "Flow" → "Workflow")
-        //    then match on componentType tag
-        var def = ComponentDefinitionRegistry.GetByName(input);
-        if (def != null)
-        {
-            var byAlias = templates.FirstOrDefault(t =>
-                string.Equals(GetComponentTypeName(t), def.Name, StringComparison.OrdinalIgnoreCase));
-            if (byAlias != null)
-                return byAlias;
-        }
-
-        return null;
+        // 2. Match on componentType tag value, normalizing both sides through the registry
+        //    (e.g. "Role" and "SecurityRole" both normalize to the same canonical name, so
+        //    either input matches a template tagged with either form)
+        var canonicalInput = ComponentDefinitionRegistry.GetByName(input)?.Name ?? input;
+        return templates.FirstOrDefault(t =>
+            string.Equals(GetCanonicalComponentTypeName(t), canonicalInput, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
-    /// Finds all templates tagged with the given component type name.
+    /// Finds all templates tagged with the given component type name. Both the input and each
+    /// template's tag are normalized through <see cref="ComponentDefinitionRegistry.GetByName"/>
+    /// so canonical names and aliases match symmetrically.
     /// </summary>
     public static IReadOnlyList<ITemplateInfo> FindAllForType(string componentTypeName, IReadOnlyList<ITemplateInfo> templates)
     {
+        var canonicalType = ComponentDefinitionRegistry.GetByName(componentTypeName)?.Name ?? componentTypeName;
         return templates
-            .Where(t => string.Equals(GetComponentTypeName(t), componentTypeName, StringComparison.OrdinalIgnoreCase))
+            .Where(t => string.Equals(GetCanonicalComponentTypeName(t), canonicalType, StringComparison.OrdinalIgnoreCase))
             .ToList();
     }
 
     /// <summary>
     /// Finds the template for a component type (1:1 mapping — returns exactly one or null).
+    /// Both the input and each template's tag are normalized through
+    /// <see cref="ComponentDefinitionRegistry.GetByName"/> so canonical names and aliases match
+    /// symmetrically.
     /// </summary>
     public static ITemplateInfo? FindTemplateForType(string componentTypeName, IReadOnlyList<ITemplateInfo> templates)
     {
+        var canonicalType = ComponentDefinitionRegistry.GetByName(componentTypeName)?.Name ?? componentTypeName;
         return templates.FirstOrDefault(t =>
-            string.Equals(GetComponentTypeName(t), componentTypeName, StringComparison.OrdinalIgnoreCase));
+            string.Equals(GetCanonicalComponentTypeName(t), canonicalType, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>
@@ -82,5 +79,20 @@ public static class TemplateResolver
     public static string? GetComponentTypeName(ITemplateInfo template)
     {
         return template.Tags.TryGetValue(ComponentTypeTagKey, out var ct) ? ct.DefaultValue : null;
+    }
+
+    /// <summary>
+    /// Extracts the componentType tag value from a template and normalizes it through
+    /// <see cref="ComponentDefinitionRegistry.GetByName"/> to its canonical registry name.
+    /// If the tag value has no registry entry, it is returned unchanged (normalization is a
+    /// no-op for tags like "FormTab" that aren't in the registry).
+    /// </summary>
+    public static string? GetCanonicalComponentTypeName(ITemplateInfo template)
+    {
+        var raw = GetComponentTypeName(template);
+        if (raw is null)
+            return null;
+
+        return ComponentDefinitionRegistry.GetByName(raw)?.Name ?? raw;
     }
 }

--- a/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateResolver.cs
+++ b/src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateResolver.cs
@@ -13,7 +13,10 @@ public static class TemplateResolver
 {
     /// <summary>
     /// The tag key used in template.json to declare the component type name.
-    /// Value must match a <see cref="ComponentDefinition.Name"/> from the registry.
+    /// Value may be either the canonical <see cref="ComponentDefinition.Name"/> from the
+    /// registry (e.g. "Role") or any of its registered aliases (e.g. "SecurityRole") — both
+    /// forms are normalized through <see cref="ComponentDefinitionRegistry.GetByName"/> before
+    /// comparison, so either resolves correctly.
     /// </summary>
     public const string ComponentTypeTagKey = "componentType";
 
@@ -41,7 +44,7 @@ public static class TemplateResolver
         // 2. Match on componentType tag value, normalizing both sides through the registry
         //    (e.g. "Role" and "SecurityRole" both normalize to the same canonical name, so
         //    either input matches a template tagged with either form)
-        var canonicalInput = ComponentDefinitionRegistry.GetByName(input)?.Name ?? input;
+        var canonicalInput = Canonicalize(input);
         return templates.FirstOrDefault(t =>
             string.Equals(GetCanonicalComponentTypeName(t), canonicalInput, StringComparison.OrdinalIgnoreCase));
     }
@@ -53,7 +56,7 @@ public static class TemplateResolver
     /// </summary>
     public static IReadOnlyList<ITemplateInfo> FindAllForType(string componentTypeName, IReadOnlyList<ITemplateInfo> templates)
     {
-        var canonicalType = ComponentDefinitionRegistry.GetByName(componentTypeName)?.Name ?? componentTypeName;
+        var canonicalType = Canonicalize(componentTypeName);
         return templates
             .Where(t => string.Equals(GetCanonicalComponentTypeName(t), canonicalType, StringComparison.OrdinalIgnoreCase))
             .ToList();
@@ -67,7 +70,7 @@ public static class TemplateResolver
     /// </summary>
     public static ITemplateInfo? FindTemplateForType(string componentTypeName, IReadOnlyList<ITemplateInfo> templates)
     {
-        var canonicalType = ComponentDefinitionRegistry.GetByName(componentTypeName)?.Name ?? componentTypeName;
+        var canonicalType = Canonicalize(componentTypeName);
         return templates.FirstOrDefault(t =>
             string.Equals(GetCanonicalComponentTypeName(t), canonicalType, StringComparison.OrdinalIgnoreCase));
     }
@@ -93,6 +96,17 @@ public static class TemplateResolver
         if (raw is null)
             return null;
 
-        return ComponentDefinitionRegistry.GetByName(raw)?.Name ?? raw;
+        return Canonicalize(raw);
     }
+
+    /// <summary>
+    /// Normalizes a component type name or alias to its canonical <see cref="ComponentDefinition.Name"/>
+    /// via <see cref="ComponentDefinitionRegistry.GetByName"/>. If the value has no registry entry, it is
+    /// returned unchanged (normalization is a no-op for values like "FormTab" that aren't in the registry).
+    /// This is the single normalization rule shared by <see cref="Resolve"/>, <see cref="FindAllForType"/>,
+    /// <see cref="FindTemplateForType"/>, and <see cref="GetCanonicalComponentTypeName"/> so alias
+    /// resolution cannot drift between them.
+    /// </summary>
+    private static string Canonicalize(string value) =>
+        ComponentDefinitionRegistry.GetByName(value)?.Name ?? value;
 }

--- a/tests/TALXIS.CLI.Tests/TemplateEngine/TemplateResolverTests.cs
+++ b/tests/TALXIS.CLI.Tests/TemplateEngine/TemplateResolverTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Constraints;
+using Microsoft.TemplateEngine.Abstractions.Parameters;
+using TALXIS.CLI.Features.Workspace.TemplateEngine;
+using Xunit;
+
+namespace TALXIS.CLI.Tests.TemplateEngine;
+
+public class TemplateResolverTests
+{
+    private static readonly FakeTemplateInfo SecurityRoleTemplate = new("pp-security-role", "pp-security-role", "SecurityRole");
+    private static readonly FakeTemplateInfo FlowTemplate = new("pp-flow", "pp-flow", "Flow");
+    private static readonly FakeTemplateInfo PcfTemplate = new("pp-pcf", "pp-pcf", "PcfControl");
+    private static readonly FakeTemplateInfo EntityTemplate = new("pp-entity", "pp-entity", "Entity");
+    private static readonly FakeTemplateInfo FormTabTemplate = new("pp-form-tab", "pp-form-tab", "FormTab");
+
+    private static readonly IReadOnlyList<ITemplateInfo> Templates = new ITemplateInfo[]
+    {
+        SecurityRoleTemplate,
+        FlowTemplate,
+        PcfTemplate,
+        EntityTemplate,
+        FormTabTemplate,
+    };
+
+    [Fact]
+    public void Resolve_CanonicalRegistryName_And_TemplateAlias_ResolveToSameTemplate()
+    {
+        // "Role" is the canonical ComponentDefinitionRegistry name; the template is tagged with
+        // the alias "SecurityRole". Both must resolve to the same template.
+        var byCanonical = TemplateResolver.Resolve("Role", Templates);
+        var byAlias = TemplateResolver.Resolve("SecurityRole", Templates);
+
+        Assert.Same(SecurityRoleTemplate, byCanonical);
+        Assert.Same(SecurityRoleTemplate, byAlias);
+    }
+
+    [Fact]
+    public void Resolve_CanonicalWorkflowName_And_TemplateFlowAlias_ResolveToSameTemplate()
+    {
+        var byCanonical = TemplateResolver.Resolve("Workflow", Templates);
+        var byAlias = TemplateResolver.Resolve("Flow", Templates);
+
+        Assert.Same(FlowTemplate, byCanonical);
+        Assert.Same(FlowTemplate, byAlias);
+    }
+
+    [Fact]
+    public void Resolve_CanonicalCustomControlName_And_TemplatePcfAlias_ResolveToSameTemplate()
+    {
+        var byCanonical = TemplateResolver.Resolve("CustomControl", Templates);
+        var byAlias = TemplateResolver.Resolve("PcfControl", Templates);
+
+        Assert.Same(PcfTemplate, byCanonical);
+        Assert.Same(PcfTemplate, byAlias);
+    }
+
+    [Fact]
+    public void Resolve_TagWithNoRegistryEntry_StillResolvesByDirectTagMatch()
+    {
+        // "FormTab" has no ComponentDefinitionRegistry entry, so normalization is a no-op and the
+        // pre-fix direct-tag-match behavior must be preserved.
+        var resolved = TemplateResolver.Resolve("FormTab", Templates);
+
+        Assert.Same(FormTabTemplate, resolved);
+    }
+
+    [Fact]
+    public void Resolve_ShortNameAndTagMatch_StillResolveSameTemplate_Regression()
+    {
+        var byShortName = TemplateResolver.Resolve("pp-entity", Templates);
+        var byTag = TemplateResolver.Resolve("Entity", Templates);
+
+        Assert.Same(EntityTemplate, byShortName);
+        Assert.Same(EntityTemplate, byTag);
+    }
+
+    [Fact]
+    public void Resolve_UnknownInput_ReturnsNull()
+    {
+        var resolved = TemplateResolver.Resolve("NoSuchComponentType", Templates);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void FindTemplateForType_CanonicalName_And_TemplateAlias_FindSameTemplate()
+    {
+        // FindAllForType/FindTemplateForType currently have no callers in the codebase, but are
+        // fixed for consistency with Resolve and covered here to keep them correct.
+        var byCanonical = TemplateResolver.FindTemplateForType("Role", Templates);
+        var byAlias = TemplateResolver.FindTemplateForType("SecurityRole", Templates);
+
+        Assert.Same(SecurityRoleTemplate, byCanonical);
+        Assert.Same(SecurityRoleTemplate, byAlias);
+    }
+
+    [Fact]
+    public void FindAllForType_CanonicalName_And_TemplateAlias_FindSameTemplate()
+    {
+        var byCanonical = TemplateResolver.FindAllForType("Workflow", Templates);
+        var byAlias = TemplateResolver.FindAllForType("Flow", Templates);
+
+        Assert.Same(FlowTemplate, Assert.Single(byCanonical));
+        Assert.Same(FlowTemplate, Assert.Single(byAlias));
+    }
+
+    /// <summary>
+    /// Minimal <see cref="ITemplateInfo"/> test double, shaped from the authoritative interface
+    /// declarations in dotnet/templating (tag v10.0.201, matching the
+    /// Microsoft.TemplateEngine.Abstractions package version restored locally). Only
+    /// <see cref="ShortNameList"/>, <see cref="Name"/>, and <see cref="Tags"/> (which
+    /// <see cref="TemplateResolver.GetComponentTypeName"/> reads via <c>ICacheTag.DefaultValue</c>)
+    /// carry meaningful values; every other member is unused by the code under test and returns an
+    /// empty/default value of the correct type.
+    /// </summary>
+#pragma warning disable CS0618 // ICacheTag/ICacheParameter/Tags/CacheParameters/Parameters are all [Obsolete] but still declared by ITemplateInfo
+    private sealed class FakeTemplateInfo : ITemplateInfo
+    {
+        public FakeTemplateInfo(string identity, string shortName, string componentType)
+        {
+            Identity = identity;
+            Name = identity;
+            ShortNameList = new[] { shortName };
+            Tags = new Dictionary<string, ICacheTag>
+            {
+                [TemplateResolver.ComponentTypeTagKey] = new FakeCacheTag(componentType),
+            };
+        }
+
+        // ITemplateLocator
+        public Guid GeneratorId => Guid.Empty;
+        public string MountPointUri => string.Empty;
+        public string ConfigPlace => string.Empty;
+
+        // IExtendedTemplateLocator
+        public string? LocaleConfigPlace => null;
+        public string? HostConfigPlace => null;
+
+        // ITemplateMetadata
+        public string? Author => null;
+        public string? Description => null;
+        public IReadOnlyList<string> Classifications => Array.Empty<string>();
+        public string? DefaultName => null;
+        public string Identity { get; }
+        public string? GroupIdentity => null;
+        public int Precedence => 0;
+        public string Name { get; }
+        public IReadOnlyDictionary<string, string> TagsCollection => new Dictionary<string, string>();
+        public IParameterDefinitionSet ParameterDefinitions => ParameterDefinitionSet.Empty;
+        public string? ThirdPartyNotices => null;
+        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo => new Dictionary<string, IBaselineInfo>();
+        public IReadOnlyList<string> ShortNameList { get; }
+        public IReadOnlyList<Guid> PostActions => Array.Empty<Guid>();
+        public IReadOnlyList<TemplateConstraintInfo> Constraints => Array.Empty<TemplateConstraintInfo>();
+        public bool PreferDefaultName => false;
+
+        // ITemplateInfo's own (all [Obsolete]) members - required by the interface, unused here.
+        public string ShortName => ShortNameList.Count > 0 ? ShortNameList[0] : string.Empty;
+        public IReadOnlyDictionary<string, ICacheTag> Tags { get; }
+        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters => new Dictionary<string, ICacheParameter>();
+        public IReadOnlyList<ITemplateParameter> Parameters => Array.Empty<ITemplateParameter>();
+        public bool HasScriptRunningPostActions { get; set; }
+    }
+#pragma warning restore CS0618
+
+    /// <summary>
+    /// Minimal <see cref="ICacheTag"/> test double. Only <see cref="DefaultValue"/> (the
+    /// componentType tag's value) is meaningful.
+    /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete - ICacheTag itself is [Obsolete] but is what ITemplateInfo.Tags still declares
+    private sealed class FakeCacheTag : ICacheTag
+    {
+        public FakeCacheTag(string defaultValue)
+        {
+            DefaultValue = defaultValue;
+        }
+
+        public string? DisplayName => null;
+        public string? Description => null;
+        public IReadOnlyDictionary<string, ParameterChoice> Choices => new Dictionary<string, ParameterChoice>();
+        public string? DefaultValue { get; }
+    }
+#pragma warning restore CS0618
+}


### PR DESCRIPTION
## Root cause

`TemplateResolver.Resolve` matched a user-supplied component type against a
template's `componentType` tag in two separate steps: first a raw string
comparison against the input as given, then - only if that failed - a
`ComponentDefinitionRegistry.GetByName` lookup that resolved the *input*
before comparing again. The *template's own tag value* was never normalized
through the registry - only the input side was.

This made resolution asymmetric. Templates are tagged with their intentional
alias (`pp-security-role` uses `"SecurityRole"`, `pp-flow` uses `"Flow"`,
`pp-pcf` uses `"PcfControl"` - these tag choices are correct and are
unchanged by this fix). Looking up the alias itself worked, because the raw
comparison matched the tag directly. But looking up the *canonical* registry
name (`"Role"`, `"Workflow"`, `"CustomControl"`) failed: the raw comparison
against `"SecurityRole"` doesn't match `"Role"`, and the registry-resolution
step resolved `"Role"` to itself (it's already canonical) and compared again
against the literal tag `"SecurityRole"`, which never matches either.
`ComponentDefinitionRegistry.GetByName` is itself fully symmetric -
`GetByName("Role")` and `GetByName("SecurityRole")` both return the same
`ComponentDefinition` with `Name == "Role"` - but `TemplateResolver` only
normalized one side of the comparison.

Concretely: `txc workspace component parameter list SecurityRole` succeeded,
while `txc workspace component parameter list Role` failed with
`Template 'Role' not found.`, even though both are supposed to resolve to the
same `pp-security-role` template.

## Fix

In `src/TALXIS.CLI.Features.Workspace/TemplateEngine/TemplateResolver.cs`,
added `GetCanonicalComponentTypeName`, which reads a template's
`componentType` tag and resolves it through
`ComponentDefinitionRegistry.GetByName` the same way the input is resolved
(falling back to the raw tag value unchanged when it has no registry entry,
e.g. `"FormTab"`). `Resolve` now normalizes both sides through this helper
before comparing, collapsing the old three-step lookup into two: direct
short-name/full-name match, then a single symmetric normalized-tag match.
Applied the same normalization to `FindAllForType`/`FindTemplateForType` for
consistency - neither has any callers in the codebase today, but both are now
correct.

No changes to `ComponentDefinitionRegistry` (in `TALXIS.Platform.Metadata`)
and no changes to any `.template.json` files - the alias tag choices on
`pp-security-role`/`pp-flow`/`pp-pcf` stay exactly as they are. This is
purely a resolver-side fix.

## Verification

- `dotnet build` on the full solution - compiles cleanly, no new warnings.
- Added `tests/TALXIS.CLI.Tests/TemplateEngine/TemplateResolverTests.cs`
  covering: canonical name and alias both resolving to the same template for
  `Role`/`SecurityRole`, `Workflow`/`Flow`, and `CustomControl`/`PcfControl`;
  a tag with no registry entry (`FormTab`) still resolving via direct-tag
  match; the pre-existing short-name/tag-match regression case (`pp-entity`/
  `Entity`); an unknown input returning `null`; and the same alias-symmetry
  coverage for `FindTemplateForType`/`FindAllForType`.
- `dotnet test tests/TALXIS.CLI.Tests` - 737 passed, 0 failed (729 baseline
  in this checkout + 8 new tests).
- `dotnet test tests/TALXIS.CLI.IntegrationTests` - 40 passed, 5 skipped
  (live-environment tests requiring credentials), 0 failed.
- Manual before/after repro with an isolated fake `$HOME` (never touched the
  real `~/.templateengine` or global `txc` install): built the CLI at
  `b5f4a4c` (pre-fix) and at this branch's tip (post-fix) as two standalone
  binaries, installed the real `TALXIS.DevKit.Templates.Dataverse` package
  once into the fake `$HOME`, then ran both binaries against it.
  - Pre-fix: `txc workspace component parameter list SecurityRole` succeeds;
    `... Role` fails with `Template 'Role' not found.`; same pattern
    reproduced for `Flow` (succeeds) vs. `Workflow` (fails).
  - Post-fix, same fake `$HOME`/installed package: `Role`, `SecurityRole`,
    `Workflow`, and `Flow` all succeed, with `Role`'s output identical to
    `SecurityRole`'s.